### PR TITLE
Make vars file more sane

### DIFF
--- a/easy-rsa/2.0/vars
+++ b/easy-rsa/2.0/vars
@@ -66,9 +66,15 @@ export KEY_PROVINCE="CA"
 export KEY_CITY="SanFrancisco"
 export KEY_ORG="Fort-Funston"
 export KEY_EMAIL="me@myhost.mydomain"
-export KEY_EMAIL=mail@host.domain
-export KEY_CN=changeme
-export KEY_NAME=changeme
-export KEY_OU=changeme
-export PKCS11_MODULE_PATH=changeme
-export PKCS11_PIN=1234
+export KEY_OU="MyOrganizationalUnit"
+
+# X509 Subject Field
+export KEY_NAME="EasyRSA"
+
+# PKCS11 Smart Card
+# export PKCS11_MODULE_PATH="/usr/lib/changeme.so"
+# export PKCS11_PIN=1234
+
+# If you'd like to sign all keys with the same Common Name, uncomment the KEY_CN export below
+# You will also need to make sure your OpenVPN server config has the duplicate-cn option set
+# export KEY_CN="CommonName"


### PR DESCRIPTION
- Removed duplicate KEY_EMAIL var
- Commented out KEY_PCS11 vars [1]
- Commented out KEY_CN with explanation
- Set saner defaults
- reorganized vars, "required" fields first

[1] I commented these out because they're already set to dummy and you only need to change them if you're indeed going to use them.  This makes it a little less confusing to newbies who may not be interested in PKCS11 and get confused when reading that they should now "leave any of these fields blank".
