### PR TITLE
Fix -n "User PIN:" mis-print and Token/SmartCard keysize adjust in vars

### DIFF
--- a/easy-rsa/2.0/pkitool
+++ b/easy-rsa/2.0/pkitool
@@ -339,7 +339,7 @@ if [ -d "$KEY_DIR" ] && [ "$KEY_CONFIG" ]; then
 	PKCS11_ARGS=
 	if [ $DO_P11 -eq 1 ]; then
 	        stty -echo
-	        echo -n "User PIN: "
+	        printf "User PIN: "
 	        read -r PKCS11_PIN
 	        stty echo
 		export PKCS11_PIN
@@ -347,7 +347,7 @@ if [ -d "$KEY_DIR" ] && [ "$KEY_CONFIG" ]; then
 		echo "Generating key pair on PKCS#11 token..."
 		$PKCS11TOOL --module "$PKCS11_MODULE_PATH" --keypairgen \
 			--login --pin "$PKCS11_PIN" \
-			--key-type rsa:1024 \
+			--key-type rsa:$PKCS11_KEY_SIZE \
 			--slot "$PKCS11_SLOT" --id "$PKCS11_ID" --label "$PKCS11_LABEL" || exit 1
 		PKCS11_ARGS="-engine pkcs11 -keyform engine -key $PKCS11_SLOT:$PKCS11_ID"
 	fi

--- a/easy-rsa/2.0/vars
+++ b/easy-rsa/2.0/vars
@@ -74,6 +74,9 @@ export KEY_NAME="EasyRSA"
 # PKCS11 Smart Card
 # export PKCS11_MODULE_PATH="/usr/lib/changeme.so"
 # export PKCS11_PIN=1234
+# If your smartcard/token can handle 2048, set to 2048 else use the default of 1024
+# export PKCS11_KEY_SIZE=2048
+export PKCS11_KEY_SIZE=1024
 
 # If you'd like to sign all keys with the same Common Name, uncomment the KEY_CN export below
 # You will also need to make sure your OpenVPN server config has the duplicate-cn option set


### PR DESCRIPTION
<b>Fix -n "User PIN:" mis-print</b>
The <code>echo -n</code> dos not work in a vanilla Bourne shell (not linked to bash) and just prints:

<pre>-n User PIN: 
(also a new line is added and the cursor is on the next line)
</pre>

Changed it into using printf which is more consistent between different shells

<b>PKCS11_KEY_SIZE in vars for setting Token/SmartCard key size (1024 or 2048)</b>
Added the <code>PKCS11_KEY_SIZE=1024</code> in the <code>./vars</code> as default value.

Changed the pkitool to use the value from <code>PKCS11_KEY_SIZE</code> for setting the internal priv/pub key size of smart cards and tokens. Old cards only support 1024, newer cards support 2048+ bits internally.

Hope this helps!

Wessel
