### PR TITLE
- Fixed installation script from Makefile.am

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -44,6 +44,7 @@ dist_doc_DATA = \
 dist_easyrsa_DATA =
 
 install-data-local:	install-dist_easyrsaDATA
+	mkdir -p "$(DESTDIR)$(easyrsadir)"
 	cp "$(srcdir)/easy-rsa/2.0"/* "$(DESTDIR)$(easyrsadir)"
 
 uninstall-local:


### PR DESCRIPTION
Hello,

Just noticed installation script will fail if easyrsadir does not exist prior. Amended Makefile.am accordingly. Now RPM package creation builds seamlessly from:
autoreconf -i
./configure --prefix=/usr
make dist-gzip
rpmbuild -ta easy-rsa-....tar.gz

Great work with easy-rsa, congratulations.

Best regards,

Chris
