### PR TITLE
Update KEY_CONFIG placeholder

### DIFF
--- a/easy-rsa/2.0/vars
+++ b/easy-rsa/2.0/vars
@@ -26,7 +26,7 @@ export GREP="grep"
 # This variable should point to
 # the openssl.cnf file included
 # with easy-rsa.
-export KEY_CONFIG=`$EASY_RSA/whichopensslcnf $EASY_RSA`
+export KEY_CONFIG="$EASY_RSA/openssl-X-X-X.cnf"
 
 # Edit this variable to point to
 # your soon-to-be-created key


### PR DESCRIPTION
The KEY_CONFIG value is surrounded by backticks, which causes an error when sourcing the file prior to using any of the easy-rsa scripts.

This change removes the backticks and alters the placeholder to suggest the correct value.
