### PR TITLE
Adds support for export-p7 and nokey option for export-p12

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -764,10 +764,8 @@ You may now use this name to perform signing operations on this request.
 
 # export pkcs#12 or pkcs#7
 export_pkcs() {
-	[[ -n "$1" ]] && [[ ( "$1" == "p12" || "$1" == "p7" ) ]] || die "\
-The first argument must be p12 or p7."
-        local pkcs_type="$1"
-        shift
+	local pkcs_type="$1"
+	shift
 
 	[ -n "$1" ] || die "\
 Unable to export p12: incorrect command syntax.
@@ -806,32 +804,32 @@ Missing file expected at: $crt_ca"
 Unable to export $pkcs_type for short name '$short_name' without the certificate.
 Missing cert expected at: $crt_in"
 
-        case "$pkcs_type" in
-        p12)
-	        local pkcs_out="$EASYRSA_PKI/private/$short_name.p12"
+	case "$pkcs_type" in
+	p12)
+		local pkcs_out="$EASYRSA_PKI/private/$short_name.p12"
 
-                if [ $want_key -eq 1 ]; then
-                        [ -f "$key_in" ] || die "\
-Unable to export p12 for short name '$short_name' without the key.
-Missing key expected at: $key_in, or use nokey option.)"
-                else
-                        pkcs_opts="$pkcs_opts -nokeys"
-                fi
+		if [ $want_key -eq 1 ]; then
+			[ -f "$key_in" ] || die "\
+Unable to export p12 for short name '$short_name' without the key (missing file, or use nokey option.)
+Missing key expected at: $key_in"
+		else
+			pkcs_opts="$pkcs_opts -nokeys"
+		fi
 
-                # export the p12:
-                "$EASYRSA_OPENSSL" pkcs12 -in "$crt_in" -inkey "$key_in" -export \
-                        -out "$pkcs_out" $pkcs_opts || die "\
+		# export the p12:
+		"$EASYRSA_OPENSSL" pkcs12 -in "$crt_in" -inkey "$key_in" -export \
+			-out "$pkcs_out" $pkcs_opts || die "\
 Export of p12 failed: see above for related openssl errors."
-        ;;
-        p7)
-	        local pkcs_out="$EASYRSA_PKI/private/$short_name.p7b"
+	;;
+	p7)
+		local pkcs_out="$EASYRSA_PKI/issued/$short_name.p7b"
 
-                # export the p7:
-                "$EASYRSA_OPENSSL" crl2pkcs7 -nocrl -certfile "$crt_in" \
-                        -out "$pkcs_out" $pkcs_opts || die "\
+		# export the p7:
+		"$EASYRSA_OPENSSL" crl2pkcs7 -nocrl -certfile "$crt_in" \
+			-out "$pkcs_out" $pkcs_opts || die "\
 Export of p7 failed: see above for related openssl errors."
-        ;;
-        esac
+	;;
+esac
 
 	notice "\
 Successful export of $pkcs_type file. Your exported file is at the following
@@ -1130,7 +1128,7 @@ case "$cmd" in
 	export-p12)
 		export_pkcs p12 "$@"
 		;;
-        export-p7)
+	export-p7)
 		export_pkcs p7 "$@"
 		;;
 


### PR DESCRIPTION
added command export-p7 to export certs using pkcs7 format.
added option nokey for pkcs12 to avoid exporting private keys
fixed issues related by Josh Cepek
(rebased from upstream)
