### PR TITLE
Fix --req-ca to be used for build-ca

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -448,8 +448,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	printf "" > "$EASYRSA_PKI/index.txt" || die "$err_file"
 	print "01" > "$EASYRSA_PKI/serial" || die "$err_file"
 
-	# Default CN only when not in global EASYRSA_BATCH mode:
-	[ $EASYRSA_BATCH ] && opts="$opts -batch" || export EASYRSA_REQ_CN="Easy-RSA CA"
+	[ $EASYRSA_BATCH ] && opts="$opts -batch"
 	# create the CA keypair:
 	"$EASYRSA_OPENSSL" req -new -newkey $EASYRSA_ALGO:"$EASYRSA_ALGO_PARAMS" \
 		-config "$EASYRSA_SSL_CONF" -keyout "$out_key" -out "$out_file" $opts || \


### PR DESCRIPTION
Default CN is already defined [here](https://github.com/jirutka/easy-rsa/blob/9038afcdf308372d512502d5fae96fad7980b8c6/easyrsa3/easyrsa#L1010). This export is undesirable and overwrites value passed with `--req-ca` or defined using `EASYRSA_REQ_CN` in vars.
