### PR TITLE
The state should not be abbreviated

### DIFF
--- a/easy-rsa/2.0/vars
+++ b/easy-rsa/2.0/vars
@@ -62,7 +62,7 @@ export KEY_EXPIRE=3650
 # which will be placed in the certificate.
 # Don't leave any of these fields blank.
 export KEY_COUNTRY="US"
-export KEY_PROVINCE="CA"
+export KEY_PROVINCE="California"
 export KEY_CITY="SanFrancisco"
 export KEY_ORG="Fort-Funston"
 export KEY_EMAIL="me@myhost.mydomain"


### PR DESCRIPTION
The command line tool instructs to not use an abbreviation, so we should expand CA to California.