### PR TITLE
added support to specify open-ssl config file using --ssl-conf command flag

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -185,6 +185,7 @@ General options:
 
 --batch         : set automatic (no-prompts when possible) mode
 --pki-dir=DIR   : declares the PKI directory
+--ssl-conf=FILE : define a specific open-ssl config file to use for Easy-RSA config
 --vars=FILE     : define a specific 'vars' file to use for Easy-RSA config
 
 Certificate & Request options: (these impact cert/req field values)
@@ -1074,6 +1075,8 @@ while :; do
 		;;
 	--pki-dir)
 		export EASYRSA_PKI="$val" ;;
+    --ssl-conf)
+        export EASYRSA_SSL_CONF="$val" ;;
 	--use-algo)
 		export EASYRSA_ALGO="$val" ;;
 	--keysize)


### PR DESCRIPTION
I needed this command flag to support some automated processes that were throwing the error: 

The OpenSSL config file cannot be found.
Expected location: /.../openssl-1.0.cnf
