### PR TITLE
Fix Bad move in gen_curl

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -734,7 +734,7 @@ gen_crl() {
 
 	local out_file="$EASYRSA_PKI/crl.pem"
 	out_file_tmp="$(mktemp -u "$out_file.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$out_file_tmp"
-	"$EASYRSA_OPENSSL" ca -utf8 -gencrl -out "$out_file" -config "$EASYRSA_SSL_CONF" || die "\
+	"$EASYRSA_OPENSSL" ca -utf8 -gencrl -out "$out_file_tmp" -config "$EASYRSA_SSL_CONF" || die "\
 CRL Generation failed.
 "
 	mv "$out_file_tmp" "$out_file"; EASYRSA_TEMP_FILE_2=


### PR DESCRIPTION
Error msg:

Note: using Easy-RSA configuration from: ./vars
Using configuration from /Users/sskaje/Work/CA/Easy/openssl-1.0.cnf
Enter pass phrase for /Users/sskaje/Work/CA/Easy/pki/private/ca.key:
mv: /Users/sskaje/Work/CA/Easy/pki/crl.pem.tpH4U0wpn3: No such file or directory

An updated CRL has been created.
CRL file: /Users/sskaje/Work/CA/Easy/pki/crl.pem