### PR TITLE
Generate random serial number for all certificates

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -652,6 +652,17 @@ Certificate created at: $crt_out
 build_full() {
 	verify_ca_init
 
+	local i= serial= check_serial=
+	for i in 1 2 3 4 5; do
+		"$EASYRSA_OPENSSL" rand -hex 16 -out "$EASYRSA_PKI/serial"
+		serial="$(cat "$EASYRSA_PKI/serial")"
+		check_serial="$("$EASYRSA_OPENSSL" ca -config "$EASYRSA_SSL_CONF" -status "$serial" 2>&1)"
+		case "$check_serial" in
+			*"not present in db"*) break ;;
+			*) continue ;;
+		esac
+	done
+
 	# pull filename base:
 	[ -n "$2" ] || die "\
 Error: didn't find a file base name as the first argument.


### PR DESCRIPTION
Monotonous serial number increments could disclose VPN users number. To prevent this, we could generate random certificate serial number every build_full request.