### PR TITLE
Allow subject alternative names to be copied from certificate signing requests

### DIFF
--- a/easyrsa3/openssl-1.0.cnf
+++ b/easyrsa3/openssl-1.0.cnf
@@ -37,6 +37,9 @@ preserve	= no			# keep passed DN ordering
 # and supplied fields are just that :-)
 policy		= policy_anything
 
+# Allow subjectAlternativeNames to be copied fromt the certificate signing request
+copy_extensions = copy
+
 # For the 'anything' policy, which defines allowed DN fields
 [ policy_anything ]
 countryName		= optional


### PR DESCRIPTION
I added the `copy_extensions = copy` option to the `[ CA_default ]` section. By my understanding of the documentation at https://www.openssl.org/docs/manmaster/apps/ca.html, this should be fine, as long as `basicConstraints = CA:False` is either set or the incoming certificate signing requests are trustworthy.

It seems to me that this is set from within the easy_rsa when signing requests - at least in some cases, but I'm not sure I follow that code completely.

However if signing requests are trustworthy (so a ca you use for internal purposes, which IMO is what easy_rsa was designed for) this should be fine in any case.

Is that acceptable to you guys?

Also solves https://github.com/OpenVPN/easy-rsa/issues/88
