### PR TITLE
Convert README and COPYING into markdown files

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -1,15 +1,16 @@
 Easy-RSA -- A Shell-based CA Utility
+====================================
 
 Copyright (C) 2013 by the Open-Source OpenVPN development community
 
-Easy-RSA 3 license: GPLv2:
+Easy-RSA 3 license: GPLv2
 -------------------------
 
 All the Easy-RSA code contained in this project falls under a GPLv2 license with
 full text available in the Licensing/ directory. Additional components used by
 this project fall under additional licenses:
 
-Additional licenses for external components:
+Additional licenses for external components
 -------------------------------------------
 
 The following components are under different licenses; while not part of the

--- a/README.md
+++ b/README.md
@@ -1,39 +1,40 @@
-OVERVIEW:
+# Overview
+
 easy-rsa is a CLI utility to build and manage a PKI CA. In laymen's terms,
 this means to create a root certificate authority, and request and sign 
 certificates, including sub-CAs and certificate revokation lists (CRL).
 
-DOWNLOADS:
+# Downloads
 
 If you are looking for release downloads, please see the releases section on
 GitHub. Releases are also available as source checkouts using named tags.
 
-DOCUMENTATION:
+# Documentation
 
-For 3.x project documentation and usage, see the README.quickstart.md file or
+For 3.x project documentation and usage, see the [README.quickstart.md](README.quickstart.md) file or
 the more detailed docs under the doc/ directory. The .md files are in Markdown
 format and can be converted to html files as desired for release packages, or
 read as-is in plaintext.
 
-GETTING HELP USING EASY-RSA:
+# Getting help using easy-rsa
 
 Currently, Easy-RSA development co-exists with OpenVPN even though they are
 separate projects. The following resources are good places as of this writing to
 seek help using Easy-RSA:
 
-The openvpn-users mailing list is a good place to post usage or help questions:
-https://lists.sourceforge.net/lists/listinfo/openvpn-users
+The [openvpn-users mailing list](https://lists.sourceforge.net/lists/listinfo/openvpn-users)
+is a good place to post usage or help questions.
 
 You can also try IRC at Freenode/#openvpn
 
-BRANCH STRUCTURE:
+# Branch structure
 
 The easy-rsa master branch is currently tracking development for the 3.x release
 cycle. The prior 2.x and 1.x versions are available as release branches for
 tracking and possible back-porting of relevant fixes. Branch layout is:
 
-  master <- 3.x, at present
-  release/2.x
-  release/1.x
+    master <- 3.x, at present
+    release/2.x
+    release/1.x
 
-LICENSING info for 3.x is in the COPYING file
+LICENSING info for 3.x is in the [COPYING.md](COPYING.md) file


### PR DESCRIPTION
This PR has a few goals:
* Make the files look nicer on the likes of GitHub and GitLab
* Switch to a single standard for formatting the documentation
* Allow users to view the referenced files (COPYING.md, README.quickstart.md) more conveniently

The COPYING file was actually already in markdown syntax, but was missing the .md suffix. I will later patch the OpenVPN man-page to point to README.md (now it is pointing [here](https://openvpn.net/index.php/open-source/documentation/miscellaneous/77-rsa-key-management.html)). 