### PR TITLE
Add --root command-line option to set the top level directory

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -184,6 +184,7 @@ non-empty values to options are mandatory.
 General options:
 
 --batch         : set automatic (no-prompts when possible) mode
+--root=DIR      : declares the root (top level) of the Easy-RSA directory tree
 --pki-dir=DIR   : declares the PKI directory
 --vars=FILE     : define a specific 'vars' file to use for Easy-RSA config
 
@@ -1139,6 +1140,8 @@ while :; do
 		export EASYRSA_SUBCA_LEN="$val" ;;
 	--vars)
 		export EASYRSA_VARS_FILE="$val" ;;
+	--root)
+		export EASYRSA="$val" ;;
 	--subject-alt-name)
 		export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -115,7 +115,8 @@ cmd_help() {
       Human-readable output is shown, including any requested cert options when
       showing a request."
       			opts="
-          full   - show full req/cert info, including pubkey/sig data" ;;
+          full   - show full req/cert info, including pubkey/sig data
+          pem    - show PEM format req/cert" ;;
 		import-req) text="
   import-req <request_file_path> <short_basename>
       Import a certificate request from a file
@@ -942,9 +943,11 @@ Run easyrsa without commands for usage help."
 
 	# opts support
 	local opts="-${type}opt no_pubkey,no_sigdump"
+	local output_opts='-text -noout'
 	while [ -n "$1" ]; do
 		case "$1" in
 			full) opts= ;;
+			 pem) output_opts='-outform pem' ;;
 			*) warn "Ignoring unknown command option: '$1'" ;;
 		esac
 		shift
@@ -975,7 +978,7 @@ Showing $type details for '$name'.
 This file is stored at:
 $in_file
 "
-	"$EASYRSA_OPENSSL" $format -in "$in_file" -noout -text\
+	"$EASYRSA_OPENSSL" $format -in "$in_file" $output_opts \
 		-nameopt multiline $opts || die "\
 OpenSSL failure to process the input"
 } # => show()


### PR DESCRIPTION
Provide a command-line argument to set the root (top level) directory of the easy-rsa tree. 

This is normally set to `pwd` unless variable `EASYRSA` is set, either through the environment or in `vars`. Because the default location of `vars` is relative to `EASYRSA` this must be pre-set before accessing `vars` or the path to `vars` must be given explicitly and then `vars` must be edited to set `EASYRSA`.

I needed a non-environment way to set `EASYRSA` because I have a dedicated `ca` account that is used through restricted `sudo` which does not propagate environment variables. 

I could use `--vars` and then edit `vars` to set `EASYRSA` but this `--root` option is neater and does not requie altering the stock `vars` file.
