### PR TITLE
Add a `pem` command-option to `show` which outputs the req/cert in PEM format

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -115,7 +115,8 @@ cmd_help() {
       Human-readable output is shown, including any requested cert options when
       showing a request."
       			opts="
-          full   - show full req/cert info, including pubkey/sig data" ;;
+          full   - show full req/cert info, including pubkey/sig data
+          pem    - show PEM format req/cert" ;;
 		import-req) text="
   import-req <request_file_path> <short_basename>
       Import a certificate request from a file
@@ -941,9 +942,11 @@ Run easyrsa without commands for usage help."
 
 	# opts support
 	local opts="-${type}opt no_pubkey,no_sigdump"
+	local output_opts='-text -noout'
 	while [ -n "$1" ]; do
 		case "$1" in
 			full) opts= ;;
+			 pem) output_opts='-outform pem' ;;
 			*) warn "Ignoring unknown command option: '$1'" ;;
 		esac
 		shift
@@ -974,7 +977,7 @@ Showing $type details for '$name'.
 This file is stored at:
 $in_file
 "
-	"$EASYRSA_OPENSSL" $format -in "$in_file" -noout -text\
+	"$EASYRSA_OPENSSL" $format -in "$in_file" $output_opts \
 		-nameopt multiline $opts || die "\
 OpenSSL failure to process the input"
 } # => show()


### PR DESCRIPTION
This allows access to the certificate via EasyRSA without
requiring knowledge/access to the PKI directory tree.
