### PR TITLE
easyrsa: find vars also in $PWD and $PWD/pki

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1002,6 +1002,10 @@ vars_setup() {
 	# program location:
 	elif [ -f "$prog_vars" ]; then
 		vars="$prog_vars"
+	elif [ -f "$PWD/pki/vars" ]; then
+		vars="$PWD/pki/vars"
+	elif [ -f "$PWD/vars" ]; then
+		vars="$PWD/vars"
 	fi
 	
 	# If a vars file was located, source it


### PR DESCRIPTION
Find and source `vars` also in the canonical locations `$PWD/pki` and `$PWD` (addresses #119 ).

The only disadvantage I can think of is that a `vars` in `./` or `pki/` should be ignored and no `vars` should be sourced at all. However, I can't see the use of that - except to write confusing command lines.