### PR TITLE
Make $PWD/pki the default PKI location

### DIFF
--- a/doc/EasyRSA-Advanced.md
+++ b/doc/EasyRSA-Advanced.md
@@ -34,6 +34,7 @@ Configuration Reference
   1. File referenced by the --vars CLI option
   2. The file referenced by the env-var named `EASYRSA_VARS_FILE`
   3. The `EASYRSA_PKI` directory
+  4. The default PKI directory at $PWD/pki (usually will be the same as above)
   4. The `EASYRSA` directory
   5. The location of the easyrsa program (usually will be the same as above)
 
@@ -80,7 +81,7 @@ possible terse description is shown below:
  *  `EASYRSA` - should point to the Easy-RSA top-level dir, normally $PWD
  *  `EASYRSA_OPENSSL` - command to invoke openssl
  *  `EASYRSA_SSL_CONF` - the openssl config file to use
- *  `EASYRSA_PKI` (CLI: `--pki-dir`) - dir to use to hold all PKI-specific files
+ *  `EASYRSA_PKI` (CLI: `--pki-dir`) - dir to use to hold all PKI-specific files, normally $PWD/pki.
  *  `EASYRSA_DN` (CLI: `--dn-mode`) - set to the string `cn_only` or `org` to
     alter the fields to include in the req DN
  *  `EASYRSA_REQ_COUNTRY` (CLI: `--req-c`) - set the DN country with org mode

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -989,13 +989,15 @@ vars_setup() {
 
 	# set up program path
 	local prog_vars="${0%/*}/vars"
+	# set up PKI path
+	local pki_vars="${EASYRSA_PKI:-$PWD/pki}/vars"
 
 	# command-line path:
 	if [ -f "$EASYRSA_VARS_FILE" ]; then
 		vars="$EASYRSA_VARS_FILE"
-	# EASYRSA_PKI, if defined:
-	elif [ -n "$EASYRSA_PKI" ] && [ -f "$EASYRSA_PKI/vars" ]; then
-		vars="$EASYRSA_PKI/vars"
+	# PKI location, if present:
+	elif [ -f "$pki_vars" ]; then
+		vars="$pki_vars"
 	# EASYRSA, if defined:
 	elif [ -n "$EASYRSA" ] && [ -f "$EASYRSA/vars" ]; then
 		vars="$EASYRSA/vars"
@@ -1013,9 +1015,9 @@ Note: using Easy-RSA configuration from: $vars"
 	fi
 	
 	# Set defaults, preferring existing env-vars if present
-	set_var EASYRSA		"$PWD"
+	set_var EASYRSA		"${0%/*}"
 	set_var EASYRSA_OPENSSL	openssl
-	set_var EASYRSA_PKI	"$EASYRSA/pki"
+	set_var EASYRSA_PKI	"$PWD/pki"
 	set_var EASYRSA_DN	cn_only
 	set_var EASYRSA_REQ_COUNTRY	"US"
 	set_var EASYRSA_REQ_PROVINCE	"California"
@@ -1225,4 +1227,4 @@ case "$cmd" in
 		;;
 esac
 
-# vim: ft=sh nu ai sw=8 ts=8
+# vim: ft=sh nu ai sw=8 ts=8 noet


### PR DESCRIPTION
I'd like to propose some changes to the default values of the following configuration variables:

 * `EASYRSA` should default to the program location (via $0) instead of $PWD.
 * `EASYRSA_PKI` should default to $PWD/pki instead of $EASYRSA/pki.

The old defaults imply an assumption that easy-rsa is executed using ./easyrsa, and that the PKI directory is located in the program directory. While that is likely the case for newcomers who just cloned the repository, and perhaps also for Windows users (I wouldn't know about that), it is probably not true on Unix systems where easy-rsa is provided by a package.

The proposed changes retain existing behavior for:

 * All examples mentioned in the documentation.
 * All cases where EASYRSA and EASYRSA_PKI are explicitly defined by the user, using any of the available mechanisms.

The new use-case that becomes possible by the proposed change, without any configuration, is one where:

 * A shared instance of easy-rsa is available via the command $PATH.
 * The default configuration files provide the defaults for all users, and serve as templates for customization.
 * Users can switch between PKIs simply by using the _cd_ command, thus making it easier to maintain multiple PKIs.

This usage pattern fits better to a typical Unix system, where a native OS package provides a shared instance of easyrsa.