### PR TITLE
Add commands to publish certificate to a different location after signing

### DIFF
--- a/build/Building.md
+++ b/build/Building.md
@@ -54,14 +54,14 @@ with a basic build dir from earlier, proceed as follows.
    * cat.exe
    * cp.exe
    * diff.exe [+]
-   * grep.exe [+]
+   * grep.exe
    * ls.exe [+]
-   * md5sum.exe [+]
+   * md5sum.exe
    * mkdir.exe
-   * mv.exe [+]
+   * mv.exe
    * printf.exe
    * rm.exe
-   * sed.exe [+]
+   * sed.exe
    * which.exe
 
 5. Zip up the target directory for release distribution.

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -55,6 +55,7 @@ Here is the list of commands available with a short syntax reminder. Use the
   export-p7 <file_name_base> [ cmd-opts ]
   export-p8 <file_name_base> [ cmd-opts ]
   export-p12 <file_name_base> [ cmd-opts ]
+  publish-cert <file_name_base> [ cmd-opts ]
   set-rsa-pass <file_name_base> [ cmd-opts ]
   set-ec-pass <file_name_base> [ cmd-opts ]
   upgrade <type>
@@ -340,6 +341,15 @@ cmd_help() {
 		opts="
       * nopass  - do not encrypt the private key (default is encrypted)"
 	;;
+	publish-cert)
+		text="
+* publish-cert <filename_base> [ cmd-opts ]
+
+      Publish the certificate specified by <filename_base>."
+
+		opts="
+      * nostrip - do not strip plaintext"
+	;;
 	set-rsa-pass|set-ec-pass)
 		text="
 * set-rsa-pass <file_name_base> [ cmd-opts ]
@@ -472,6 +482,7 @@ General options:
 --keep-tmp=NAME : Keep the original temporary session by name: NAME
                   NAME is a sub-directory of the dir declared by --tmp-dir
                   This option ALWAYS over-writes a sub-dir of the same name.
+--pub-dir=DIR   : declares the publish directory
 
 Certificate & Request options: (these impact cert/req field values)
 
@@ -1828,6 +1839,11 @@ $(display_dn req "$req_in")
 	#unset -v EASYRSA_BATCH # This is why batch mode should not silence output
 	notice "Certificate created at: $crt_out"
 
+	# publish
+	if [ -n "$EASYRSA_PUBLISH" ]; then
+		publish cert "$2"
+	fi
+
 	return 0
 } # => sign_req()
 
@@ -2911,6 +2927,57 @@ You may now use this name to perform signing operations on this request."
 
 	return 0
 } # => import_req()
+
+# publish backend
+publish() {
+	type="$1"
+	name="$2"
+	in_file=""
+	out_file=""
+	format=""
+
+	# opts support
+	shift 2
+	want_strip=1
+	while [ -n "$1" ]; do
+		case "$1" in
+			nostrip) want_strip= ;;
+			*) warn "Ignoring unknown command option: '$1'" ;;
+		esac
+		shift
+	done
+
+	# ensure the publish folder exists
+	[ -d "$EASYRSA_PUBLISH" ] || die "\
+Missing publish dir : $EASYRSA_PUBLISH"
+
+	if [ "$type" = "cert" ]; then
+		verify_ca_init
+		in_file="$EASYRSA_PKI/issued/${name}.crt"
+		out_file="$EASYRSA_PUBLISH/issued/${name}.crt"
+		format="x509"
+		mkdir -p "$EASYRSA_PUBLISH/issued"
+	else
+		die "\
+Unknown publish type : $type"
+	fi
+
+	# Verify file exists and is of the correct type
+	[ -f "$in_file" ] || die "\
+No such $type file with a basename of '$name' is present.
+Expected to find this file at:
+$in_file"
+	verify_file $format "$in_file" || die "\
+This file is not a valid $type file:
+$in_file"
+
+	if [ $want_strip ]; then
+		easyrsa_openssl $format -in "$in_file" -out "$out_file"
+	else
+		cp "$in_file" "$out_file"
+	fi
+	notice "Certificate published at: $out_file"
+} # => publish()
 
 # export pkcs#12, pkcs#7, pkcs#8 or pkcs#1
 export_pkcs() {
@@ -4188,6 +4255,7 @@ Sourcing the vars file and building certificates will probably fail ..'
 	set_var EASYRSA_TEMP_DIR		"$EASYRSA_PKI"
 	set_var EASYRSA_REQ_CN			ChangeMe
 	set_var EASYRSA_DIGEST			sha256
+	set_var EASYRSA_PUBLISH			""
 
 	set_var EASYRSA_SSL_CONF		"$EASYRSA_PKI/openssl-easyrsa.cnf"
 	set_var EASYRSA_SAFE_CONF		"$EASYRSA_PKI/safessl-easyrsa.cnf"
@@ -4945,6 +5013,10 @@ while :; do
 	--tmp-dir)
 		export EASYRSA_TEMP_DIR="$val"
 		;;
+	--pub-dir|--publish-dir)
+		empty_ok=1
+		export EASYRSA_PUBLISH="$val"
+		;;
 	--ssl-conf)
 		export EASYRSA_SSL_CONF="$val"
 		;;
@@ -5163,6 +5235,9 @@ case "$cmd" in
 		;;
 	export-p1)
 		export_pkcs p1 "$@"
+		;;
+	publish-cert)
+		publish cert "$@"
 		;;
 	set-rsa-pass)
 		set_pass rsa "$@"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -296,6 +296,9 @@ cmd_help() {
 
       The <short_name_base> is the <file_name_base> to create.
 
+      Note: the first parameter can be skipped the file will be looked up
+      in the publish directory
+
       Example usage:
         import-req /some/where/bob_request.req bob"
 	;;
@@ -2913,10 +2916,17 @@ import_req() {
 	# Verify PKI has been initialised
 	verify_pki_init
 
-	# pull passed paths
-	in_req="$1"
-	short_name="$2"
-	out_req="$EASYRSA_PKI/reqs/$2.req"
+	if [ -n "$EASYRSA_PUBLISH" -a -f "$EASYRSA_PUBLISH/reqs/$1.req" ]; then
+		# take from publish dir
+		in_req="$EASYRSA_PUBLISH/reqs/$1.req"
+		short_name="$1"
+		out_req="$EASYRSA_PKI/reqs/$1.req"
+	else
+		# pull passed paths
+		in_req="$1"
+		short_name="$2"
+		out_req="$EASYRSA_PKI/reqs/$2.req"
+	fi
 
 	[ "$short_name" ] || die "\
 Unable to import: incorrect command syntax.

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -40,6 +40,7 @@ Here is the list of commands available with a short syntax reminder. Use the
   revoke-renewed <file_name_base> [cmd-opts]
   rewind-renew <certificate-serial-number>
   rebuild <file_name_base> [cmd-opts]
+  status <file_name_base>
   gen-crl
   update-db
   show-req <file_name_base> [ cmd-opts ]
@@ -204,6 +205,11 @@ cmd_help() {
 
   * NOTE: This does NOT 'unrenew' or 'unrevoke' a certificate.
     Ref : https://github.com/OpenVPN/easy-rsa/issues/578"
+	;;
+	status)
+		 text="
+* status <filename_base>
+      Check the status of a certificate specified by the filename_base"
 	;;
 	gen-crl)
 		text="
@@ -2889,6 +2895,29 @@ Failed to remove the duplicate certificate in the certs_by_serial folder"
 	return 0
 } # => rebuild_move()
 
+# status backend
+status() {
+	verify_ca_init
+
+	# pull filename base:
+	[ -n "$1" ] || die "\
+Error: didn't find a file base name as the first argument.
+Run easyrsa without commands for usage and command help."
+	crt_in="$EASYRSA_PKI/issued/$1.crt"
+
+	verify_file x509 "$crt_in" || die "\
+Unable to get status as the input file is not a valid certificate.
+Unexpected input in file: $crt_in"
+
+	crt_serial_file=$(cd "$EASYRSA_PKI/certs_by_serial/" && md5sum *|grep "$(md5sum $crt_in|awk '{print $1}')"|awk '{print $2}')
+
+	[ ! -f $crt_serial_file ] || die "\
+Could not find serial associated with input in file: $crt_in
+Was it signed already ?"
+
+	easyrsa_openssl ca -utf8 -status "${crt_serial_file%.pem}" -config "$EASYRSA_SSL_CONF"
+} #= status()
+
 # gen-crl backend
 gen_crl() {
 	verify_ca_init
@@ -5332,6 +5361,9 @@ case "$cmd" in
 	rebuild)
 		[ "$alias_days" ] && export EASYRSA_CERT_EXPIRE="$alias_days"; :
 		rebuild "$@"
+		;;
+	status)
+		status "$@"
 		;;
 	import-req)
 		import_req "$@"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -56,6 +56,7 @@ Here is the list of commands available with a short syntax reminder. Use the
   export-p8 <file_name_base> [ cmd-opts ]
   export-p12 <file_name_base> [ cmd-opts ]
   publish-cert <file_name_base> [ cmd-opts ]
+  publish-ca
   set-rsa-pass <file_name_base> [ cmd-opts ]
   set-ec-pass <file_name_base> [ cmd-opts ]
   upgrade <type>
@@ -349,6 +350,13 @@ cmd_help() {
 
 		opts="
       * nostrip - do not strip plaintext"
+	;;
+	publish-ca)
+		text="
+* publish-ca [ cmd-opts ]
+      Publish the CA certificate, the index database and the crl."
+		opts="
+      * update - update db and crl before publishing."
 	;;
 	set-rsa-pass|set-ec-pass)
 		text="
@@ -2891,6 +2899,12 @@ CRL Generation failed."
 An updated CRL has been created.
 CRL file: $out_file"
 
+	# publish
+	if [ -n "$EASYRSA_PUBLISH" ]; then
+		publish crl crl.pem
+		publish crl crl.der to-der
+	fi
+
 	return 0
 } # => gen_crl()
 
@@ -2939,9 +2953,11 @@ publish() {
 	# opts support
 	shift 2
 	want_strip=1
+	opts=""
 	while [ -n "$1" ]; do
 		case "$1" in
 			nostrip|noregen) want_strip= ;;
+			to-der) opts="-inform PEM -outform DER" ;;
 			*) warn "Ignoring unknown command option: '$1'" ;;
 		esac
 		shift
@@ -2985,6 +3001,12 @@ Missing publish dir : $EASYRSA_PUBLISH"
 		mkdir -p "$EASYRSA_PUBLISH/private"
 		;;
 	#TODO add p1)
+	crl)
+		verify_ca_init
+		in_file="$EASYRSA_PKI/crl.pem"
+		out_file="$EASYRSA_PUBLISH/${name}"
+		format="crl"
+		;;
 	*)
 		die "\
 Unknown publish type : $type"
@@ -3003,12 +3025,53 @@ $in_file"
 	fi
 
 	if [ $want_strip ]; then
-		easyrsa_openssl $format -in "$in_file" -out "$out_file"
+		easyrsa_openssl $format -in "$in_file" -out "$out_file" $opts
 	else
 		cp "$in_file" "$out_file"
 	fi
-	notice "Certificate published at: $out_file"
+	notice "File published at: $out_file"
 } # => publish()
+
+# publish-ca backend
+publish_ca() {
+	# opts support
+	want_update=""
+	notice=""
+	while [ -n "$1" ]; do
+		case "$1" in
+			update) want_update=1 ;;
+			*) warn "Ignoring unknown command option: '$1'" ;;
+		esac
+		shift
+	done
+	# ensure the publish folder exists
+	[ -d "$EASYRSA_PUBLISH" ] || die "\
+Missing publish dir : $EASYRSA_PUBLISH"
+	verify_ca_init
+
+	if [ $want_update ]; then
+		update_db
+		gen_crl
+		notice="after being regenerated.
+The crl has been published at $EASYRSA_PUBLISH/crl.pem
+                          and $EASYRSA_PUBLISH/crl.der
+after being regenerated."
+	elif [ -e "$EASYRSA_PKI/crl.pem" ]; then
+		publish crl crl.pem
+		publish crl crl.der to-der
+		notice="\
+The crl has been published at $EASYRSA_PUBLISH/crl.pem
+                          and $EASYRSA_PUBLISH/crl.der"
+	fi
+	for i in index.txt ca.crt; do
+		cp "$EASYRSA_PKI/$i" "$EASYRSA_PUBLISH/$i"
+	done
+
+	notice "\
+The CA certificate has been published at $EASYRSA_PUBLISH/ca.crt
+The associated index has been published at $EASYRSA_PUBLISH/index.txt
+$notice"
+} # => publish_ca()
 
 # export pkcs#12, pkcs#7, pkcs#8 or pkcs#1
 export_pkcs() {
@@ -5273,6 +5336,9 @@ case "$cmd" in
 		;;
 	publish-cert)
 		publish cert "$@"
+		;;
+	publish-ca)
+		publish_ca "$@"
 		;;
 	set-rsa-pass)
 		set_pass rsa "$@"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1815,6 +1815,10 @@ basicConstraints is not defined, cannot use 'pathlen'"
 			# Add any advanced extensions supplied by env-var:
 			[ -z "$EASYRSA_EXTRA_EXTS" ] || print "$EASYRSA_EXTRA_EXTS"
 		fi
+
+		# Append last any COMMON-SECTIONS file (if present)
+		cat "$EASYRSA_EXT_DIR/COMMON-SECTIONS"
+
 	} > "$ext_tmp" || die "\
 Failed to create temp extension file (bad permissions?) at:
 $ext_tmp"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3331,7 +3331,7 @@ Run easyrsa without commands for usage help."
 	# Determine cert/req type (v2)
 	case "$type" in
 	cert)
-		verify_ca_init
+		verify_pki_init
 		in_file="$EASYRSA_PKI/issued/$name.crt"
 		format="x509"
 	;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2941,7 +2941,7 @@ publish() {
 	want_strip=1
 	while [ -n "$1" ]; do
 		case "$1" in
-			nostrip) want_strip= ;;
+			nostrip|noregen) want_strip= ;;
 			*) warn "Ignoring unknown command option: '$1'" ;;
 		esac
 		shift
@@ -2951,25 +2951,56 @@ publish() {
 	[ -d "$EASYRSA_PUBLISH" ] || die "\
 Missing publish dir : $EASYRSA_PUBLISH"
 
-	if [ "$type" = "cert" ]; then
+	do_verify=1
+	case "$type" in
+	cert)
 		verify_ca_init
 		in_file="$EASYRSA_PKI/issued/${name}.crt"
 		out_file="$EASYRSA_PUBLISH/issued/${name}.crt"
 		format="x509"
 		mkdir -p "$EASYRSA_PUBLISH/issued"
-	else
+		;;
+	p12)
+		verify_pki_init
+		in_file="$EASYRSA_PKI/private/$short_name.p12"
+		out_file="$EASYRSA_PUBLISH/private/$short_name.p12"
+		format="pkcs12"
+		#skip verification when passout is set to avoid prompt
+		if [ ${EASYRSA_PASSOUT:+1} ]; then do_verify= ; fi
+		mkdir -p "$EASYRSA_PUBLISH/private"
+		;;
+	p7)
+		verify_pki_init
+		in_file="$EASYRSA_PKI/issued/$short_name.p7b"
+		out_file="$EASYRSA_PUBLISH/issued/$short_name.p7b"
+		format="pkcs7"
+		mkdir -p "$EASYRSA_PUBLISH/issued"
+		;;
+	p8)
+		verify_pki_init
+		in_file="$EASYRSA_PKI/private/$short_name.p8"
+		out_file="$EASYRSA_PUBLISH/private/$short_name.p8"
+		format="pkcs8"
+		do_verify=
+		mkdir -p "$EASYRSA_PUBLISH/private"
+		;;
+	#TODO add p1)
+	*)
 		die "\
 Unknown publish type : $type"
-	fi
+		;;
+	esac
 
 	# Verify file exists and is of the correct type
 	[ -f "$in_file" ] || die "\
 No such $type file with a basename of '$name' is present.
 Expected to find this file at:
 $in_file"
-	verify_file $format "$in_file" || die "\
+	if [ $do_verify ]; then
+		verify_file $format "$in_file" || die "\
 This file is not a valid $type file:
 $in_file"
+	fi
 
 	if [ $want_strip ]; then
 		easyrsa_openssl $format -in "$in_file" -out "$out_file"
@@ -3095,6 +3126,10 @@ Missing key expected at: $key_in"
 Successful export of $pkcs_type file. Your exported file is at the following
 location: $pkcs_out"
 
+	# publish
+	if [ -n "$EASYRSA_PUBLISH" ]; then
+		publish $pkcs_type "$short_name" noregen
+	fi
 	return 0
 } # => export_pkcs()
 

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -163,6 +163,13 @@ fi
 
 #set_var EASYRSA_TEMP_FILE	"$EASYRSA_PKI/extensions.temp"
 
+# This option allows to publish the signed certificates to a folder
+# outside the pki. Set this variable to the desired folder.
+# When empty the certificates are not published they remain in the pki
+# folder.
+
+#set_var EASYRSA_PUBLISH	""
+
 # !!
 # NOTE: ADVANCED OPTIONS BELOW THIS POINT
 # PLAY WITH THEM AT YOUR OWN RISK

--- a/easyrsa3/x509-types/COMMON-SECTIONS
+++ b/easyrsa3/x509-types/COMMON-SECTIONS
@@ -1,0 +1,13 @@
+# X509 extensions added to every signed cert
+
+# This file is included for every cert signed, and by default does nothing.
+# It could be used to add sections shared by every cert, such as a CDP as
+# demonstrated in the following example:
+
+# in COMMON
+#crlDistributionPoints = @crlDistributionPoints_values
+# in COMMON-SECTIONS (here)
+#[ crlDistributionPoints_values ]
+#URI.1=http://example.net/pki/crl.der
+#URI.2=http://example.net/pki/crl.pem
+


### PR DESCRIPTION
Hello, a pull-request to add a 'publish' feature to easy-rsa.

The rational is as follows:
I use easy-rsa at two locations, lets call them SHARED and PRIVATE.
SHARED is used to generate request and to publish the results, it does not contains a CA. It can be accessed/mounted to install the certificate on the servers or client.
PRIVATE contains the CA certificate. PRIVATE can access SHARED but nothing else, it does not have network access.
The commands added in this set of commit help handle this case.

A typical usage is:

In SHARED run:
  easy-rsa gen-req my_server
In PRIVATE set the variable EASYRSA_PUBLISH to SHARED and run: 
  easy-rsa import-req my_server
  easy-rsa sign server my_server
  easy-rsa publish-ca update
Then SHARED contains all the needed files but not the private key of the CA.

The pull-request also contains two patch not directly related to the feature, tell me if you prefer to have separate pull-requests for them instead.

Best Regards,

Julien VdG