### PR TITLE
Default SAN in server certs, serial randomization

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -569,6 +569,18 @@ sign_req() {
 	local req_in="$EASYRSA_PKI/reqs/$2.req"
 	local crt_out="$EASYRSA_PKI/issued/$2.crt"
 
+	# Randomize Serial number
+	local i= serial= check_serial=
+	for i in 1 2 3 4 5; do
+		"$EASYRSA_OPENSSL" rand -hex 16 -out "$EASYRSA_PKI/serial"
+		serial="$(cat "$EASYRSA_PKI/serial")"
+		check_serial="$("$EASYRSA_OPENSSL" ca -config "$EASYRSA_SSL_CONF" -status "$serial" 2>&1)"
+		case "$check_serial" in
+			*"not present in db"*) break ;;
+			*) continue ;;
+		esac
+	done
+
 	# Support batch by internal caller:
 	[ "$3" = "batch" ] && local EASYRSA_BATCH=1
 
@@ -660,17 +672,6 @@ Certificate created at: $crt_out
 # used to generate+sign in 1 step
 build_full() {
 	verify_ca_init
-
-	local i= serial= check_serial=
-	for i in 1 2 3 4 5; do
-		"$EASYRSA_OPENSSL" rand -hex 16 -out "$EASYRSA_PKI/serial"
-		serial="$(cat "$EASYRSA_PKI/serial")"
-		check_serial="$("$EASYRSA_OPENSSL" ca -config "$EASYRSA_SSL_CONF" -status "$serial" 2>&1)"
-		case "$check_serial" in
-			*"not present in db"*) break ;;
-			*) continue ;;
-		esac
-	done
 
 	# pull filename base:
 	[ -n "$2" ] || die "\

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -627,6 +627,15 @@ $(display_dn req "$req_in")
 			esac
 		fi
 
+		# If type is server and no subjectAltName was requested,
+		# add one to the extensions file
+		if [[ "$crt_type" == 'server' ]]
+		then
+			echo "$EASYRSA_EXTRA_EXTS" | 
+				grep -q subjectAltName || 
+				print $(default_server_san "$req_in")
+		fi
+
 		# Add any advanced extensions supplied by env-var:
 		[ -n "$EASYRSA_EXTRA_EXTS" ] && print "$EASYRSA_EXTRA_EXTS"
 		
@@ -922,6 +931,22 @@ display_dn() {
 	local format="$1" path="$2"
 	print "$("$EASYRSA_OPENSSL" $format -in "$path" -noout -subject -nameopt multiline)"
 } # => display_dn()
+
+# generate default SAN from req/X509, passed by full pathname
+default_server_san() {
+	local path="$1"
+	local cn=$(
+		"$EASYRSA_OPENSSL" req -in "$path" -noout -subject -nameopt sep_multiline |
+		awk -F'=' '/^  *CN=/{print $2}'
+		)
+	echo "$cn" | egrep -q '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
+	if [[ $? -eq 0 ]]
+	then
+		print "subjectAltName = IP:$cn"
+	else
+		print "subjectAltName = DNS:$cn"
+	fi
+} # => default_server_san()
 
 # verify a file seems to be a valid req/X509
 verify_file() {


### PR DESCRIPTION
When issuing a server certificate, easyrsa now adds the CN as a subjectAltName by default, as recent browsers have stopped using the CN for hostname validation altogether. This default SAN will be overriden if the user uses the --subject-alt-name option.

Also, @ValdikSS's serial randomization is too nice to only be in build_full, so I moved it into the sign_req function.