### PR TITLE
Fix --copy-ext missing empty_ok.

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1169,6 +1169,7 @@ while :; do
 	--vars)
 		export EASYRSA_VARS_FILE="$val" ;;
 	--copy-ext)
+		empty_ok=1
 		export EASYRSA_CP_EXT=1 ;;
 	--subject-alt-name)
 		export EASYRSA_EXTRA_EXTS="\


### PR DESCRIPTION
Option `--copy-ext` is missing `empty_ok=1` in the switch case.