### PR TITLE
Fix generation of subjectAltName in master branch.

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -655,7 +655,7 @@ $(display_dn req "$req_in")
 		if [ "$crt_type" = 'server' ]; then
 			echo "$EASYRSA_EXTRA_EXTS" | 
 				grep -q subjectAltName || 
-				print "default_server_san $req_in"
+				default_server_san $req_in
 		fi
 
 		# Add any advanced extensions supplied by env-var:

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -279,7 +279,7 @@ Type the word '$value' to continue, or any other input to abort."
 
 # remove temp files
 clean_temp() {
-	for f in "$EASYRSA_TEMP_FILE" "$EASYRSA_TEMP_FILE_2" "$EASYRSA_TEMP_FILE_3"
+	for f in "$EASYRSA_TEMP_CONF" "$EASYRSA_TEMP_EXT" "$EASYRSA_TEMP_FILE_2" "$EASYRSA_TEMP_FILE_3"
 	do	[ -f "$f" ] && rm "$f" 2>/dev/null
 	done
 } # => clean_temp()
@@ -546,10 +546,10 @@ $EASYRSA_EXTRA_EXTS"
 }'
 		print "$extra_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
-			> "$EASYRSA_TEMP_FILE" \
+			> "$EASYRSA_TEMP_CONF" \
 			|| die "Copying SSL config to temp file failed"
 		# Use this new SSL config for the rest of this function
-		EASYRSA_SSL_CONF="$EASYRSA_TEMP_FILE"
+		EASYRSA_SSL_CONF="$EASYRSA_TEMP_CONF"
 	fi
 
 	key_out_tmp="$(mktemp "$key_out.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$key_out_tmp"
@@ -662,14 +662,14 @@ $(display_dn req "$req_in")
 		[ -n "$EASYRSA_EXTRA_EXTS" ] && print "$EASYRSA_EXTRA_EXTS"
 		
 		: # needed to keep die from inherting the above test
-	} > "$EASYRSA_TEMP_FILE" || die "\
+	} > "$EASYRSA_TEMP_EXT" || die "\
 Failed to create temp extension file (bad permissions?) at:
-$EASYRSA_TEMP_FILE"
+$EASYRSA_TEMP_EXT"
 
 	# sign request
 	crt_out_tmp="$(mktemp "$crt_out.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$crt_out_tmp"
 	"$EASYRSA_OPENSSL" ca -utf8 -in "$req_in" -out "$crt_out_tmp" -config "$EASYRSA_SSL_CONF" \
-		-extfile "$EASYRSA_TEMP_FILE" -days $EASYRSA_CERT_EXPIRE -batch $opts \
+		-extfile "$EASYRSA_TEMP_EXT" -days $EASYRSA_CERT_EXPIRE -batch $opts \
 		|| die "signing failed (openssl output above may have more detail)"
 	mv "$crt_out_tmp" "$crt_out"; EASYRSA_TEMP_FILE_2=
 	notice "\
@@ -1077,7 +1077,8 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_CRL_DAYS	180
 	set_var EASYRSA_NS_SUPPORT	no
 	set_var EASYRSA_NS_COMMENT	"Easy-RSA Generated Certificate"
-	set_var EASYRSA_TEMP_FILE	"$EASYRSA_PKI/extensions.temp"
+	set_var EASYRSA_TEMP_CONF	"$EASYRSA_PKI/openssl-easyrsa.temp"
+	set_var EASYRSA_TEMP_EXT	"$EASYRSA_PKI/extensions.temp"
 	set_var EASYRSA_TEMP_FILE_2	""
 	set_var EASYRSA_TEMP_FILE_3	""
 	set_var EASYRSA_REQ_CN		ChangeMe

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1186,6 +1186,7 @@ while :; do
 	--vars)
 		export EASYRSA_VARS_FILE="$val" ;;
 	--copy-ext)
+		empty_ok=1
 		export EASYRSA_CP_EXT=1 ;;
 	--subject-alt-name)
 		export EASYRSA_EXTRA_EXTS="\


### PR DESCRIPTION
Fixes: #170 

The [default_server_san()](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L946) function generates a valid [subjectAltName](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L149) based on the CSR CommonName.

The only place where this function would be useful is in generating a default `subjectAltName` in the event that one is not specified on the command line [here](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L658).  Inexplicably, the current master code prints an invalid `subjectAltName` consisting of the full path to the CSR file.

The [3.0.4 branch](https://github.com/OpenVPN/easy-rsa/blob/v3.0.4/easyrsa3/easyrsa#L660) prints a `subjectAltNam`e that is valid only in cases where the CN is a valid hostname, but fails where the CN is an IP address.

This PR replaces the incorrect `subjectAltName` with a call to the [default_server_san()](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L946) function.

Also, the [EASYRSA_TEMP_FILE](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L1080) is used for both a [replacement EASYRSA_SSL_CONF](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L552) and for a [temp extension file](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L672).  These two purposes conflict when specifying a [--subject-alt-name](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L149) argument, which is currently broken.

This PR uses [EASYRSA_TEMP_CONF](https://github.com/pillarsdotnet/easy-rsa/blob/master/easyrsa3/easyrsa#L552) for the first purpose and [EASYRSA_TEMP_EXT](https://github.com/pillarsdotnet/easy-rsa/blob/master/easyrsa3/easyrsa#L672) for the second.  This restores the  [--subject-alt-name](https://github.com/OpenVPN/easy-rsa/blob/master/easyrsa3/easyrsa#L149) functionality.

Also incorporates #153 
  
  