### PR TITLE
Generate the CA key and request in one command

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -465,34 +465,14 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	[ "$EASYRSA_BATCH" ] && opts="$opts -batch" || export EASYRSA_REQ_CN="Easy-RSA CA"
 
 	out_key_tmp="$(mktemp "$out_key.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$out_key_tmp"
-	out_key_pass_tmp="$(mktemp "$out_key_pass.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_3="$out_key_pass_tmp"
 	out_file_tmp="$(mktemp "$out_file.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_3="$out_file_tmp"
-	printf "Enter New CA Key Passphrase: "
-	stty -echo
-	read kpass
-	stty echo
-	echo
-	printf "Re-Enter New CA Key Passphrase: "
-	stty -echo
-	read kpass2
-	stty echo
-	echo
-	if [ "$kpass" = "$kpass2" ];
-	then
-		printf "$kpass" > "$out_key_pass_tmp"
-	else
-		die "Passphrases do not match."
-	fi
-	# create the CA key using AES256
-	"$EASYRSA_OPENSSL" genrsa -aes256 -out "$out_key_tmp" -passout file:"$out_key_pass_tmp" 
-	# create the CA keypair:
+	# create the CA request:
 	#shellcheck disable=SC2086
-	"$EASYRSA_OPENSSL" req -utf8 -new -key "$out_key_tmp" \
-		-config "$EASYRSA_SSL_CONF" -keyout "$out_key_tmp" -out "$out_file_tmp" -passin file:"$out_key_pass_tmp" $opts || \
-		die "Failed to build the CA"
+	"$EASYRSA_OPENSSL" req -utf8 -new -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" \
+		-config "$EASYRSA_SSL_CONF" -keyout "$out_key_tmp" -out "$out_file_tmp" $opts \
+		|| die "Failed to build the CA"
 	mv "$out_key_tmp" "$out_key"; EASYRSA_TEMP_FILE_2=
 	mv "$out_file_tmp" "$out_file"; EASYRSA_TEMP_FILE_3=
-	rm "$out_key_pass_tmp"
 
 	# Success messages
 	if [ $sub_ca ]; then


### PR DESCRIPTION
Use `openssl req`'s `-newkey` parameter to generate the key instead of separately generating the key and then generating the request from that key.

This avoids having to manipulate the password in EasyRSA (Reading from input, comparing, *storing in plaintext on the filesystem*) and lets OpenSSL ask for the password. This should be more secure and also needs less code.

Fixes #111 and #181.