### PR TITLE
Fix backslash handling when asking CA password

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -469,12 +469,12 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	out_file_tmp="$(mktemp "$out_file.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_3="$out_file_tmp"
 	printf "Enter New CA Key Passphrase: "
 	stty -echo
-	read kpass
+	read -r kpass
 	stty echo
 	echo
 	printf "Re-Enter New CA Key Passphrase: "
 	stty -echo
-	read kpass2
+	read -r kpass2
 	stty echo
 	echo
 	if [ "$kpass" = "$kpass2" ];


### PR DESCRIPTION
`read` treats '\\' (backslashes) as escape sequences by default resulting in unexpected behaviour with passwords containing backslashes. Adding the `-r` parameter should fix this and restore expected behaviour.

From the `read` manpage:

    By  default,  unless  the −r option is specified, <backslash> shall act as an escape character.
    
    [...]
    
    The following option is supported:
    -r        Do not treat a <backslash> character in any special way. Consider each <backslash> to be  part  of
              the input line.