### PR TITLE
CA certificate should be used as a digital signature

### DIFF
--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -122,7 +122,7 @@ basicConstraints = CA:true
 
 # Limit key usage to CA tasks. If you really want to use the generated pair as
 # a self-signed cert, comment this out.
-keyUsage = cRLSign, keyCertSign
+keyUsage = digitalSignature, cRLSign, keyCertSign
 
 # nsCertType omitted by default. Let's try to let the deprecated stuff die.
 # nsCertType = sslCA


### PR DESCRIPTION
Alongside the subject-alt-name fix https://github.com/OpenVPN/easy-rsa/issues/126, chrome wants the CA certificate to be used as digitalSignature.

### How to replicate

##### Invalid CA
1. Generate a signed certificate.
1. Import in to keystore and trust CA.
1. Run local server using certificate.
1. Add `mylocaldomain.com` to `/etc/hosts`
1. Open Chrome and navigate to `https://mylocaldomain.com`
1. See certificate is invalid.

##### Valid CA
1. Add `digitalSignature` to `keyUsage` in the `openssl-easyrsa.cnf`
1. Generate a signed certificate.
1. Import in to keystore and trust CA.
1. Run local server using certificate.
1. Add `mylocaldomain.com` to `/etc/hosts`
1. Open Chrome and navigate to `https://mylocaldomain.com`
1. See certificate is valid.

```sh
./easyrsa init-pki

./easyrsa \
	--batch \
	--dn-mode=org \
	--req-c="US" \
	--req-st="California" \
	--req-city="SF" \
	--req-org="Copyleft Certificate Co" \
	--req-email=me@example.net \
	--req-ou="My Organizational Unit" \
	--req-cn="my-local-ca" \
	build-ca \
        nopass

./easyrsa \
	--batch \
	--dn-mode=org \
	--req-c="US" \
	--req-st="California" \
	--req-city="SF" \
	--req-org="Copyleft Certificate Co" \
	--req-email=me@example.net \
	--req-ou="My Organizational Unit" \
	--req-cn="mylocaldomain.com" \
	--subject-alt-name="DNS:mylocaldomain.com" \
	build-server-full \
	'mylocaldomain.com' \
        nopass
```

### example nodejs for certificate testing
```js
const https = require('https');
const fs = require('fs');

const options = {
  key: fs.readFileSync('./pki/private/mylocaldomain.com.key'),
  cert: fs.readFileSync('./pki/issued/mylocaldomain.com.crt'),
};

var port = 8443;
https.createServer(options, (req, res) => {
  console.log('request');
  res.setHeader('Content-Type', 'text/html; charset=utf-8');
  res.setHeader('Cache-Control', 'no-cache');
  res.writeHead(200);
  res.end(`
    <h3>echo on port: ${port}</h3>
    <div>Date: ${Date.now()}</div>
  `);
}).listen(port);

console.log('listening on:' + port);
```