### PR TITLE
remove quotes around "$pkcs_opts"

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -874,7 +874,7 @@ Run easyrsa without commands for usage and command help."
 		verify_file x509 "$crt_ca" || die "\
 Unable to include CA cert in the $pkcs_type output (missing file, or use noca option.)
 Missing file expected at: $crt_ca"
-		pkcs_opts="$pkcs_opts -certfile $crt_ca"
+		pkcs_opts="$pkcs_opts -certfile \"$crt_ca\""
 	fi
 
 	# input files must exist
@@ -897,7 +897,7 @@ Missing key expected at: $key_in"
 
 		# export the p12:
 		"$EASYRSA_OPENSSL" pkcs12 -in "$crt_in" -inkey "$key_in" -export \
-			-out "$pkcs_out" "$pkcs_opts" || die "\
+			-out "$pkcs_out" $pkcs_opts || die "\
 Export of p12 failed: see above for related openssl errors."
 	;;
 	p7)


### PR DESCRIPTION
the $pkcs_opts variable contains arguments which should not be quoted, added quotes to ca cert path instead as this can be quoted. 

The quotes broke the export command