### PR TITLE
Soft reset

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -26,7 +26,7 @@ For a listing of options that can be supplied before the command, use:
 Here is the list of commands available with a short syntax reminder. Use the
 'help' command above to get full usage details.
 
-  init-pki
+  init-pki [ cmd-opts ]
   build-ca [ cmd-opts ]
   gen-dh
   gen-req <filename_base> [ cmd-opts ]
@@ -64,7 +64,10 @@ cmd_help() {
 	case "$1" in
 		init-pki|clean-all) text="
   init-pki [ cmd-opts ]
-      Removes & re-initializes the PKI dir for a clean PKI" ;;
+      Removes & re-initializes the PKI dir for a clean PKI"
+      				opts="
+        hard-reset  - Recursively deletes the PKI directory if it exists.
+        soft-reset  - Keeps the vars file and the PKI directory itself intact." ;;
 		build-ca) text="
   build-ca [ cmd-opts ]
       Creates a new CA"
@@ -390,6 +393,16 @@ $help_note"
 init_pki() {
 	vars_source_check
 
+	reset="soft"
+	while [ -n "$1" ]; do
+		case "$1" in
+			hard-reset|hard) reset="hard" ;;
+			soft-reset|soft) reset="soft" ;;
+			*) warn "Ignoring unknown command option: '$1'" ;;
+		esac
+		shift
+	done
+
 	# If EASYRSA_PKI exists, confirm before we rm -rf (skiped with EASYRSA_BATCH)
 	if [ -e "$EASYRSA_PKI" ]; then
 		confirm "Confirm removal: " "yes" "
@@ -398,7 +411,20 @@ WARNING!!!
 You are about to remove the EASYRSA_PKI at: $EASYRSA_PKI
 and initialize a fresh PKI here."
 		# now remove it:
-		rm -rf "$EASYRSA_PKI" || die "Removal of PKI dir failed. Check/correct errors above"
+		case "$reset" in
+			hard)
+				rm -rf "$EASYRSA_PKI" || die "Removal of PKI dir failed. Check/correct errors above"
+				;;
+			soft)
+				files="ca.crt certs_by_serial ecparams index.txt issued private reqs serial"
+				for i in $files; do
+					rm -rf "$EASYRSA_PKI/$i" || die "Removal of PKI dir failed. Check/correct errors above"
+				done
+				;;
+			*)
+				die "Removal of PKI dir failed. Unknown reset type."
+				;;
+		esac
 	fi
 
 	# new dirs:

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -418,7 +418,7 @@ and initialize a fresh PKI here."
 			soft)
 				files="ca.crt certs_by_serial ecparams index.txt index.txt.attr index.txt.old issued private reqs serial serial.old"
 				for i in $files; do
-					rm -rf "$EASYRSA_PKI/$i" || die "Removal of PKI dir failed. Check/correct errors above"
+					rm -rf "${EASYRSA_PKI:?}/$i" || die "Removal of PKI dir failed. Check/correct errors above"
 				done
 				;;
 			# More modes could be added here, e.g. only remove

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -416,11 +416,13 @@ and initialize a fresh PKI here."
 				rm -rf "$EASYRSA_PKI" || die "Removal of PKI dir failed. Check/correct errors above"
 				;;
 			soft)
-				files="ca.crt certs_by_serial ecparams index.txt issued private reqs serial"
+				files="ca.crt certs_by_serial ecparams index.txt index.txt.attr index.txt.old issued private reqs serial serial.old"
 				for i in $files; do
 					rm -rf "$EASYRSA_PKI/$i" || die "Removal of PKI dir failed. Check/correct errors above"
 				done
 				;;
+			# More modes could be added here, e.g. only remove
+			# issued certs (and clean database), but keep CA intact.
 			*)
 				die "Removal of PKI dir failed. Unknown reset type."
 				;;


### PR DESCRIPTION
This is similar to what was suggested in #178.

This adds `soft-reset` and `hard-reset` cmd-opts to `init-pki` subcommand, where `hard-reset` recursively removes the PKI directory (the current behavior) and `soft-reset` only removes most of the content, but keeps the directory and the `vars` file (as well as other user created files) intact.

I decided to implement this as cmd-opts instead of a `--option`, because from looking at the existing options, it seems like they are more generic or common to a family of subcommands, whereas cmd-opts seem to be specific to a single subcommand (though `nopass` would be an exception to that rule).

Note that I have made `soft-reset` the default behavior if no cmd-opt is passed, which is different from the previous behavior and may break scripts relying on this. I did this because I find this the saner option in most use-cases, but this can easily be changed if maintaining previous behavior is deemed more important.