### PR TITLE
Create index.attr file on init-pki

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -406,6 +406,9 @@ and initialize a fresh PKI here."
 		mkdir -p "$EASYRSA_PKI/$i" || die "Failed to create PKI file structure (permissions?)"
 	done
 
+	# Create index.attr file to avoid warnings while generating the first certificate.
+	echo "unique_subject = yes" > "$EASYRSA_PKI/index.txt.attr"
+
 	notice "\
 init-pki complete; you may now create a CA or requests.
 Your newly created PKI dir is: $EASYRSA_PKI


### PR DESCRIPTION
Avoid a nasty error message when running build-{client,server}-full for the first time.
Stick with the default value 'yes' to enforce unique subjects.