### PR TITLE
If a CN is supplied from environment, keep it

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -800,7 +800,8 @@ Matching file found at: "
 	[ -f "$crt_out" ] && die "Certificate $err_exists $crt_out"
 
 	# create request
-	EASYRSA_REQ_CN="$name"
+	# if a global CN is set, keep it
+	[ -n "$EASYRSA_REQ_CN" ] || EASYRSA_REQ_CN="$name"
 	#shellcheck disable=SC2086
 	gen_req "$name" batch $req_opts
 


### PR DESCRIPTION
This is a proposal batch allowing to specify a custom CN using
```
export EASYRSA_REQ_CN="Some-openVPN-server"
easyrsa --batch build-server-full server nopass
```
while keeping the filenames..
