### PR TITLE
Avoid storing password in insecure disk file

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -334,10 +334,10 @@ easyrsa_openssl() {
 		return
 	fi
 
-	easyrsa_openssl_conf=$(easyrsa_mktemp)
+	easyrsa_openssl_conf=$(easyrsa_mktemp) || die "Failed to create temporary file"
 	easyrsa_extra_exts=
 	if [ -n "$EASYRSA_EXTRA_EXTS" ]; then
-		easyrsa_extra_exts=$(easyrsa_mktemp)
+		easyrsa_extra_exts=$(easyrsa_mktemp) || die "Failed to create temporary file"
 		cat >"$easyrsa_extra_exts" <<-EOF
 			req_extensions = req_extra
 			[ req_extra ]
@@ -576,11 +576,11 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	# shellcheck disable=SC2015
 	[ "$EASYRSA_BATCH" ] && opts="$opts -batch" || export EASYRSA_REQ_CN="Easy-RSA CA"
 
-	out_key_tmp="$(easyrsa_mktemp)"
-	out_file_tmp="$(easyrsa_mktemp)"
+	out_key_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	out_file_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	# Get password from user if necessary
 	if [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then
-		out_key_pass_tmp="$(easyrsa_mktemp)"
+		out_key_pass_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 		echo
 		printf "Enter New CA Key Passphrase: "
 		hide_read_pass kpass
@@ -703,7 +703,7 @@ $EASYRSA_EXTRA_EXTS"
 	{ while ( getline<"/dev/stdin" ) {print} next }
  {print}
 }'
-		conf_tmp="$(easyrsa_mktemp)"
+		conf_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 		print "$extra_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
 			> "$conf_tmp" \
@@ -712,8 +712,8 @@ $EASYRSA_EXTRA_EXTS"
 		EASYRSA_SSL_CONF="$conf_tmp"
 	fi
 
-	key_out_tmp="$(easyrsa_mktemp)"
-	req_out_tmp="$(easyrsa_mktemp)"
+	key_out_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	req_out_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	# generate request
 	[ $EASYRSA_BATCH ] && opts="$opts -batch"
 	# shellcheck disable=2086,2148
@@ -792,7 +792,7 @@ $(display_dn req "$req_in")
 "	# => confirm end
 
 	# Generate the extensions file for this cert:
-	ext_tmp="$(easyrsa_mktemp)"
+	ext_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	{
 		# Append first any COMMON file (if present) then the cert-type extensions
 		cat "$EASYRSA_EXT_DIR/COMMON"
@@ -834,7 +834,7 @@ Failed to create temp extension file (bad permissions?) at:
 $ext_tmp"
 
 	# sign request
-	crt_out_tmp="$(easyrsa_mktemp)"
+	crt_out_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	easyrsa_openssl ca -utf8 -in "$req_in" -out "$crt_out_tmp" \
 		-extfile "$ext_tmp" -days "$EASYRSA_CERT_EXPIRE" -batch $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} \
 		|| die "signing failed (openssl output above may have more detail)"
@@ -1178,7 +1178,7 @@ gen_crl() {
 	verify_ca_init
 
 	out_file="$EASYRSA_PKI/crl.pem"
-	out_file_tmp="$(easyrsa_mktemp)"
+	out_file_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || die "\
 CRL Generation failed.
 "
@@ -1336,7 +1336,7 @@ $file"
 If the key is currently encrypted you must supply the decryption passphrase.
 ${crypto:+You will then enter a new PEM passphrase for this key.$NL}"
 
-	out_key_tmp="$(easyrsa_mktemp)"
+	out_key_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	easyrsa_openssl "$key_type" -in "$file" -out "$out_key_tmp" $crypto ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || die "\
 Failed to change the private key passphrase. See above for possible openssl
 error messages."

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -600,11 +600,19 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		hide_read_pass kpass2
 		echo
 		# shellcheck disable=2154
-		if [ "$kpass" = "$kpass2" ];
-		then
+		if [ "$kpass" != "$kpass2" ]; then
+			die "Passphrases do not match."
+		fi
+
+		# Try to use named pipe but falls back if it fails (windows)
+		if ! (umask 177; mkfifo "$out_key_pass_tmp.pipe"); then
+			use_namedpipes=false
+			warn "mkfifo failed. Using temporary file in disk instead"
 			printf "%s" "$kpass" > "$out_key_pass_tmp"
 		else
-			die "Passphrases do not match."
+			use_namedpipes=true
+			rm -f "$out_key_pass_tmp"
+			mv -f "$out_key_pass_tmp.pipe" "$out_key_pass_tmp"
 		fi
 	fi
 
@@ -612,7 +620,10 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	crypto_opts=""
 	if [ ! $nopass ]; then
 		crypto_opts="$crypto"
-		[ -z "$EASYRSA_PASSOUT" ] && crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
+		[ -z "$EASYRSA_PASSOUT" ] && {
+			crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp";
+			$use_namedpipes && { printf "%s" "$kpass" > "$out_key_pass_tmp" & }
+		}
 	fi
 	if [ "$EASYRSA_ALGO" = "rsa" ]; then
 		#shellcheck disable=SC2086
@@ -627,7 +638,12 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 
 	# create the CA keypair:
 	crypto_opts=""
-	[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && crypto_opts="-passin file:$out_key_pass_tmp"
+	if [ ! $nopass ]; then
+		[ -z "$EASYRSA_PASSIN" ] && {
+			crypto_opts="-passin file:$out_key_pass_tmp"
+			$use_namedpipes && { printf "%s" "$kpass" > "$out_key_pass_tmp" & }
+		}
+	fi
 
 	#shellcheck disable=SC2086
 	easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -311,7 +311,18 @@ easyrsa_mktemp() {
 	[ -n "$EASYRSA_TEMP_DIR_session" ] || die "EASYRSA_TEMP_DIR_session not initialized!"
 	[ -d "$EASYRSA_TEMP_DIR_session" ] || mkdir -p "$EASYRSA_TEMP_DIR_session" ||
 	       die "Could not create temporary directory '$EASYRSA_TEMP_DIR_session'. Permission or concurrency problem?"
-	mktemp "$EASYRSA_TEMP_DIR_session/tmp.XXXXXX"
+	[ -d "$EASYRSA_TEMP_DIR_session" ] || die "Temporary directory '$EASYRSA_TEMP_DIR_session' does not exist"
+
+	template="$EASYRSA_TEMP_DIR_session/tmp.XXXXXX"
+	tempfile=$(mktemp "$template") || return
+
+	# win32 mktemp shipped by easyrsa returns template as file!
+	if [ "$template" = "$tempfile" ]; then
+		# but win32 mktemp -d does work
+		tempfile=$(mktemp -du "$tempfile") || return
+		printf "" > "$tempfile" || return
+	fi
+	echo "$tempfile"
 } # => easyrsa_mktemp
 
 # remove temp files and do terminal cleanups


### PR DESCRIPTION
mktemp create a world readable file in /tmp to temporary save
CA password. An attacker could either read this file during
build-ca or retrieve it afterwards directly from disk blocks if
not overwritten.

Now it uses named pipes accessible only to owner inside pki dir.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>