### PR TITLE
fix trap cleanup for non-bash

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1307,6 +1307,8 @@ vars_setup
 
 # Register clean_temp on EXIT
 trap "clean_temp" EXIT
+trap "exit 130" INT
+trap 'exit 143' TERM
 
 # determine how we were called, then hand off to the function responsible
 cmd="$1"


### PR DESCRIPTION
busybox and freebsd sh does not call EXIT trap when it receives
a signal.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>