### PR TITLE
add --passin --passout for alternative pass src/dst

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -254,8 +254,7 @@ die() {
 Easy-RSA error:
 
 $1" 1>&2
-	clean_temp;
-	prog_exit "${2:-1}"
+	exit "${2:-1}"
 } # => die()
 
 # non-fatal warning output
@@ -305,21 +304,15 @@ Type the word '$value' to continue, or any other input to abort."
 	exit 9
 } # => confirm()
 
-# remove temp files
-clean_temp() {
+# remove temp files and do terminal cleanups
+cleanup() {
 	for f in "$EASYRSA_TEMP_CONF" "$EASYRSA_TEMP_EXT" \
 		"$EASYRSA_TEMP_FILE_2" "$EASYRSA_TEMP_FILE_3" "$EASYRSA_TEMP_FILE_4"
 	do	[ -f "$f" ] && rm "$f" 2>/dev/null
 	done
-} # => clean_temp()
-
-prog_exit() {
-	ESTAT=0
-	[ -n "$1" ] && ESTAT=$1
 	(stty echo 2>/dev/null) || set -o echo
 	echo "" # just to get a clean line
-	exit "$ESTAT"
-} # => prog_exit()
+} # => cleanup()
 
 # Make LibreSSL safe config file from OpenSSL config file
 make_ssl_config() {
@@ -1625,12 +1618,15 @@ done
 # Intelligent env-var detection and auto-loading:
 vars_setup
 
-# Register clean_temp and prog_exit on SIGHUP, SIGINT, SIGQUIT, and SIGABRT
-trap "clean_temp; prog_exit 1" 1 
-trap "clean_temp; prog_exit 2" 2
-trap "clean_temp; prog_exit 3" 3
-trap "clean_temp; prog_exit 6" 6
-trap "clean_temp; prog_exit 15" 15
+# Register cleanup on EXIT
+trap "cleanup" EXIT
+# When SIGHUP, SIGINT, SIGQUIT, SIGABRT and SIGTERM,
+# explicitly exit to signal EXIT (non-bash shells)
+trap "exit 1" 1
+trap "exit 2" 2
+trap "exit 3" 3
+trap "exit 6" 6
+trap "exit 14" 15
 
 # determine how we were called, then hand off to the function responsible
 cmd="$1"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -319,28 +319,58 @@ cleanup() {
 	echo "" # just to get a clean line
 } # => cleanup()
 
-# Make LibreSSL safe config file from OpenSSL config file
-make_ssl_config() {
-sed \
-       -e "s\`ENV::EASYRSA\`EASYRSA\`g" \
-       -e "s\`\$dir\`$EASYRSA_PKI\`g" \
-       -e "s\`\$EASYRSA_PKI\`$EASYRSA_PKI\`g" \
-       -e "s\`\$EASYRSA_CERT_EXPIRE\`$EASYRSA_CERT_EXPIRE\`g" \
-       -e "s\`\$EASYRSA_CRL_DAYS\`$EASYRSA_CRL_DAYS\`g" \
-       -e "s\`\$EASYRSA_DIGEST\`$EASYRSA_DIGEST\`g" \
-       -e "s\`\$EASYRSA_KEY_SIZE\`$EASYRSA_KEY_SIZE\`g" \
-       -e "s\`\$EASYRSA_DIGEST\`$EASYRSA_DIGEST\`g" \
-       -e "s\`\$EASYRSA_DN\`$EASYRSA_DN\`g" \
-       -e "s\`\$EASYRSA_REQ_COUNTRY\`$EASYRSA_REQ_COUNTRY\`g" \
-       -e "s\`\$EASYRSA_REQ_PROVINCE\`$EASYRSA_REQ_PROVINCE\`g" \
-       -e "s\`\$EASYRSA_REQ_CITY\`$EASYRSA_REQ_CITY\`g" \
-       -e "s\`\$EASYRSA_REQ_ORG\`$EASYRSA_REQ_ORG\`g" \
-       -e "s\`\$EASYRSA_REQ_OU\`$EASYRSA_REQ_OU\`g" \
-       -e "s\`\$EASYRSA_REQ_CN\`$EASYRSA_REQ_CN\`g" \
-       -e "s\`\$EASYRSA_REQ_EMAIL\`$EASYRSA_REQ_EMAIL\`g" \
-	"$EASYRSA_SSL_CONF" > "$EASYRSA_SAFE_CONF" || die "\
-Failed to update $EASYRSA_SAFE_CONF"
-} # => make_ssl_config()
+easyrsa_openssl() {
+	openssl_command=$1; shift
+
+	case $openssl_command in
+		ca|req|srp|ts) has_config=true;;
+		*) has_config=false;;
+	esac
+
+	if ! $has_config; then
+		"$EASYRSA_OPENSSL" "$openssl_command" "$@"
+		return
+	fi
+
+	easyrsa_openssl_conf=$(easyrsa_mktemp)
+	easyrsa_extra_exts=
+	if [ -n "$EASYRSA_EXTRA_EXTS" ]; then
+		easyrsa_extra_exts=$(easyrsa_mktemp)
+		cat >"$easyrsa_extra_exts" <<-EOF
+			req_extensions = req_extra
+			[ req_extra ]
+			$EASYRSA_EXTRA_EXTS
+		EOF
+	fi
+
+	# Make LibreSSL safe config file from OpenSSL config file
+	sed \
+		-e "s\`ENV::EASYRSA\`EASYRSA\`g" \
+		-e "s\`\$dir\`$EASYRSA_PKI\`g" \
+		-e "s\`\$EASYRSA_PKI\`$EASYRSA_PKI\`g" \
+		-e "s\`\$EASYRSA_CERT_EXPIRE\`$EASYRSA_CERT_EXPIRE\`g" \
+		-e "s\`\$EASYRSA_CRL_DAYS\`$EASYRSA_CRL_DAYS\`g" \
+		-e "s\`\$EASYRSA_DIGEST\`$EASYRSA_DIGEST\`g" \
+		-e "s\`\$EASYRSA_KEY_SIZE\`$EASYRSA_KEY_SIZE\`g" \
+		-e "s\`\$EASYRSA_DIGEST\`$EASYRSA_DIGEST\`g" \
+		-e "s\`\$EASYRSA_DN\`$EASYRSA_DN\`g" \
+		-e "s\`\$EASYRSA_REQ_COUNTRY\`$EASYRSA_REQ_COUNTRY\`g" \
+		-e "s\`\$EASYRSA_REQ_PROVINCE\`$EASYRSA_REQ_PROVINCE\`g" \
+		-e "s\`\$EASYRSA_REQ_CITY\`$EASYRSA_REQ_CITY\`g" \
+		-e "s\`\$EASYRSA_REQ_ORG\`$EASYRSA_REQ_ORG\`g" \
+		-e "s\`\$EASYRSA_REQ_OU\`$EASYRSA_REQ_OU\`g" \
+		-e "s\`\$EASYRSA_REQ_CN\`$EASYRSA_REQ_CN\`g" \
+		-e "s\`\$EASYRSA_REQ_EMAIL\`$EASYRSA_REQ_EMAIL\`g" \
+		${EASYRSA_EXTRA_EXTS:+-e "/^#%EXTRA_EXTS%/r $easyrsa_extra_exts"} \
+		"$EASYRSA_SSL_CONF" > "$easyrsa_openssl_conf" ||
+		die "Failed to update $easyrsa_openssl_conf"
+
+	"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" "$@"
+	err=$?
+	rm -f "$easyrsa_openssl_conf"
+	rm -f "$easyrsa_extra_exts"
+	return $err
+} # => easyrsa_openssl
 
 vars_source_check() {
 	# Check for defined EASYRSA_PKI
@@ -373,9 +403,6 @@ $out"
 }
 
 verify_ssl_lib () {
-	# make safessl-easyrsa.cnf
-	make_ssl_config
-
 	# Verify EASYRSA_OPENSSL command gives expected output
 	if [ -z "$EASYRSA_SSL_OK" ]; then
 		val="$("$EASYRSA_OPENSSL" version)"
@@ -582,8 +609,8 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	# create the CA keypair:
 	[ ! $nopass ] && crypto_opts="-passin file:$out_key_pass_tmp"
 	#shellcheck disable=SC2086
-	"$EASYRSA_OPENSSL" req -utf8 -new -key "$out_key_tmp" \
-		-config "$EASYRSA_SAFE_CONF" -keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts || \
+	easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
+		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts || \
 		die "Failed to build the CA"
 
 	mv "$out_key_tmp" "$out_key"
@@ -680,12 +707,11 @@ $EASYRSA_EXTRA_EXTS"
 	# generate request
 	[ $EASYRSA_BATCH ] && opts="$opts -batch"
 	# shellcheck disable=2086,2148
-	"$EASYRSA_OPENSSL" req -utf8 -new -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" \
-		-config "$EASYRSA_SAFE_CONF" -keyout "$key_out_tmp" -out "$req_out_tmp" $opts \
+	easyrsa_openssl req -utf8 -new -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" \
+		-keyout "$key_out_tmp" -out "$req_out_tmp" $opts \
 		|| die "Failed to generate request"
 	mv "$key_out_tmp" "$key_out"
 	mv "$req_out_tmp" "$req_out"
-	[ -z "$conf_tmp" ] || rm -f "$conf_tmp"
 	notice "\
 Keypair and certificate request completed. Your files are:
 req: $req_out
@@ -796,7 +822,7 @@ $ext_tmp"
 
 	# sign request
 	crt_out_tmp="$(easyrsa_mktemp)"
-	"$EASYRSA_OPENSSL" ca -utf8 -in "$req_in" -out "$crt_out_tmp" -config "$EASYRSA_SAFE_CONF" \
+	easyrsa_openssl ca -utf8 -in "$req_in" -out "$crt_out_tmp" \
 		-extfile "$ext_tmp" -days "$EASYRSA_CERT_EXPIRE" -batch $opts \
 		|| die "signing failed (openssl output above may have more detail)"
 	mv "$crt_out_tmp" "$crt_out"
@@ -883,7 +909,7 @@ Unable to revoke as no certificate was found. Certificate was expected
 at: $crt_in"
 
 	# shellcheck disable=SC2086
-	"$EASYRSA_OPENSSL" ca -utf8 -revoke "$crt_in" -config "$EASYRSA_SAFE_CONF" $opts || die "\
+	easyrsa_openssl ca -utf8 -revoke "$crt_in" $opts || die "\
 Failed to revoke certificate: revocation command failed."
 
 	# move revoked files so we can reissue certificates with the same name
@@ -924,7 +950,7 @@ input in file: $req_in"
 	fi
 
 	# get the serial number of the certificate -> serial=XXXX
-	cert_serial="$("$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -serial)"
+	cert_serial="$(easyrsa_openssl x509 -in "$crt_in" -noout -serial)"
 	# remove the serial= part -> we only need the XXXX part
 	cert_serial=${cert_serial##*=}
 
@@ -998,7 +1024,7 @@ at: $crt_in"
 
 	# Check if old cert is expired or expires within 30 days
 	expire_date=$(
-		"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -enddate |
+		easyrsa_openssl x509 -in "$crt_in" -noout -enddate |
 		sed 's/^notAfter=//'
 		)
         case $(uname 2>/dev/null) in
@@ -1019,7 +1045,7 @@ Renewal not allowed."
 
 	# Extract certificate usage from old cert
 	cert_ext_key_usage=$(
-		"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -text |
+		easyrsa_openssl x509 -in "$crt_in" -noout -text |
 		sed -n "/X509v3 Extended Key Usage:/{n;s/^ *//g;p;}"
 		)
 	case $cert_ext_key_usage in
@@ -1038,7 +1064,7 @@ Renewal not allowed."
 	echo "$EASYRSA_EXTRA_EXTS" | grep -q subjectAltName || \
 	{
 		san=$(
-			"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -text |
+			easyrsa_openssl x509 -in "$crt_in" -noout -text |
 			sed -n "/X509v3 Subject Alternative Name:/{n;s/ //g;p;}"
 			)
 		[ -n "$san" ] && export EASYRSA_EXTRA_EXTS="\
@@ -1090,7 +1116,7 @@ input in file: $req_in"
 	fi
 
 	# get the serial number of the certificate -> serial=XXXX
-	cert_serial="$("$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -serial)"
+	cert_serial="$(easyrsa_openssl x509 -in "$crt_in" -noout -serial)"
 	# remove the serial= part -> we only need the XXXX part
 	cert_serial=${cert_serial##*=}
 
@@ -1137,7 +1163,7 @@ gen_crl() {
 
 	out_file="$EASYRSA_PKI/crl.pem"
 	out_file_tmp="$(easyrsa_mktemp)"
-	"$EASYRSA_OPENSSL" ca -utf8 -gencrl -out "$out_file_tmp" -config "$EASYRSA_SAFE_CONF" || die "\
+	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" || die "\
 CRL Generation failed.
 "
 	mv "$out_file_tmp" "$out_file"
@@ -1238,7 +1264,7 @@ Missing key expected at: $key_in"
 
 		# export the p12:
 		# shellcheck disable=SC2086
-		"$EASYRSA_OPENSSL" pkcs12 -in "$crt_in" -inkey "$key_in" -export \
+		easyrsa_openssl pkcs12 -in "$crt_in" -inkey "$key_in" -export \
 			-out "$pkcs_out" $pkcs_opts || die "\
 Export of p12 failed: see above for related openssl errors."
 	;;
@@ -1247,7 +1273,7 @@ Export of p12 failed: see above for related openssl errors."
 
 		# export the p7:
 		# shellcheck disable=SC2086
-		"$EASYRSA_OPENSSL" crl2pkcs7 -nocrl -certfile "$crt_in" \
+		easyrsa_openssl crl2pkcs7 -nocrl -certfile "$crt_in" \
 			-out "$pkcs_out" $pkcs_opts || die "\
 Export of p7 failed: see above for related openssl errors."
 	;;
@@ -1295,7 +1321,7 @@ If the key is currently encrypted you must supply the decryption passphrase.
 ${crypto:+You will then enter a new PEM passphrase for this key.$NL}"
 
 	out_key_tmp="$(easyrsa_mktemp)"
-	"$EASYRSA_OPENSSL" "$key_type" -in "$file" -out "$out_key_tmp" $crypto || die "\
+	easyrsa_openssl "$key_type" -in "$file" -out "$out_key_tmp" $crypto || die "\
 Failed to change the private key passphrase. See above for possible openssl
 error messages."
 
@@ -1310,7 +1336,7 @@ Failed to change the private key passphrase. See above for error messages."
 update_db() {
 	verify_ca_init
 
-	"$EASYRSA_OPENSSL" ca -utf8 -updatedb -config "$EASYRSA_SSL_CONF" || die "\
+	easyrsa_openssl ca -utf8 -updatedb || die "\
 Failed to perform update-db: see above for related openssl errors."
 	return 0
 } # => update_db()
@@ -1325,7 +1351,7 @@ display_dn() {
 default_server_san() {
 	path="$1"
 	cn=$(
-		"$EASYRSA_OPENSSL" req -in "$path" -noout -subject -nameopt sep_multiline |
+		easyrsa_openssl req -in "$path" -noout -subject -nameopt sep_multiline |
 		awk -F'=' '/^  *CN=/{print $2}'
 		)
 	echo "$cn" | grep -E -q '^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
@@ -1341,7 +1367,7 @@ default_server_san() {
 verify_file() {
 	format="$1" 
 	path="$2"
-	"$EASYRSA_OPENSSL" "$format" -in "$path" -noout 2>/dev/null || return 1
+	easyrsa_openssl "$format" -in "$path" -noout 2>/dev/null || return 1
 	return 0
 } # => verify_file()
 
@@ -1396,7 +1422,7 @@ Showing $type details for '$name'.
 This file is stored at:
 $in_file
 "
-	"$EASYRSA_OPENSSL" $format -in "$in_file" -noout -text\
+	easyrsa_openssl $format -in "$in_file" -noout -text\
 		-nameopt multiline $opts || die "\
 OpenSSL failure to process the input"
 } # => show()
@@ -1432,7 +1458,7 @@ Showing $type details for 'ca'.
 This file is stored at:
 $in_file
 "
-	"$EASYRSA_OPENSSL" $format -in "$in_file" -noout -text\
+	easyrsa_openssl $format -in "$in_file" -noout -text\
 		-nameopt multiline $opts || die "\
 OpenSSL failure to process the input"
 } # => show_ca()
@@ -1499,9 +1525,7 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_TEMP_DIR	"$EASYRSA_PKI"
 	set_var EASYRSA_REQ_CN		ChangeMe
 	set_var EASYRSA_DIGEST		sha256
-
 	set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
-	set_var EASYRSA_SAFE_CONF	"$EASYRSA_PKI/safessl-easyrsa.cnf"
 
 	# Same as above for the x509-types extensions dir
 	if [ -d "$EASYRSA_PKI/x509-types" ]; then
@@ -1521,9 +1545,6 @@ Note: using Easy-RSA configuration from: $vars"
 	fi
 
 	[ -n "$EASYRSA_TEMP_DIR_session" ] || EASYRSA_TEMP_DIR_session="$(mktemp -ud "$EASYRSA_TEMP_DIR/easy-rsa-$$.XXXXXX")"
-
-	# Setting OPENSSL_CONF prevents bogus warnings (especially useful on win32)
-	export OPENSSL_CONF="$EASYRSA_SAFE_CONF"
 } # vars_setup()
 
 # variable assignment by indirection when undefined; merely exports

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -209,6 +209,8 @@ non-empty values to options are mandatory.
 General options:
 
 --batch         : set automatic (no-prompts when possible) mode
+--passin=ARG    : set -passin ARG for openssl
+--passout=ARG   : set -passout ARG for openssl
 --pki-dir=DIR   : declares the PKI directory
 --vars=FILE     : define a specific 'vars' file to use for Easy-RSA config
 
@@ -523,7 +525,6 @@ build_ca() {
 	sub_ca=""
 	nopass=""
 	crypto="-aes256"
-	crypto_opts=""
 	while [ -n "$1" ]; do
 		case "$1" in
 			subca) sub_ca=1 ;;
@@ -577,7 +578,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	out_key_tmp="$(easyrsa_mktemp)"
 	out_file_tmp="$(easyrsa_mktemp)"
 	# Get password from user if necessary
-	if [ ! $nopass ]; then
+	if [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then
 		out_key_pass_tmp="$(easyrsa_mktemp)"
 		echo
 		printf "Enter New CA Key Passphrase: "
@@ -596,21 +597,29 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	fi
 
 	# create the CA key using AES256
-	[ ! $nopass ] && crypto_opts="$crypto -passout file:$out_key_pass_tmp"
+	crypto_opts=""
+	if [ ! $nopass ]; then
+		crypto_opts="$crypto"
+		[ -z "$EASYRSA_PASSOUT" ] && crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
+	fi
 	if [ "$EASYRSA_ALGO" = "rsa" ]; then
 		#shellcheck disable=SC2086
-		"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts "$EASYRSA_ALGO_PARAMS"
+		"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} "$EASYRSA_ALGO_PARAMS" || \
+			die "Failed create CA private key"
 	elif [ "$EASYRSA_ALGO" = "ec" ]; then
 		#shellcheck disable=SC2086
 		"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
-			"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts
+			"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
+			die "Failed create CA private key"
 	fi
 
 	# create the CA keypair:
-	[ ! $nopass ] && crypto_opts="-passin file:$out_key_pass_tmp"
+	crypto_opts=""
+	[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && crypto_opts="-passin file:$out_key_pass_tmp"
+
 	#shellcheck disable=SC2086
 	easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
-		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts || \
+		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
 		die "Failed to build the CA"
 
 	mv "$out_key_tmp" "$out_key"
@@ -708,7 +717,7 @@ $EASYRSA_EXTRA_EXTS"
 	[ $EASYRSA_BATCH ] && opts="$opts -batch"
 	# shellcheck disable=2086,2148
 	easyrsa_openssl req -utf8 -new -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" \
-		-keyout "$key_out_tmp" -out "$req_out_tmp" $opts \
+		-keyout "$key_out_tmp" -out "$req_out_tmp" $opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} \
 		|| die "Failed to generate request"
 	mv "$key_out_tmp" "$key_out"
 	mv "$req_out_tmp" "$req_out"
@@ -823,7 +832,7 @@ $ext_tmp"
 	# sign request
 	crt_out_tmp="$(easyrsa_mktemp)"
 	easyrsa_openssl ca -utf8 -in "$req_in" -out "$crt_out_tmp" \
-		-extfile "$ext_tmp" -days "$EASYRSA_CERT_EXPIRE" -batch $opts \
+		-extfile "$ext_tmp" -days "$EASYRSA_CERT_EXPIRE" -batch $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} \
 		|| die "signing failed (openssl output above may have more detail)"
 	mv "$crt_out_tmp" "$crt_out"
 	rm -f "$ext_tmp"
@@ -909,7 +918,7 @@ Unable to revoke as no certificate was found. Certificate was expected
 at: $crt_in"
 
 	# shellcheck disable=SC2086
-	easyrsa_openssl ca -utf8 -revoke "$crt_in" $opts || die "\
+	easyrsa_openssl ca -utf8 -revoke "$crt_in" ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} $opts || die "\
 Failed to revoke certificate: revocation command failed."
 
 	# move revoked files so we can reissue certificates with the same name
@@ -1163,7 +1172,7 @@ gen_crl() {
 
 	out_file="$EASYRSA_PKI/crl.pem"
 	out_file_tmp="$(easyrsa_mktemp)"
-	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" || die "\
+	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || die "\
 CRL Generation failed.
 "
 	mv "$out_file_tmp" "$out_file"
@@ -1265,7 +1274,7 @@ Missing key expected at: $key_in"
 		# export the p12:
 		# shellcheck disable=SC2086
 		easyrsa_openssl pkcs12 -in "$crt_in" -inkey "$key_in" -export \
-			-out "$pkcs_out" $pkcs_opts || die "\
+			-out "$pkcs_out" $pkcs_opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || die "\
 Export of p12 failed: see above for related openssl errors."
 	;;
 	p7)
@@ -1274,7 +1283,7 @@ Export of p12 failed: see above for related openssl errors."
 		# export the p7:
 		# shellcheck disable=SC2086
 		easyrsa_openssl crl2pkcs7 -nocrl -certfile "$crt_in" \
-			-out "$pkcs_out" $pkcs_opts || die "\
+			-out "$pkcs_out" $pkcs_opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || die "\
 Export of p7 failed: see above for related openssl errors."
 	;;
 esac
@@ -1321,7 +1330,7 @@ If the key is currently encrypted you must supply the decryption passphrase.
 ${crypto:+You will then enter a new PEM passphrase for this key.$NL}"
 
 	out_key_tmp="$(easyrsa_mktemp)"
-	easyrsa_openssl "$key_type" -in "$file" -out "$out_key_tmp" $crypto || die "\
+	easyrsa_openssl "$key_type" -in "$file" -out "$out_key_tmp" $crypto ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || die "\
 Failed to change the private key passphrase. See above for possible openssl
 error messages."
 
@@ -1566,6 +1575,10 @@ NL='
 # Be secure with a restrictive umask
 [ -z "$EASYRSA_NO_UMASK" ] && umask 077
 
+# Ignore some env vars
+EASYRSA_PASSIN=
+EASYRSA_PASSOUT=
+
 # Parse options
 while :; do
 	# Separate option from value:
@@ -1619,6 +1632,10 @@ while :; do
 	--batch)
 		empty_ok=1
 		export EASYRSA_BATCH=1 ;;
+	--passin)
+		export EASYRSA_PASSIN="$val";;
+	--passout)
+		export EASYRSA_PASSOUT="$val";;
 	--subca-len)
 		export EASYRSA_SUBCA_LEN="$val" ;;
 	--vars)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -304,12 +304,17 @@ Type the word '$value' to continue, or any other input to abort."
 	exit 9
 } # => confirm()
 
+# mktemp wrapper
+easyrsa_mktemp() {
+	[ -n "$EASYRSA_TEMP_DIR_session" ] || die "EASYRSA_TEMP_DIR_session not initialized!"
+	[ -d "$EASYRSA_TEMP_DIR_session" ] || mkdir -p "$EASYRSA_TEMP_DIR_session" ||
+	       die "Could not create temporary directory '$EASYRSA_TEMP_DIR_session'. Permission or concurrency problem?"
+	mktemp "$EASYRSA_TEMP_DIR_session/tmp.XXXXXX"
+} # => easyrsa_mktemp
+
 # remove temp files and do terminal cleanups
 cleanup() {
-	for f in "$EASYRSA_TEMP_CONF" "$EASYRSA_TEMP_EXT" \
-		"$EASYRSA_TEMP_FILE_2" "$EASYRSA_TEMP_FILE_3" "$EASYRSA_TEMP_FILE_4"
-	do	[ -f "$f" ] && rm "$f" 2>/dev/null
-	done
+	[ -z "$EASYRSA_TEMP_DIR_session" ] || rm -rf "$EASYRSA_TEMP_DIR_session"
 	(stty echo 2>/dev/null) || set -o echo
 	echo "" # just to get a clean line
 } # => cleanup()
@@ -542,11 +547,11 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	# shellcheck disable=SC2015
 	[ "$EASYRSA_BATCH" ] && opts="$opts -batch" || export EASYRSA_REQ_CN="Easy-RSA CA"
 
-	out_key_tmp="$(mktemp "$out_key.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$out_key_tmp"
-	out_file_tmp="$(mktemp "$out_file.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_3="$out_file_tmp"
+	out_key_tmp="$(easyrsa_mktemp)"
+	out_file_tmp="$(easyrsa_mktemp)"
 	# Get password from user if necessary
 	if [ ! $nopass ]; then
-		out_key_pass_tmp="$(mktemp)"; EASYRSA_TEMP_FILE_4="$out_key_pass_tmp"
+		out_key_pass_tmp="$(easyrsa_mktemp)"
 		echo
 		printf "Enter New CA Key Passphrase: "
 		hide_read_pass kpass
@@ -581,9 +586,9 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		-config "$EASYRSA_SAFE_CONF" -keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts || \
 		die "Failed to build the CA"
 
-	mv "$out_key_tmp" "$out_key"; EASYRSA_TEMP_FILE_2=
-	mv "$out_file_tmp" "$out_file"; EASYRSA_TEMP_FILE_3=
-	[ -f "$out_key_pass_tmp" ] && rm "$out_key_pass_tmp" && EASYRSA_TEMP_FILE_4=
+	mv "$out_key_tmp" "$out_key"
+	mv "$out_file_tmp" "$out_file"
+	[ -f "$out_key_pass_tmp" ] && rm "$out_key_pass_tmp"
 
 	# Success messages
 	if [ $sub_ca ]; then
@@ -661,24 +666,26 @@ $EASYRSA_EXTRA_EXTS"
 	{ while ( getline<"/dev/stdin" ) {print} next }
  {print}
 }'
+		conf_tmp="$(easyrsa_mktemp)"
 		print "$extra_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
-			> "$EASYRSA_TEMP_CONF" \
+			> "$conf_tmp" \
 			|| die "Copying SSL config to temp file failed"
 		# Use this new SSL config for the rest of this function
-		EASYRSA_SSL_CONF="$EASYRSA_TEMP_CONF"
+		EASYRSA_SSL_CONF="$conf_tmp"
 	fi
 
-	key_out_tmp="$(mktemp "$key_out.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$key_out_tmp"
-	req_out_tmp="$(mktemp "$req_out.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_3="$req_out_tmp"
+	key_out_tmp="$(easyrsa_mktemp)"
+	req_out_tmp="$(easyrsa_mktemp)"
 	# generate request
 	[ $EASYRSA_BATCH ] && opts="$opts -batch"
 	# shellcheck disable=2086,2148
 	"$EASYRSA_OPENSSL" req -utf8 -new -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" \
 		-config "$EASYRSA_SAFE_CONF" -keyout "$key_out_tmp" -out "$req_out_tmp" $opts \
 		|| die "Failed to generate request"
-	mv "$key_out_tmp" "$key_out"; EASYRSA_TEMP_FILE_2=
-	mv "$req_out_tmp" "$req_out"; EASYRSA_TEMP_FILE_3=
+	mv "$key_out_tmp" "$key_out"
+	mv "$req_out_tmp" "$req_out"
+	[ -z "$conf_tmp" ] || rm -f "$conf_tmp"
 	notice "\
 Keypair and certificate request completed. Your files are:
 req: $req_out
@@ -746,6 +753,7 @@ $(display_dn req "$req_in")
 "	# => confirm end
 
 	# Generate the extensions file for this cert:
+	ext_tmp="$(easyrsa_mktemp)"
 	{
 		# Append first any COMMON file (if present) then the cert-type extensions
 		cat "$EASYRSA_EXT_DIR/COMMON"
@@ -782,17 +790,17 @@ $(display_dn req "$req_in")
 		[ -n "$EASYRSA_EXTRA_EXTS" ] && print "$EASYRSA_EXTRA_EXTS"
 
 		: # needed to keep die from inherting the above test
-	} > "$EASYRSA_TEMP_EXT" || die "\
+	} > "$ext_tmp" || die "\
 Failed to create temp extension file (bad permissions?) at:
-$EASYRSA_TEMP_EXT"
+$ext_tmp"
 
 	# sign request
-	# shellcheck disable=SC2086
-	crt_out_tmp="$(mktemp "$crt_out.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$crt_out_tmp"
+	crt_out_tmp="$(easyrsa_mktemp)"
 	"$EASYRSA_OPENSSL" ca -utf8 -in "$req_in" -out "$crt_out_tmp" -config "$EASYRSA_SAFE_CONF" \
-		-extfile "$EASYRSA_TEMP_EXT" -days "$EASYRSA_CERT_EXPIRE" -batch $opts \
+		-extfile "$ext_tmp" -days "$EASYRSA_CERT_EXPIRE" -batch $opts \
 		|| die "signing failed (openssl output above may have more detail)"
-	mv "$crt_out_tmp" "$crt_out"; EASYRSA_TEMP_FILE_2=
+	mv "$crt_out_tmp" "$crt_out"
+	rm -f "$ext_tmp"
 	notice "\
 Certificate created at: $crt_out
 "
@@ -1128,11 +1136,11 @@ gen_crl() {
 	verify_ca_init
 
 	out_file="$EASYRSA_PKI/crl.pem"
-	out_file_tmp="$(mktemp "$out_file.XXXXXXXXXX")"; EASYRSA_TEMP_FILE_2="$out_file_tmp"
+	out_file_tmp="$(easyrsa_mktemp)"
 	"$EASYRSA_OPENSSL" ca -utf8 -gencrl -out "$out_file_tmp" -config "$EASYRSA_SAFE_CONF" || die "\
 CRL Generation failed.
 "
-	mv "$out_file_tmp" "$out_file"; EASYRSA_TEMP_FILE_2=
+	mv "$out_file_tmp" "$out_file"
 
 	notice "\
 An updated CRL has been created.
@@ -1286,13 +1294,12 @@ $file"
 If the key is currently encrypted you must supply the decryption passphrase.
 ${crypto:+You will then enter a new PEM passphrase for this key.$NL}"
 
-	EASYRSA_TEMP_FILE_2="$file.temp"
-
-	"$EASYRSA_OPENSSL" "$key_type" -in "$file" -out "$EASYRSA_TEMP_FILE_2" $crypto || die "\
+	out_key_tmp="$(easyrsa_mktemp)"
+	"$EASYRSA_OPENSSL" "$key_type" -in "$file" -out "$out_key_tmp" $crypto || die "\
 Failed to change the private key passphrase. See above for possible openssl
 error messages."
 
-	mv "$EASYRSA_TEMP_FILE_2" "$file" || die "\
+	mv "$out_key_tmp" "$file" || die "\
 Failed to change the private key passphrase. See above for error messages."
 
 	notice "Key passphrase successfully changed"
@@ -1489,10 +1496,7 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_CRL_DAYS	180
 	set_var EASYRSA_NS_SUPPORT	no
 	set_var EASYRSA_NS_COMMENT	"Easy-RSA (~VER~) Generated Certificate"
-	set_var EASYRSA_TEMP_CONF	"$EASYRSA_PKI/openssl-easyrsa.temp"
-	set_var EASYRSA_TEMP_EXT	"$EASYRSA_PKI/extensions.temp"
-	set_var EASYRSA_TEMP_FILE_2	""
-	set_var EASYRSA_TEMP_FILE_3	""
+	set_var EASYRSA_TEMP_DIR	"$EASYRSA_PKI"
 	set_var EASYRSA_REQ_CN		ChangeMe
 	set_var EASYRSA_DIGEST		sha256
 
@@ -1515,6 +1519,8 @@ Note: using Easy-RSA configuration from: $vars"
 	else
 		die "Alg '$EASYRSA_ALGO' is invalid: must be 'rsa' or 'ec'"
 	fi
+
+	[ -n "$EASYRSA_TEMP_DIR_session" ] || EASYRSA_TEMP_DIR_session="$(mktemp -ud "$EASYRSA_TEMP_DIR/easy-rsa-$$.XXXXXX")"
 
 	# Setting OPENSSL_CONF prevents bogus warnings (especially useful on win32)
 	export OPENSSL_CONF="$EASYRSA_SAFE_CONF"

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -71,6 +71,10 @@ fi
 
 #set_var EASYRSA_PKI		"$PWD/pki"
 
+# Define directory for temporary subdirectories.
+
+#set_var EASYRSA_TEMP_DIR	"$EASYRSA_PKI"
+
 # Define X509 DN mode.
 # This is used to adjust what elements are included in the Subject field as the DN
 # (this is the "Distinguished Name.")


### PR DESCRIPTION
Batch operations cannot be automated if openssl keeps asking
for a password. These new options allow the user to specify
a new source for password, using any openssl password options
like pass:1234 or env:var

Aborts build-ca if privkey generation fails.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>

This is based on #240 (pending)
This fixes #103, #101, #73, #18