### PR TITLE
Remove req/privkey in build_full when sign_req fails

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -846,7 +846,10 @@ Matching file found at: "
 	gen_req "$name" batch $req_opts
 
 	# Sign it
-	sign_req "$crt_type" "$name" batch
+	( sign_req "$crt_type" "$name" batch ) || {
+		rm -f "$req_out" "$key_out"
+		die "Failed to sign '$name'"
+	}
 
 } # => build_full()
 


### PR DESCRIPTION
build_full leave req/privkey ig sign fails (i.e. when CA pass was
incorrect). If build_full fails, it should remove everything it created.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>