### PR TITLE
fix prog_vars when easyrsa is symlink or in $PATH

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1446,7 +1446,11 @@ vars_setup() {
 	vars=
 
 	# set up program path
-	prog_vars="${0%/*}/vars"
+	prog_file="$0"
+	prog_file2="$(which -- "$prog_file" 2>/dev/null)" && prog_file="$prog_file2"
+	prog_file2="$(readlink -f "$prog_file" 2>/dev/null)" && prog_file="$prog_file2"
+	prog_dir="${prog_file%/*}"
+	prog_vars="${prog_dir}/vars"
 	# set up PKI path
 	pki_vars="${EASYRSA_PKI:-$PWD/pki}/vars"
 
@@ -1476,7 +1480,7 @@ Note: using Easy-RSA configuration from: $vars"
 	fi
 	
 	# Set defaults, preferring existing env-vars if present
-	set_var EASYRSA		"${0%/*}"
+	set_var EASYRSA		"$prog_dir"
 	set_var EASYRSA_OPENSSL	openssl
 	set_var EASYRSA_PKI	"$PWD/pki"
 	set_var EASYRSA_DN	cn_only


### PR DESCRIPTION
When easyrsa in in $PATH, $0 does not contain a directory, resulting
in an invalid prog_vars. prog_vars is used to get default vars
location, if $EASYRSA_VARS_FILE, $EASYRSA_PKI/vars and $PWD/pki/vars
does not exist.

$0 is also used to set $EASYRSA the same way prog_vars is defined.

$EASYRSA/openssl-easyrsa.cnf is used to set $EASYRSA_SSL_CONF initial
content if missing.

$EASYRSA/x509-types is used to for extensions dir if $EASYRSA_EXT_DIR
and $EASYRSA_PKI/x509-types are not found. However, if vars already
needs changes, it is better to set $EASYRSA_EXT_DIR and file locations
there.

Normally a symlink to /usr/bin will be used to put easyrsa in $PATH.
Following $PATH and symlink allows easyrsa to be located in a more
standard dir like /usr/lib/easy-rsa/easyrsa and vars at
/usr/{lib,libexec,share}/easyrsa/vars, which could be a symlink to
/etc/easy-rsa/vars. vars can be easily appended with the default
distribution values.

With this patch, a system-wide easyrsa package could use this file
structure without patching easyrsa:

 /etc/easy-rsa/openssl-easyrsa.cnf
 /etc/easy-rsa/pki/
 /etc/easy-rsa/vars
 /usr/bin/easyrsa -> /usr/lib/easy-rsa/easyrsa
 /usr/lib/easy-rsa/easyrsa
 /usr/lib/easy-rsa/openssl-easyrsa.cnf
 /usr/lib/easy-rsa/vars -> /etc/easy-rsa/vars
 /usr/lib/easy-rsa/x509-types

If following symlink fails (win32), the previous behavior is used.

Signed-off-by: Luiz Angelo Daros de Luca <luizluca@gmail.com>