### PR TITLE
Fixes for the renew command

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1040,7 +1040,7 @@ Renewal not allowed."
 			"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -text |
 			sed -n "/X509v3 Subject Alternative Name:/{n;s/ //g;p;}"
 			)
-		export EASYRSA_EXTRA_EXTS="\
+		[ -n "$san" ] && export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS
 subjectAltName = $san"
 	}

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1010,10 +1010,10 @@ at: $crt_in"
 		)
 	expire_date=$(date -d "$expire_date" +%s)
 
-	allow_renew_date=$(date -d '+30day' +%s)
+	allow_renew_date=$(date -d "+${EASYRSA_CERT_RENEW}day" +%s)
 
 	[ "$expire_date" -lt "$allow_renew_date" ] || die "\
-Certificate expires in more than 30 days.
+Certificate expires in more than $EASYRSA_CERT_RENEW days.
 Renewal not allowed."
 
 	# Extract certificate usage from old cert
@@ -1488,6 +1488,7 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_EC_DIR		"$EASYRSA_PKI/ecparams"
 	set_var EASYRSA_CA_EXPIRE	3650
 	set_var EASYRSA_CERT_EXPIRE	1080 # new default of 36 months	
+	set_var EASYRSA_CERT_RENEW	30
 	set_var EASYRSA_CRL_DAYS	180
 	set_var EASYRSA_NS_SUPPORT	no
 	set_var EASYRSA_NS_COMMENT	"Easy-RSA (~VER~) Generated Certificate"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1006,13 +1006,13 @@ at: $crt_in"
 	# Check if old cert is expired or expires within 30 days
 	expire_date=$(
 		"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -enddate |
-		sed -n 's/^notAfter=//'
+		sed 's/^notAfter=//'
 		)
 	expire_date=$(date -d "$expire_date" +%s)
 
 	allow_renew_date=$(date -d '+30day' +%s)
 
-	[ "$expire_date" -gt "$allow_renew_date" ] || die "\
+	[ "$expire_date" -lt "$allow_renew_date" ] || die "\
 Certificate expires in more than 30 days.
 Renewal not allowed."
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -959,7 +959,7 @@ input in file: $req_in"
 		# get file extension
 		file_ext="${file##*.}"
 
-		mv "$file" "$EASYRSA_PKI/revoked/private_by_serial/$cert_serial.$file_ext"
+		[ -f "$file" ] && mv "$file" "$EASYRSA_PKI/revoked/private_by_serial/$cert_serial.$file_ext"
 	done
 
 	# remove the dublicate certificate in the certs_by_serial folder
@@ -1113,7 +1113,7 @@ input in file: $req_in"
 		# get file extension
 		file_ext="${file##*.}"
 
-		mv "$file" "$EASYRSA_PKI/renewed/private_by_serial/$cert_serial.$file_ext"
+		[ -f "$file" ] && mv "$file" "$EASYRSA_PKI/renewed/private_by_serial/$cert_serial.$file_ext"
 	done
 
 	# remove the duplicate certificate in the certs_by_serial folder

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1018,8 +1018,8 @@ Renewal not allowed."
 
 	# Extract certificate usage from old cert
 	cert_ext_key_usage=$(
-		"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -ext extendedKeyUsage |
-		sed -n "2p;n;s/^ *//;p;"
+		"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -text |
+		sed -n "/X509v3 Extended Key Usage:/{n;s/^ *//g;p;}"
 		)
 	case $cert_ext_key_usage in
 		"TLS Web Client Authentication")
@@ -1037,8 +1037,8 @@ Renewal not allowed."
 	echo "$EASYRSA_EXTRA_EXTS" | grep -q subjectAltName || \
 	{
 		san=$(
-			"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -ext subjectAltName |
-			sed -n "2p;{n;s/ //g;p;}"
+			"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -text |
+			sed -n "/X509v3 Subject Alternative Name:/{n;s/ //g;p;}"
 			)
 		export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -127,6 +127,10 @@ fi
 # parsed after this timeframe passes. It is only used for an expected next
 # publication date.
 
+# How many days before its expiration date a certificate is allowed to be
+# renewed?
+#set_var EASYRSA_CERT_RENEW	30
+
 #set_var EASYRSA_CRL_DAYS	180
 
 # Support deprecated "Netscape" extensions? (choices "yes" or "no".) The default


### PR DESCRIPTION
Fixes:
- Cert expiration check was broken.
- Some older openssl versions do not have the -ext option.
- SAN could be empty in some cases.
- Don't try to move inexistant files to the renewed subdirs (also fixed for revoked certs).

Enhancement:
- The grace period for renewing a cert is now configurable.
