### PR TITLE
op_test: server renew and tiny lag to verify date

### DIFF
--- a/op_test.sh
+++ b/op_test.sh
@@ -466,6 +466,9 @@ create_pki ()
 	REQ_name="s01"
 	build_full
 	show_cert
+	sleep 3
+	renew_cert
+	show_cert
 	revoke_cert
 
 	REQ_type="server"
@@ -484,7 +487,9 @@ create_pki ()
 	REQ_name="c01"
 	build_full
 	show_cert
+	sleep 3
 	renew_cert
+	show_cert
 	revoke_cert
 
 	REQ_type="server"


### PR DESCRIPTION
The lag adds verifiable data to the test log because the cert dates are changed.
Signed-off-by: Richard Bonhomme <tincanteksup@gmail.com>