### PR TITLE
Gracefuly handle IP when both renewing cert and keeping SAN from the old cert

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1081,7 +1081,7 @@ Renewal not allowed."
 	{
 		san=$(
 			easyrsa_openssl x509 -in "$crt_in" -noout -text |
-			sed -n "/X509v3 Subject Alternative Name:/{n;s/ //g;p;}"
+			sed -n "/X509v3 Subject Alternative Name:/{n;s/IP Address:/IP:/;s/ //g;p;}"
 			)
 		[ -n "$san" ] && export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS


### PR DESCRIPTION
The SAN as extracted from the certificate can't be re-injected as is in the IP Address case.
```
            X509v3 Subject Alternative Name: 
                DNS:www.example.net, DNS:www2.example.net, IP Address:10.10.10.10
```
```IP Address:``` needs to be rewritten as ```IP:```.

Fixes #305 