### PR TITLE
Add support for generating KDC server certificates

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1580,6 +1580,7 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_DIGEST		sha256
 	set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
 	set_var EASYRSA_SAFE_CONF	"$EASYRSA_PKI/safessl-easyrsa.cnf"
+	set_var EASYRSA_KDC_REALM	"CHANGEME.EXAMPLE.COM"
 
 	# Same as above for the x509-types extensions dir
 	if [ -d "$EASYRSA_PKI/x509-types" ]; then

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -190,6 +190,9 @@ fi
 #
 #set_var EASYRSA_EXT_DIR	"$EASYRSA/x509-types"
 
+# If you want to generate KDC certificates, you need to set the realm here.
+#set_var EASYRSA_KDC_REALM      "CHANGEME.EXAMPLE.COM"
+
 # OpenSSL config file:
 # If you need to use a specific openssl config file, you can reference it here.
 # Normally this file is auto-detected from a file named openssl-easyrsa.cnf from the

--- a/easyrsa3/x509-types/kdc
+++ b/easyrsa3/x509-types/kdc
@@ -1,0 +1,21 @@
+# X509 extensions for a KDC server certificate
+
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+extendedKeyUsage = 1.3.6.1.5.2.3.5
+keyUsage = nonRepudiation,digitalSignature,keyEncipherment,keyAgreement
+issuerAltName = issuer:copy
+subjectAltName = otherName:1.3.6.1.5.2.2;SEQUENCE:kdc_princ_name
+
+[kdc_princ_name]
+realm = EXP:0,GeneralString:${ENV::EASYRSA_KDC_REALM}
+principal_name = EXP:1,SEQUENCE:kdc_principal_seq
+
+[kdc_principal_seq]
+name_type = EXP:0,INTEGER:1
+name_string = EXP:1,SEQUENCE:kdc_principals
+
+[kdc_principals]
+princ1 = GeneralString:krbtgt
+princ2 = GeneralString:${ENV::EASYRSA_KDC_REALM}


### PR DESCRIPTION
This adds a new x509 cert type for KDC server certificates. Generating KDC certificates needs a kerberos realm to be provided, so also add a new EASYRSA_KDC_REALM conf entry.

This does not handle generating KDC client certificates, as I don't need this feature, but this could probably be added later with yet another x509 cert type and re-using the same conf entry and passing the client name.