### PR TITLE
Allow ca.key to be a pipe for non-interactive use

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -474,9 +474,10 @@ verify_ca_init() {
 	# First check the PKI has been initialized
 	verify_pki_init
 
-	# verify expected files present:
+	# Verify expected files are present. Allow files to be regular files
+	# (or symlinks), but also pipes, for flexibility with ca.key
 	for i in serial index.txt index.txt.attr ca.crt private/ca.key; do
-		if [ ! -f "$EASYRSA_PKI/$i" ]; then
+		if [ ! -f "$EASYRSA_PKI/$i" ] && [ ! -p "$EASYRSA_PKI/$i" ]; then
 			[ "$1" = "test" ] && return 1
 			die "\
 Missing expected CA file: $i (perhaps you need to run build-ca?)


### PR DESCRIPTION
Non-interactive use of Easy-RSA requires ca.key to be available unencrypted, because the password prompt is interactive. This makes it difficult to use Easy-RSA with config management eg. Ansible, unless we store ca.key unprotected.

This patch allows ca.key to be loaded from a named pipe. As such, it can be quite safely loaded using a tool such as Pass, prior to invoking Easy-RSA:

```
mkfifo -m 600 ca.key
pass "$PSTORE_CA_KEY" >ca.key &
```