### PR TITLE
Support for Edwards Curves

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -393,6 +393,7 @@ easyrsa_openssl() {
 		cp "$easyrsa_openssl_conf" "$EASYRSA_SAFE_CONF"
 		err=$?
 	else
+		echo "$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" "$@"
 		"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" "$@"
 		err=$?
 	fi
@@ -409,7 +410,8 @@ EASYRSA_PKI env-var undefined"
 } # => vars_source_check()
 
 # Verify supplied curve exists and generate curve file if needed
-verify_curve() {
+verify_curve_ec() {
+
 	if ! "$EASYRSA_OPENSSL" ecparam -name "$EASYRSA_CURVE" > /dev/null; then
 		die "\
 Curve $EASYRSA_CURVE not found. Run openssl ecparam -list_curves to show a
@@ -430,6 +432,13 @@ $out"
 
 	# Explicitly return success for caller
 	return 0
+}
+
+verify_curve_ed() {
+	if [ "ed25519" = "$EASYRSA_CURVE" ] || [ "ed448" = "$EASYRSA_CURVE" ] ; then
+		return 0
+	fi
+		return 1
 }
 
 verify_ssl_lib () {
@@ -578,7 +587,8 @@ build_ca() {
 	done
 
 	verify_pki_init
-	[ "$EASYRSA_ALGO" = "ec" ] && verify_curve
+	[ "$EASYRSA_ALGO" = "ec" ] && verify_curve_ec
+	[ "$EASYRSA_ALGO" = "ed" ] && verify_curve_ed
 
 	# setup for the simpler intermediate CA situation and overwrite with root-CA if needed:
 	out_file="$EASYRSA_PKI/reqs/ca.req"
@@ -655,6 +665,11 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
 			"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
 			die "Failed create CA private key"
+	elif [ "ed" = "$EASYRSA_ALGO" ]; then
+                CURVE_CAPS=$(echo $EASYRSA_CURVE | tr '[a-z]' '[A-Z]')
+                echo "$EASYRSA_OPENSSL genpkey -algorithm $CURVE_CAPS -out $out_key_tmp"
+		"$EASYRSA_OPENSSL" genpkey -algorithm $CURVE_CAPS -out $out_key_tmp || \
+                        die "Failed create CA private key"
 	fi
 
 	# create the CA keypair:
@@ -723,7 +738,8 @@ Run easyrsa without commands for usage and commands."
 	done
 
 	verify_pki_init
-	[ "$EASYRSA_ALGO" = "ec" ] && verify_curve
+	[ "$EASYRSA_ALGO" = "ec" ] && verify_curve_ec
+        [ "$EASYRSA_ALGO" = "ed" ] && verify_curve_ed
 
 	# don't wipe out an existing private key without confirmation
 	[ -f "$key_out" ] && confirm "Confirm key overwrite: " "yes" "\
@@ -760,7 +776,11 @@ $EASYRSA_EXTRA_EXTS"
 	# generate request
 	[ $EASYRSA_BATCH ] && opts="$opts -batch"
 	# shellcheck disable=2086,2148
-	easyrsa_openssl req -utf8 -new -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" \
+	algo_opts=""
+	if [ "ed" != $EASYRSA_ALGO ];then
+		algo_opts=' -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" '
+	fi
+	easyrsa_openssl req -utf8 -new $algo_opts \
 		-keyout "$key_out_tmp" -out "$req_out_tmp" $opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} \
 		|| die "Failed to generate request"
 	mv "$key_out_tmp" "$key_out"
@@ -1670,8 +1690,8 @@ Note: using Easy-RSA configuration from: $vars"
 		EASYRSA_ALGO_PARAMS="$EASYRSA_EC_DIR/${EASYRSA_CURVE}.pem"
 	elif [ "rsa" = "$EASYRSA_ALGO" ]; then
 		EASYRSA_ALGO_PARAMS="${EASYRSA_KEY_SIZE}"
-	else
-		die "Alg '$EASYRSA_ALGO' is invalid: must be 'rsa' or 'ec'"
+	elif [ "ed" != "$EASYRSA_ALGO" ]; then
+		die "Alg '$EASYRSA_ALGO' is invalid: must be 'rsa', 'ec' or 'ed' "
 	fi
 
 	# Assign value to $EASYRSA_TEMP_DIR_session and work around Windows mktemp bug when parent dir is missing

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -665,10 +665,13 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
 			die "Failed create CA private key"
 	elif [ "ed" = "$EASYRSA_ALGO" ]; then
-                CURVE_CAPS=$(echo $EASYRSA_CURVE | tr '[a-z]' '[A-Z]')
-                echo "$EASYRSA_OPENSSL genpkey -algorithm $CURVE_CAPS -out $out_key_tmp"
-		"$EASYRSA_OPENSSL" genpkey -algorithm $CURVE_CAPS -out $out_key_tmp || \
+                if [ "ed25519" = "$EASYRSA_CURVE" ]; then
+			"$EASYRSA_OPENSSL" genpkey -algorithm ED25519  -out $out_key_tmp || \
                         die "Failed create CA private key"
+		elif [ "ed448" = "$EASYRSA_CURVE" ]; then
+			"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp || \
+                        die "Failed create CA private key"
+		fi
 	fi
 
 	# create the CA keypair:

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -410,7 +410,6 @@ EASYRSA_PKI env-var undefined"
 
 # Verify supplied curve exists and generate curve file if needed
 verify_curve_ec() {
-
 	if ! "$EASYRSA_OPENSSL" ecparam -name "$EASYRSA_CURVE" > /dev/null; then
 		die "\
 Curve $EASYRSA_CURVE not found. Run openssl ecparam -list_curves to show a
@@ -435,7 +434,6 @@ $out"
 
 # Verify if Edward Curve exists
 verify_curve_ed() {
-
 	if [ "ed25519" = "$EASYRSA_CURVE" ] && "$EASYRSA_OPENSSL" genpkey -algorithm ED25519 > /dev/null; then
 		return 0
 	elif [ "ed448" = "$EASYRSA_CURVE" ] && "$EASYRSA_OPENSSL" genpkey -algorithm ED448 > /dev/null; then

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -393,7 +393,6 @@ easyrsa_openssl() {
 		cp "$easyrsa_openssl_conf" "$EASYRSA_SAFE_CONF"
 		err=$?
 	else
-		echo "$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" "$@"
 		"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" "$@"
 		err=$?
 	fi

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -433,11 +433,15 @@ $out"
 	return 0
 }
 
+# Verify if Edward Curve exists
 verify_curve_ed() {
-	if [ "ed25519" = "$EASYRSA_CURVE" ] || [ "ed448" = "$EASYRSA_CURVE" ] ; then
+
+	if [ "ed25519" = "$EASYRSA_CURVE" ] && "$EASYRSA_OPENSSL" genpkey -algorithm ED25519 > /dev/null; then
+		return 0
+	elif [ "ed448" = "$EASYRSA_CURVE" ] && "$EASYRSA_OPENSSL" genpkey -algorithm ED448 > /dev/null; then
 		return 0
 	fi
-		return 1
+		die "Curve $EASYRSA_CURVE not found."
 }
 
 verify_ssl_lib () {
@@ -665,12 +669,12 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
 			die "Failed create CA private key"
 	elif [ "ed" = "$EASYRSA_ALGO" ]; then
-                if [ "ed25519" = "$EASYRSA_CURVE" ]; then
+		if [ "ed25519" = "$EASYRSA_CURVE" ]; then
 			"$EASYRSA_OPENSSL" genpkey -algorithm ED25519  -out $out_key_tmp || \
-                        die "Failed create CA private key"
+			die "Failed create CA private key"
 		elif [ "ed448" = "$EASYRSA_CURVE" ]; then
 			"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp || \
-                        die "Failed create CA private key"
+			die "Failed create CA private key"
 		fi
 	fi
 
@@ -741,7 +745,7 @@ Run easyrsa without commands for usage and commands."
 
 	verify_pki_init
 	[ "$EASYRSA_ALGO" = "ec" ] && verify_curve_ec
-        [ "$EASYRSA_ALGO" = "ed" ] && verify_curve_ed
+	[ "$EASYRSA_ALGO" = "ed" ] && verify_curve_ed
 
 	# don't wipe out an existing private key without confirmation
 	[ -f "$key_out" ] && confirm "Confirm key overwrite: " "yes" "\
@@ -780,7 +784,7 @@ $EASYRSA_EXTRA_EXTS"
 	# shellcheck disable=2086,2148
 	algo_opts=""
 	if [ "ed" != $EASYRSA_ALGO ];then
-		algo_opts=' -newkey $EASYRSA_ALGO:$EASYRSA_ALGO_PARAMS '
+		algo_opts=" -newkey $EASYRSA_ALGO:$EASYRSA_ALGO_PARAMS "
 	fi
 	easyrsa_openssl req -utf8 -new $algo_opts \
 		-keyout "$key_out_tmp" -out "$req_out_tmp" $opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} \

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -777,7 +777,7 @@ $EASYRSA_EXTRA_EXTS"
 	# shellcheck disable=2086,2148
 	algo_opts=""
 	if [ "ed" != $EASYRSA_ALGO ];then
-		algo_opts=' -newkey "$EASYRSA_ALGO":"$EASYRSA_ALGO_PARAMS" '
+		algo_opts=' -newkey $EASYRSA_ALGO:$EASYRSA_ALGO_PARAMS '
 	fi
 	easyrsa_openssl req -utf8 -new $algo_opts \
 		-keyout "$key_out_tmp" -out "$req_out_tmp" $opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} \

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -112,10 +112,11 @@ fi
 # Choices for crypto alg are: (each in lower-case)
 #  * rsa
 #  * ec
+#  * ed
 
 #set_var EASYRSA_ALGO		rsa
 
-# Define the named curve, used in ec mode only:
+# Define the named curve, used in ec & ed modes:
 
 #set_var EASYRSA_CURVE		secp384r1
 


### PR DESCRIPTION
Solving #350 so as to accommodate any ED based curve ( ED448, ED25519 etc. ) .
OpenSSL handles Edwards Curves differently compared to elliptical curves, hence the differences in syntax.

References:

* [EC curve operations](https://wiki.openssl.org/index.php/Command_Line_Elliptic_Curve_Operations)
* [openssl genpkey](https://www.openssl.org/docs/man1.1.1/man1/openssl-genpkey.html)
* [Creating ED25519 certs](https://blog.pinterjann.is/ed25519-certificates.html)