### PR TITLE
Add support for Object Identifier in Subject Alternative Names

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1447,7 +1447,7 @@ display_san() {
 	else
 		san=$(
 			"$EASYRSA_OPENSSL" "$format" -in "$path" -noout -text |
-			sed -n "/X509v3 Subject Alternative Name:/{n;s/ //g;s/IPAddress:/IP:/g;p;}"
+			sed -n "/X509v3 Subject Alternative Name:/{n;s/ //g;s/IPAddress:/IP:/g;s/RegisteredID/RID/;p;}"
 			)
 
 		[ -n "$san" ] && print "$san"


### PR DESCRIPTION
See http://openssl.cs.utah.edu/docs/apps/x509v3_config.html:

> The subject alternative name extension allows various literal values
> to be included in the configuration file. These include email (an email
> address) URI a uniform resource indicator, DNS (a DNS domain name), RID
> (a registered ID: OBJECT IDENTIFIER), IP (an IP address), dirName (a
> distinguished name) and otherName.