### PR TITLE
Expose EASYRSA_PASSIN and EASYRSA_PASSOUT env variables

### DIFF
--- a/doc/EasyRSA-Advanced.md
+++ b/doc/EasyRSA-Advanced.md
@@ -113,3 +113,7 @@ possible terse description is shown below:
     signing
  *  `EASYRSA_BATCH` (CLI: `--batch`) - enable batch (no-prompt) mode; set
     env-var to non-zero string to enable (CLI takes no options)
+ *  `EASYRSA_PASSIN` (CLI: `--passin`) - allows to specify a source for password;
+    using any openssl password options like pass:1234 or env:var
+ *  `EASYRSA_PASSOUT` (CLI: `--passout`) - allows to specify a source for password;
+    using any openssl password options like pass:1234 or env:var

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1645,6 +1645,12 @@ vars_setup() {
 	# If a vars file was located, source it
 	# If $EASYRSA_NO_VARS is defined (not blank) this is skipped
 	if [ -z "$EASYRSA_NO_VARS" ] && [ -n "$vars" ]; then
+		if grep -Eq 'EASYRSA_PASSIN|EASYRSA_PASSOUT' "$vars"; then
+			die "\
+Variable EASYRSA_PASSIN or EASYRSA_PASSOUT has been found in the configuration \
+file. Storing sensitive information in the configuration file is not \
+recommended - please remove it from there before continuing."
+		fi
 		#shellcheck disable=SC2034
 		EASYRSA_CALLER=1 
 		# shellcheck disable=SC1090

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2324,10 +2324,6 @@ NL='
 # Be secure with a restrictive umask
 [ -z "$EASYRSA_NO_UMASK" ] && umask 077
 
-# Ignore some env vars
-EASYRSA_PASSIN=
-EASYRSA_PASSOUT=
-
 # Parse options
 while :; do
 	# Separate option from value:


### PR DESCRIPTION
By exposing these variables it's possible to configure the password from
various sources by specifing env vars. This is a followup to PR #242

Fixes #365