### PR TITLE
Enable Edwards Curves for Public Key Algorithm

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -781,7 +781,9 @@ $EASYRSA_EXTRA_EXTS"
 	[ $EASYRSA_BATCH ] && opts="$opts -batch"
 	# shellcheck disable=2086,2148
 	algo_opts=""
-	if [ "ed" != $EASYRSA_ALGO ];then
+	if [ "ed" = "$EASYRSA_ALGO" ]; then
+		algo_opts=" -newkey $EASYRSA_CURVE "
+	else
 		algo_opts=" -newkey $EASYRSA_ALGO:$EASYRSA_ALGO_PARAMS "
 	fi
 	easyrsa_openssl req -utf8 -new $algo_opts \


### PR DESCRIPTION
When Edwards curves are currently specified, they will be used for the
signature algorithm, but the actual public/private keypair will fall
back to defaults (RSA2048), which is likely not what the user intends.

This commit modifies the code so that requesting Edwards curves will
result in their use for the Public Key Algorithm (new behavior) in
addition to the Signature Algorithm (current behavior)

Ref issue: #350 

Examples of fixed and current (broken) behavior given in the commit 
message.