### PR TITLE
Function set_pass() now returns 0 on success in batch-mode

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1486,7 +1486,8 @@ error messages."
 Failed to change the private key passphrase. See above for error messages."
 
 	notice "Key passphrase successfully changed"
-	
+
+	return 0
 } # => set_pass()
 
 # update-db backend


### PR DESCRIPTION
If changing passwords in batch-mode, the commands set-rsa-pass and
set-ec-pass allways returned with an exit code != 0 on success.

The origin for this is the implementation of the function notice() which
allway returns an return-code != 0 if called in batch-mode.

This patch fixes the bug by adding a return 0 at the end of set_pass(),
because this is the way this behaviour is fixed in other functions. I
will provide an additional pull-request to improve the functions
notice() and warn().