### PR TITLE
Functions notice() and warn() return with success in batch-mode now

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -262,7 +262,7 @@ Deprecated features:
 
 # Wrapper around printf - clobber print since it's not POSIX anyway
 # shellcheck disable=SC1117
-print() { printf "%s\n" "$*"; }
+print() { printf "%s\n" "$*" || exit 1; }
 
 # Exit fatally with a message to stderr
 # present even with EASYRSA_BATCH as these are fatal problems
@@ -279,6 +279,8 @@ warn() {
 	[ ! "$EASYRSA_BATCH" ] && \
 		print "
 $1" 1>&2
+
+	return 0
 } # => warn()
 
 # informational notices to stdout
@@ -286,6 +288,8 @@ notice() {
 	[ ! "$EASYRSA_BATCH" ] && \
 		print "
 $1"
+
+	return 0
 } # => notice()
 
 # yes/no case-insensitive match (operates on stdin pipe)


### PR DESCRIPTION
The functions notice() and warn() allways exited with an return-code !=
0 if called in batch-mode, which can cause unexpected behavior in the
calling code.

Example:
If easyrsa is running in batch-mode and notice() is called as last
function in another function, the outer function will also return with
an error in spite of being successful. This happened e.g. in easy-rsa
V3.0.8 at the end of the function set_pass().