### PR TITLE
Fix: build_ca() always makes non-encrypted ED private keys

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -666,7 +666,13 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	crypto_opts=""
 	if [ ! $nopass ]; then
 		crypto_opts="$crypto"
-		[ -z "$EASYRSA_PASSOUT" ] && crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
+		if [ -z "$EASYRSA_PASSOUT" ]; then
+		    if [ "ed" = "$EASYRSA_ALGO" ]; then
+                crypto_opts="$crypto_opts -pass file:$out_key_pass_tmp"
+            else
+                crypto_opts="$crypto_opts -passin file:$out_key_pass_tmp"
+            fi
+        fi
 	fi
 	if [ "$EASYRSA_ALGO" = "rsa" ]; then
 		#shellcheck disable=SC2086
@@ -679,10 +685,10 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			die "Failed create CA private key"
 	elif [ "ed" = "$EASYRSA_ALGO" ]; then
 		if [ "ed25519" = "$EASYRSA_CURVE" ]; then
-			"$EASYRSA_OPENSSL" genpkey -algorithm ED25519  -out $out_key_tmp || \
+			"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
 			die "Failed create CA private key"
 		elif [ "ed448" = "$EASYRSA_CURVE" ]; then
-			"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp || \
+			"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
 			die "Failed create CA private key"
 		fi
 	fi


### PR DESCRIPTION
This resolves a bug where build_ca ignores the nopass flag and always makes non-encrypted private keys when ALGO is "ed".
Also solves build_ca handling of EASYRSA_PASSOUT argument when generating private keys with ALGO set to "ed".