### PR TITLE
Fix: build_ca() fails for rsa keys

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -670,7 +670,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		    if [ "ed" = "$EASYRSA_ALGO" ]; then
                 crypto_opts="$crypto_opts -pass file:$out_key_pass_tmp"
             else
-                crypto_opts="$crypto_opts -passin file:$out_key_pass_tmp"
+                crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
             fi
         fi
 	fi


### PR DESCRIPTION
This fixes an argument error I made in commit 1e98ba808c9c90629595827773a66b59f8c9b927, sorry I have not tested RSA keys as I only use ED.
The argument is -passout for all openssl versions (tested on LibreSSL 2.8.3 and OpenSSL 1.1.1d).

Fixes #403
Fixes #395