### PR TITLE
supporting nopass option for export-p12

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1414,6 +1414,9 @@ Missing key expected at: $key_in"
 		else
 			pkcs_opts="$pkcs_opts -nokeys"
 		fi
+		if [ -z $want_pass ]; then
+			pkcs_opts="$pkcs_opts -password pass: "
+		fi
 
 		# export the p12:
 		# shellcheck disable=SC2086


### PR DESCRIPTION
usage:
  ./easyrsa export-p12 EntityName nopass

fix #265 