### PR TITLE
EasyRSA-Readme.md: Avoid angle brackets mangling.

### DIFF
--- a/doc/EasyRSA-Readme.md
+++ b/doc/EasyRSA-Readme.md
@@ -192,7 +192,9 @@ Using Easy-RSA as a CA
   * server - A TLS server, suitable for a VPN or web server
   * ca - A intermediate CA, used when chaining multiple CAs together
 
-    ./easyrsa sign-req <type> nameOfRequest
+```
+./easyrsa sign-req <type> nameOfRequest
+```
 
   Additional types of certs may be defined by local sites as needed; see the
   advanced documentation for details.


### PR DESCRIPTION
GitHub treats indented code block differently than backtick code blocks. With indented blocks, HTML-tag-like tokens are removed for display, while with backtick code blocks HTML-tag-like tokens get escaped properly. You can see the error on [0]. A wrong example command is displayed. Read-the-docs even removes the whole line[1].

[0] https://github.com/OpenVPN/easy-rsa/blob/master/doc/EasyRSA-Readme.md#signing-a-request
[1] https://easy-rsa.readthedocs.io/en/latest/#using-easy-rsa-as-a-ca