### PR TITLE
Added improved support for CA stored in PKCS#11 based token (RFC 7512 URIs). 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,10 +13,29 @@ matrix:
         - shellcheck --version
         - bash -c 'export SHELLCHECK_OPTS="-S warning -e SC2006"; shopt -s globstar; shellcheck **/*.sh easyrsa3/easyrsa'
         - sh op_test.sh -vv
-
+    - os: linux
+      dist: bionic
+      env:
+        - PATH=/usr/bin:/bin:./:/usr/local/bin
+        - PKCS11_ENGINE=/usr/lib/x86_64-linux-gnu/engines-1.1/libpkcs11.so
+        - PKCS11_MODULE_PATH=/usr/lib/softhsm/libsofthsm2.so
+        - PKCS11_PIN=1234
+        - PKCS11_LABEL=my-test-token
+        - TEST_PKCS11=1       # Triggers op_test.sh to pass the pkcs11 parameter to build-ca
+      before_install:
+        # opensc to get pkcs11-tool
+        - sudo apt-get install -y opensc softhsm2 libengine-pkcs11-openssl1.1
+        - sudo mkdir -p /var/lib/softhsm/tokens
+        - sudo softhsm2-util --init-token --free --label test-token --so-pin 123456 --pin 1234
+      script:
+        - export PKCS11_SLOT=`sudo softhsm2-util --show-slots | grep ^Slot | head -n 1 | cut -d ' ' -f 2`
+        - openssl version
+        - shellcheck --version
+        - bash -c 'export SHELLCHECK_OPTS="-S warning -e SC2006"; shopt -s globstar; shellcheck **/*.sh easyrsa3/easyrsa'
+        - sudo sh op_test.orig -vv
+        
     - os: osx
       osx_image: xcode10.1
       script:
         - openssl version
         - sh op_test.sh -vv
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - sudo mkdir -p /var/lib/softhsm/tokens
         - sudo softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234
       script:
-        - export PKCS11_TOKEN_URI="`sudo p11tool --list-tokens|grep -e "URL.*SoftHSM.*"| sed 's/^.*URL: //'`;"
+        - export PKCS11_TOKEN_URI=$(sudo p11tool --list-tokens|grep -e 'URL.*SoftHSM.*'|awk  '{print $2 ";"}')
         - openssl version
         - shellcheck --version
         - bash -c 'export SHELLCHECK_OPTS="-S warning -e SC2006"; shopt -s globstar; shellcheck **/*.sh easyrsa3/easyrsa'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
         - sudo mkdir -p /var/lib/softhsm/tokens
         - sudo softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234
       script:
-        - export PKCS11_TOKEN_URI=$(sudo p11tool --list-tokens|grep -e 'URL.*SoftHSM.*'|awk  '{print $2 ";"}')
+        - export PKCS11_TOKEN_URI=$(sudo p11tool --list-tokens|grep -e 'URL.*SoftHSM.*'|awk  '{print $2}')
         - openssl version
         - shellcheck --version
         - bash -c 'export SHELLCHECK_OPTS="-S warning -e SC2006"; shopt -s globstar; shellcheck **/*.sh easyrsa3/easyrsa'

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,21 +19,22 @@ matrix:
         - PATH=/usr/bin:/bin:./:/usr/local/bin
         - PKCS11_ENGINE=/usr/lib/x86_64-linux-gnu/engines-1.1/libpkcs11.so
         - PKCS11_MODULE_PATH=/usr/lib/softhsm/libsofthsm2.so
+        - PKCS11_SLOT=01
         - PKCS11_PIN=1234
-        - PKCS11_LABEL=my-test-token
+        - PKCS11_LABEL=test-CA-key
         - TEST_PKCS11=1       # Triggers op_test.sh to pass the pkcs11 parameter to build-ca
       before_install:
         # opensc to get pkcs11-tool
-        - sudo apt-get install -y opensc softhsm2 libengine-pkcs11-openssl1.1
+        - sudo apt-get install -y opensc softhsm2 libengine-pkcs11-openssl1.1 p11tool
         - sudo mkdir -p /var/lib/softhsm/tokens
-        - sudo softhsm2-util --init-token --free --label test-token --so-pin 123456 --pin 1234
+        - sudo softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234
       script:
-        - export PKCS11_SLOT=`sudo softhsm2-util --show-slots | grep ^Slot | head -n 1 | cut -d ' ' -f 2`
+        - export PKCS11_TOKEN_URI="`sudo p11tool --list-tokens|grep -e "URL.*SoftHSM.*"| sed 's/^.*URL: //'`;"
         - openssl version
         - shellcheck --version
         - bash -c 'export SHELLCHECK_OPTS="-S warning -e SC2006"; shopt -s globstar; shellcheck **/*.sh easyrsa3/easyrsa'
         - sudo sh op_test.orig -vv
-        
+
     - os: osx
       osx_image: xcode10.1
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ matrix:
         - TEST_PKCS11=1       # Triggers op_test.sh to pass the pkcs11 parameter to build-ca
       before_install:
         # opensc to get pkcs11-tool
-        - sudo apt-get install -y opensc softhsm2 libengine-pkcs11-openssl1.1 p11tool
+        - sudo apt-get install -y opensc softhsm2 libengine-pkcs11-openssl1.1 gnutls-bin
         - sudo mkdir -p /var/lib/softhsm/tokens
         - sudo softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ matrix:
         - PATH=/usr/bin:/bin:./:/usr/local/bin
         - PKCS11_ENGINE=/usr/lib/x86_64-linux-gnu/engines-1.1/libpkcs11.so
         - PKCS11_MODULE_PATH=/usr/lib/softhsm/libsofthsm2.so
-        - PKCS11_SLOT=01
+        - PKCS11_KEY_ID=01
         - PKCS11_PIN=1234
-        - PKCS11_LABEL=test-CA-key
+        - PKCS11_KEY_LABEL=test-CA-key
         - TEST_PKCS11=1       # Triggers op_test.sh to pass the pkcs11 parameter to build-ca
       before_install:
         # opensc to get pkcs11-tool

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -73,13 +73,16 @@ Nitrokey HSM - Smartcard HSM
  The [SmartCard-HSM](https://www.smartcard-hsm.com/) is a lightweight hardware security module in a smart card form factor.
  The [Nitrokey HSM](https://www.nitrokey.com/#comparison) is a lightweight hardware security module in a USB key form factor containing the SmartCard-HSM. The [SmartCard-HSM](https://www.smartcard-hsm.com/#comparison) is available as USB key, ID-1 card with contact/contactless interface, as ID-000 plug-in and MicroSD card. Both are 100% compatible and provide a remote-manageable secure key store for RSA and ECC keys.
 (Adapted from [OpenSC Wiki](https://github.com/OpenSC/OpenSC/wiki/SmartCardHSM)).
+
 0. Initialize the token. Choose one option:
     - Simple initialization: (No DKEK shares, meaning no possibility to export a backup)
+
     ```sh
     #Initialize the token
     sc-hsm-tool --initialize
     ```
     - Initialization with DKEK share(s): (Enable to export encrypted backup --> more info)
+
     ```sh
     # Generate DKEK share
     sc-hsm-tool --create-dkek-share dkek-share-1.pbe
@@ -90,7 +93,8 @@ Nitrokey HSM - Smartcard HSM
     ```
 1. Suggested settings:
 Set `PKCS11_TOKEN_URI` according to your device serial or select it from the list during execution; choose fresh `PKCS11_KEY_LABEL` and `PKCS11_KEY_ID` for key generation or set them according to your existing keys.
-```sh
+
+  ```sh
 set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
 set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=www.CardContact.de;serial=DENK0000000;token=SmartCard-HSM%20%28UserPIN%29%00%00%00%00%00%00%00%00%00"
 set_var PKCS11_KEY_LABEL	"test-CA-key"
@@ -102,13 +106,14 @@ set_var PKCS11_KEY_ID "123456"
 
 
 2. Build the CA
-```sh
+
+  ```sh
 easyrsa build-ca pkcs11
 ```
 
 Nitrokey Pro
 ------------
-[Nitrokey Pro](https://www.nitrokey.com/#comparison)is an open-source USB key used to enable the secure encryption and signing of data. Among other features, it provides two emulated PKCS15 card, one using OpenPGP and one Using S/MIME. It can store 3 keys (more specifically, one identity, 3 subkeys).
+[Nitrokey Pro](https://www.nitrokey.com/#comparison) is an open-source USB key used to enable the secure encryption and signing of data. Among other features, it provides two emulated PKCS15 card, one using OpenPGP and one Using S/MIME. It can store 3 keys (more specifically, one identity, 3 subkeys).
 
 0. Initialize the token.  
 We suggest to [initialize the token](https://www.nitrokey.com/documentation/installation#p:nitrokey-pro) and [generate your keys](https://www.nitrokey.com/documentation/openpgp-email-encryption) following the respective manufacturer guides.
@@ -121,7 +126,8 @@ Nitrokey Pro shows up as 2 different slots:
 Select `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_KEY_LABEL`.
 
   Set `PKCS11_TOKEN_URI` to the second one (or choose it interactively); `PKCS11_KEY_ID` should not be set to `01`.
-```sh
+
+  ```sh
 set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
 set_var PKCS11_TOKEN_URI "pkcs11:model=PKCS%2315%20emulated;manufacturer=ZeitControl;serial=123456789123;token=OpenPGP%20card%20%28User%20PIN%20%28sig%29%29%00%00%00;"
 set_var PKCS11_KEY_LABEL "Signature key"
@@ -132,7 +138,8 @@ set_var PKCS11_KEY_ID "01"
 ```
 
 2. Build the CA
-```sh
+
+  ```sh
 easyrsa build-ca pkcs11
 ```
 
@@ -142,7 +149,8 @@ SoftHSM2
 [SoftHSM](https://www.opendnssec.org/softhsm/) is an implementation of a cryptographic store accessible through a PKCS #11 interface. You can use it to explore PKCS #11 without having a Hardware Security Module. It is being developed as a part of the OpenDNSSEC project. SoftHSM uses Botan for its cryptographic operations. (Adapted from [OpenDNSSEC wiki](https://www.opendnssec.org/softhsm/))
 
 0. Initialize a token
-```sh
+
+  ```sh
 softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234
 ```
   **Important:** Verify your user has sufficient permissions on `/var/lib/softhsm/tokens/`.
@@ -161,7 +169,8 @@ set_var PKCS11_KEY_LABEL "test-CA-key"
 ```
 
 2. Build the CA
-```sh
+
+  ```sh
 easyrsa build-ca pkcs11
 ```
 
@@ -183,7 +192,8 @@ Other slots requiring PIN should be valid, too. Nonetheless, take into account n
 
 1. Required settings:  
 Use `opensc-pkcs11.so`, select your device `PKCS11_TOKEN_URI`, do not change `PKCS11_KEY_LABEL` and `PKCS11_KEY_ID` unless you are using a different key.
-```sh
+
+  ```sh
 set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
 set_var PKCS11_KEY_LABEL	"SIGN"
 set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=piv_II;serial=0123456789abcdef;token=testkey"
@@ -194,7 +204,8 @@ set_var PKCS11_KEY_ID "02"
 ```
 
 2. Build CA
-```sh
+
+  ```sh
 easyrsa build-ca pkcs11
 ```
 Note: Yubikeys might require multiple PIN entry during CA building and signing operations, even when `PKCS11_PIN` var is set.

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -10,21 +10,27 @@ To build the CA on a token use the `pkcs11` parameter when calling `build-ca`.  
 
 Environment Variables
 
-* `PKCS11_MODULE_PATH` - The pkcs module to load
-* `PKCS11_SLOT` - The slot to load objects from
-* `PKCS11_PINPAD` -  Boolean, set to `true` to enable pin entry directly from PINPAD reader.
-* `PKCS11_PIN` - *INSECURE* useful for testing and automatically logs the user in
-* `PKCS11_LABEL` - The label of the key to use.  (Not de-duplicated!!)
-* `PKCS11_EXTRA_OPTIONS` - Extra options for `pkcs11-tool` (i.e. `--id` for Yubikeys). *Use with caution!*
-* `PKCS11_REQUIRE_SOPIN` - Boolean, set to `true` for devices which require SO PIN login to generate keypairs (i.e. Yubikeys)
-*  `PKCS11_SO_PIN` - *HIGLY INSECURE* useful for testing,  automatically logs the SO user in.
+* `PKCS11_MODULE_PATH` (Required) - The pkcs module to load.
+* `PKCS11_TOKEN_URI` (Required) - The PKCS11 token URI to load objects from  (according to [RFC 7512](https://tools.ietf.org/html/rfc7512)).
 
-Once you've created your CA, `./pki/private/ca.key` will not be a normal PEM key file.  Instead it will look
-like the following:
+  **Important**: terminate it with a `;`.
+  Check below examples for various commercial tokens, otherwise verify its value by checking the output of `p11tool --list-tokens` command (you might need to install gnutls-bin package).
+* `PKCS11_SLOT` (Required) - The Slot ID (in hex) to be used for key storage and certificate signing.
+
+  **Important**: Format is a sequence of an even number of hex character, without leading `0x`. (i.e. Valid examples: `01`,`012A`,`123A`; Invalid examples: `1`,`0x1`, `123`)
+* `PKCS11_PINPAD` (Optional) -  Boolean, set to `true` to enable pin entry directly from PINPAD reader.
+* `PKCS11_LABEL` - The label of the key to use.  (Not de-duplicated!!)
+* `PKCS11_EXTRA_OPTIONS` (Optional) - *Use with caution!* Extra options for `pkcs11-tool` (might be useful for non-standard implementation).
+* `PKCS11_REQUIRE_SOPIN` (Optional) - Boolean, set to `true` for devices which require SO PIN login to generate keypairs (i.e. Yubikeys)
+* `PKCS11_PIN` (Test/Automation only - *INSECURE*)-  useful for testing and automatically logs the user in
+*  `PKCS11_SO_PIN` (Test/Automation only - *HIGHLY INSECURE*) -  useful for testing,  automatically logs the SO user in.
+
+Once you've created your CA, `./pki/private/ca.key` will not be a normal PEM key file.  Instead it will look like the following:
 
 ```bash
 # EasyRSA variables pointing to the private key object
 PKCS11_MODULE_PATH=/usr/lib/libsofthsm2.so
+PKCS11_TOKEN_URI="pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=bcc3ef4e731fb246;token=test-token;"
 PKCS11_SLOT=0x23aa5c05
 PKCS11_LABEL=Fancy-SoftHSM-CA
 ```
@@ -33,14 +39,12 @@ If desired you can also include the `PKCS11_PIN` variable.  Note: This is a big 
 
 Now all operations for that CA operate on the token and the only extra interaction will be entering the token PIN.
 
-Smartcard HSM - Nitrokey HSM
+Nitrokey HSM - Smartcard HSM
 ----------------------------
-0. Required settings:
-```
-set_var PKCS11_SLOT	"0x0"
-set_var PKCS11_MODULE_PATH "path/to/opensc-pkcs11.so"
-```
-1. Initialize the token. Choose one option:
+ The [SmartCard-HSM](https://www.smartcard-hsm.com/) is a lightweight hardware security module in a smart card form factor.
+ The [Nitrokey HSM](https://www.nitrokey.com/#comparison) is a lightweight hardware security module in a USB key form factor containing the SmartCard-HSM. The [SmartCard-HSM](https://www.smartcard-hsm.com/#comparison) is available as USB key, ID-1 card with contact/contactless interface, as ID-000 plug-in and MicroSD card. Both are 100% compatible and provide a remote-manageable secure key store for RSA and ECC keys.
+(Adapted from [OpenSC Wiki](https://github.com/OpenSC/OpenSC/wiki/SmartCardHSM)).
+0. Initialize the token. Choose one option:
     - Simple initialization: (No DKEK shares, meaning no possibility to export a backup)
     ```bash
     #Initialize the token
@@ -55,6 +59,47 @@ set_var PKCS11_MODULE_PATH "path/to/opensc-pkcs11.so"
     # Import your DKEK share
     sc-hsm-tool --import-dkek-share dkek-share-1.pbe
     ```
+1. Required settings:
+Set `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_LABEL` and `PKCS11_SLOT`.
+```bash
+set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
+set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=www.CardContact.de;serial=DENK0000000;token=SmartCard-HSM%20%28UserPIN%29%00%00%00%00%00%00%00%00%00;"
+set_var PKCS11_LABEL	"test-CA-key"
+set_var PKCS11_SLOT "123456"
+# Only for testing & automation purpose.
+# Never write your production PIN to file.
+#set_var PKCS11_PIN 123456
+```
+
+2. Build the CA
+```bash
+easyrsa build-ca pkcs11
+```
+
+Nitrokey Pro
+------------
+[Nitrokey Pro](https://www.nitrokey.com/#comparison)is an open-source USB key used to enable the secure encryption and signing of data. Among other features, it provides two emulated PKCS15 card, one using OpenPGP and one Using S/MIME. It can store 3 keys (more specifically, one identity, 3 subkeys).
+
+0. Initialize the token.
+IMPORTANT: CA Keypair generation using `pkcs11-tool` on Nitrokey Pro only works if no keys are present on the device. You might need to factory reset it.
+There is possibility to add a feature to EasyRSA in the future to enable signing CA certificate using existing keys from PKCS11 token (without keypair generation).
+
+1. Required settings:
+Set `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_LABEL`.
+
+  `PKCS11_SLOT` should not be changed.
+```bash
+set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
+set_var PKCS11_TOKEN_URI "pkcs11:model=PKCS%2315%20emulated;manufacturer=ZeitControl;serial=123456789123;token=OpenPGP%20card%20%28User%20PIN%20%28sig%29%29%00%00%00;"
+set_var PKCS11_LABEL "test-CA-key"
+set_var PKCS11_SLOT "01"
+set_var PKCS11_REQUIRE_SOPIN true
+# Only for testing & automation purpose.
+# Never write your production PIN to file.
+#set_var PKCS11_PIN 123456
+#set_var PKCS11_SO_PIN "12345678"
+```
+
 2. Build the CA
 ```bash
 easyrsa build-ca pkcs11
@@ -63,40 +108,56 @@ easyrsa build-ca pkcs11
 SoftHSM2
 --------
 
-Initialize a token
+[SoftHSM](https://www.opendnssec.org/softhsm/) is an implementation of a cryptographic store accessible through a PKCS #11 interface. You can use it to explore PKCS #11 without having a Hardware Security Module. It is being developed as a part of the OpenDNSSEC project. SoftHSM uses Botan for its cryptographic operations. (Adapted from [OpenDNSSEC wiki](https://www.opendnssec.org/softhsm/))
 
-`softhsm2-util --init-token --free --label test-token --so-pin 123456 --pin 1234`
+0. Initialize a token
+`softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234`
 
-Build the CA
-
-`easyrsa build-ca pkcs11`
-
-You'll be asked for the slot which isn't going to be the slot number used when initializing the token, instead it's a longer 32 bit hexidecimal number like `0x23aa5c05` as you see in the example above.
-
-YubiKey (4, 5)
------------
-The following guide has been adapted from [Yubico Dev Pages](https://developers.yubico.com/yubico-piv-tool/YKCS11/Supported_applications/pkcs11tool.html). It was tested on Yubikey 5 NFC, but should work on other models as well.
-
-Following Yubikey's [PIV Certificate slots description](https://developers.yubico.com/PIV/Introduction/Certificate_slots.html), I would suggest using slot `9c` (id: `2`, label: `Private key for Digital Signature`) to store your CA keys.
-
-Other slots requiring PIN should be valid, too. Nonetheless, take into account necessary id and label changes. Object labels for Yubikey's slots are fixed, so check [Key Alias per Slot and Object Type](https://developers.yubico.com/yubico-piv-tool/YKCS11/Functions_and_values.html) section and change it accordingly.
-
-
-
-0. Required settings:
+1. Required settings:
+Set `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_LABEL` and `PKCS11_SLOT`.
 ```bash
-set_var PKCS11_SLOT	"0x0"
-set_var PKCS11_MODULE_PATH	"path/to/libykcs11.so"
-set_var PKCS11_LABEL	"Private key for Digital Signature"
-set_var PKCS11_EXTRA_OPTIONS	"--id 2"
-set_var PKCS11_REQUIRE_SOPIN true
-# WARNING: Following settings are for test purpose only.
-# Writing PIN and SO PIN to config is highly discouraged for security reasons.
-set_var PKCS11_SO_PIN "010203040506070801020304050607080102030405060708"
-set_var PKCS11_PIN 123456
+set_var PKCS11_MODULE_PATH "/usr/lib/softhsm/libsofthsm2.so"
+set_var PKCS11_TOKEN_URI "pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=f609a0b66832b468;token=my-test-token;"
+set_var PKCS11_SLOT "01"
+set_var PKCS11_LABEL "test-CA-key"
+# Only for testing & automation purpose.
+# Never write your production PIN to file.
+#set_var PKCS11_PIN "1234"
 ```
 
-1. Initialize the key, changing PIN and SO PIN.
+2. Build the CA
+```bash
+easyrsa build-ca pkcs11
+```
+
+
+YubiKey
+-----------
+[Yubikey](https://www.yubico.com/products/) is a Hardware authentication device manufactured by [Yubico](https://www.yubico.com/).
+The following guide has been adapted from [Yubico Dev Pages](https://developers.yubico.com/yubico-piv-tool/YKCS11/Supported_applications/pkcs11tool.html). It was tested on Yubikey 5 NFC, but should work on other models as well.
+
+Following Yubikey's [PIV Certificate slots description](https://developers.yubico.com/PIV/Introduction/Certificate_slots.html), I would suggest using slot `9c` (`PKCS11_SLOT`: `02`, `PKCS11_LABEL`: `Private key for Digital Signature`) to store your CA keys.
+
+I could not find a `PKCS11_TOKEN_URI` which is working apart from an empty one (`"pkcs11:"`), so please be do not connect other PKCS11 tokens during EasyRSA operation.
+
+Other slots requiring PIN should be valid, too. Nonetheless, take into account necessary URI and label changes. Object labels for Yubikey's slots are fixed, so check [Key Alias per Slot and Object Type](https://developers.yubico.com/yubico-piv-tool/YKCS11/Functions_and_values.html) section and change it accordingly.
+
+
+
+0. Initialize the key, changing PIN and SO PIN.
+
+1. Required settings:
+```bash
+set_var PKCS11_MODULE_PATH	"path/to/libykcs11.so"
+set_var PKCS11_LABEL	"Private key for Digital Signature"
+set_var PKCS11_TOKEN_URI	"pkcs11:"
+set_var PKCS11_SLOT "02"
+set_var PKCS11_REQUIRE_SOPIN true
+# Only for testing & automation purpose.
+# Never write your production PIN to file.
+#set_var PKCS11_SO_PIN "010203040506070801020304050607080102030405060708"
+#set_var PKCS11_PIN 123456
+```
 
 2. Build CA
 ```bash
@@ -121,7 +182,7 @@ TODO
 * [x] Renew a certificate
 * [x] Get PKCS11 module information from key file (if configured)
 * [x] Add SO login and extra options support for different implementations (i.e. Yubikey)
-* [ ] Test support with Nitrokeys
+* [x] Test support with Nitrokeys
 * [ ] If a key is being created on a device, ensure the label isn't already used by the same type of key
 * [ ] Add check to ensure openssl pkcs11 engine is installed and library able to be found.
 * [ ] Create command to extract a certificate from a key and bootstrap a new CA (maybe ask the user if that is what they want if the slot has everything that is needed)

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -13,11 +13,14 @@ arguments.
 
 Environment Variables
 
-* `PKCS11_MODULE` - The pkcs module to load
+* `PKCS11_MODULE_PATH` - The pkcs module to load
 * `PKCS11_SLOT` - The slot to load objects from
 * `PKCS11_PINPAD` -  Boolean, set to `true` to enable pin entry directly from PINPAD reader.
 * `PKCS11_PIN` - *INSECURE* useful for testing and automatically logs the user in
 * `PKCS11_LABEL` - The label of the key to use.  (Not de-duplicated!!)
+* `PKCS11_EXTRA_OPTIONS` - Extra options for `pkcs11-tool` (i.e. `--id` for Yubikeys). *Use with caution!*
+* `PKCS11_REQUIRE_SOPIN` - Boolean, set to `true` for devices which require SO PIN login to generate keypairs (i.e. Yubikeys)
+*  `PKCS11_SOPIN` - *HIGLY INSECURE* useful for testing,  automatically logs the SO user in.
 
 Once you've created your CA, `./pki/private/ca.key` will not be a normal PEM key file.  Instead it will look
 like the following:
@@ -38,6 +41,7 @@ Smartcard HSM - Nitrokey HSM
 0. Required settings:
 ```
 set_var PKCS11_SLOT	"0x0"
+set_var PKCS11_MODULE_PATH "path/to/opensc-pkcs11.so"
 ```
 1. Initialize the token. Choose one option:
     - Simple initialization: (No DKEK shares, meaning no possibility to export a backup)
@@ -72,10 +76,36 @@ Build the CA
 
 You'll be asked for the slot which isn't going to be the slot number used when initializing the token, instead it's a longer 32 bit hexidecimal number like `0x23aa5c05` as you see in the example above.
 
-YubiKey
+YubiKey (4, 5)
 -----------
+The following guide has been adapted from [Yubico Dev Pages](https://developers.yubico.com/yubico-piv-tool/YKCS11/Supported_applications/pkcs11tool.html). It was tested on Yubikey 5 NFC, but should work on other models as well.
 
-TODO: Add instructions for hosting a CA on the YubiKey
+Following Yubikey's [PIV Certificate slots description](https://developers.yubico.com/PIV/Introduction/Certificate_slots.html), I would suggest using slot `9c` (id: `2`, label: `Private key for Digital Signature`) to store your CA keys.
+
+Other slots requiring PIN should be valid, too. Nonetheless, take into account necessary id and label changes. Object labels for Yubikey's slots are fixed, so check [Key Alias per Slot and Object Type](https://developers.yubico.com/yubico-piv-tool/YKCS11/Functions_and_values.html) section and change it accordingly.
+
+
+
+0. Required settings:
+```bash
+set_var PKCS11_SLOT	"0x0"
+set_var PKCS11_MODULE_PATH	"path/to/libykcs11.so"
+set_var PKCS11_LABEL	"Private key for Digital Signature"
+set_var PKCS11_EXTRA_OPTIONS	"--id 2"
+set_var PKCS11_REQUIRE_SOPIN true
+# WARNING: Following settings are for test purpose only.
+# Writing PIN and SO PIN to config is highly discouraged for security reasons.
+set_var PKCS11_SOPIN "010203040506070801020304050607080102030405060708"
+set_var PKCS11_PIN 123456
+```
+
+1. Initialize the key, changing PIN and SO PIN.
+
+2. Build CA
+```bash
+easyrsa build-ca pkcs11
+```
+Note: Yubikeys might require a second PIN entry during signing operations, even when `PKCS11_PIN` var is set.
 
 Notes
 -----
@@ -93,7 +123,8 @@ TODO
 * [x] Revoke a certificate
 * [x] Renew a certificate
 * [x] Get PKCS11 module information from key file (if configured)
-* [ ] Add extra `pkcs11-tool` arguments to support different implementation (i.i Yubikeys' need for `--login-type so`)
+* [x] Add SO login and extra options support for different implementations (i.e. Yubikey)
+* [ ] Test support with Nitrokeys
 * [ ] If a key is being created on a device, ensure the label isn't already used by the same type of key
 * [ ] Add check to ensure openssl pkcs11 engine is installed and library able to be found.
 * [ ] Create command to extract a certificate from a key and bootstrap a new CA (maybe ask the user if that is what they want if the slot has everything that is needed)

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -1,0 +1,99 @@
+PKCS#11 support for EasyRSA
+============================
+
+OpenSSL only ever operates on one key at time for any given command.  Leveraging this fact we can
+provide support for private keys stored in PKCS#11 tokens with a relatively simple configuration.
+In order to use this capability, you must install the OpenSSL PKCS#11 engine for you operating system.  
+
+This version of the capability does not persist your PIN number automatically.  If you would like to do
+this and are aware of the security implications of doing so, see the end of this document.
+
+To build the CA on a token use the `pkcs11` parameter when calling `build-ca`.  If desired you can also use the `subca` command.  The following environment variables can be used and they have equivalant command line
+arguments.
+
+Environment Variables
+
+* `PKCS11_MODULE` - The pkcs module to load
+* `PKCS11_SLOT` - The slot to load objects from
+* `PKCS11_PINPAD` -  Boolean, set to `true` to enable pin entry directly from PINPAD reader.
+* `PKCS11_PIN` - *INSECURE* useful for testing and automatically logs the user in
+* `PKCS11_LABEL` - The label of the key to use.  (Not de-duplicated!!)
+
+Once you've created your CA, `./pki/private/ca.key` will not be a normal PEM key file.  Instead it will look
+like the following:
+
+```bash
+# EasyRSA variables pointing to the private key object
+PKCS11_MODULE_PATH=/usr/lib/libsofthsm2.so
+PKCS11_SLOT=0x23aa5c05
+PKCS11_LABEL=Fancy-SoftHSM-CA
+```
+
+If desired you can also include the `PKCS11_PIN` variable.  Note: This is a big risk for sensitive keys but very useful for automation.
+
+Now all operations for that CA operate on the token and the only extra interaction will be entering the token PIN.
+
+Smartcard HSM - Nitrokey HSM
+----------------------------
+0. Required settings:
+```
+set_var PKCS11_SLOT	"0x0"
+```
+1. Initialize the token. Choose one option:
+    - Simple initialization: (No DKEK shares, meaning no possibility to export a backup)
+    ```bash
+    #Initialize the token
+    sc-hsm-tool --initialize
+    ```
+    - Initialization with DKEK share(s): (Enable to export encrypted backup --> more info)
+    ```bash
+    # Generate DKEK share
+    sc-hsm-tool --create-dkek-share dkek-share-1.pbe
+    # Initialize the token with 1 DKEK share
+    sc-hsm-tool --initialize --dkek-shares 1
+    # Import your DKEK share
+    sc-hsm-tool --import-dkek-share dkek-share-1.pbe
+    ```
+2. Build the CA
+```bash
+easyrsa build-ca pkcs11
+```
+
+SoftHSM2
+--------
+
+Initialize a token
+
+`softhsm2-util --init-token --free --label test-token --so-pin 123456 --pin 1234`
+
+Build the CA
+
+`easyrsa build-ca pkcs11`
+
+You'll be asked for the slot which isn't going to be the slot number used when initializing the token, instead it's a longer 32 bit hexidecimal number like `0x23aa5c05` as you see in the example above.
+
+YubiKey
+-----------
+
+TODO: Add instructions for hosting a CA on the YubiKey
+
+Notes
+-----
+
+* EasyRSA creates a CA and creation is the perfect time to define everything we need to point to the key on the token
+* OpenSSL should be able to do all key operations on PKCS#11 but not all algorithms will be available with each token.  Good error messages will be important for debugging.
+
+TODO
+----
+
+* [x] Create a self signed CA on a token
+* [x] Create a CA CSR with a key on a token
+* [x] Sign a server certificate
+* [x] Sign a client certificate
+* [x] Revoke a certificate
+* [x] Renew a certificate
+* [x] Get PKCS11 module information from key file (if configured)
+* [ ] Add extra `pkcs11-tool` arguments to support different implementation (i.i Yubikeys' need for `--login-type so`)
+* [ ] If a key is being created on a device, ensure the label isn't already used by the same type of key
+* [ ] Add check to ensure openssl pkcs11 engine is installed and library able to be found.
+* [ ] Create command to extract a certificate from a key and bootstrap a new CA (maybe ask the user if that is what they want if the slot has everything that is needed)

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -186,8 +186,7 @@ Use `opensc-pkcs11.so`, select your device `PKCS11_TOKEN_URI`, do not change `PK
 ```sh
 set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
 set_var PKCS11_KEY_LABEL	"SIGN"
-set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=piv_II;serial=0123456789abcdef;token=testkey
-"
+set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=piv_II;serial=0123456789abcdef;token=testkey"
 set_var PKCS11_KEY_ID "02"
 # Only for testing & automation purpose.
 # Never write your production PIN to file.
@@ -198,7 +197,8 @@ set_var PKCS11_KEY_ID "02"
 ```sh
 easyrsa build-ca pkcs11
 ```
-Note: Yubikeys might require a second PIN entry during signing operations, even when `PKCS11_PIN` var is set.
+Note: Yubikeys might require multiple PIN entry during CA building and signing operations, even when `PKCS11_PIN` var is set.
+Also, you will get a `PKCS11_KEY_LABEL` mismatch when checking for existing key. Yubikey uses different labels for private and public keys of the same key pair (i.e. `SIGN key` vs `SIGN pubkey`). We could consider solving this checking `PKCS11_KEY_LABEL` against the private keys instead of the public ones, though this would require an extra login (extra pin insertion).
 
 Notes
 -----

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -1,15 +1,12 @@
 PKCS#11 support for EasyRSA
 ============================
 
-OpenSSL only ever operates on one key at time for any given command.  Leveraging this fact we can
-provide support for private keys stored in PKCS#11 tokens with a relatively simple configuration.
+OpenSSL only ever operates on one key at time for any given command. Leveraging this fact we can provide support for private keys stored in PKCS#11 tokens with a relatively simple configuration.
 In order to use this capability, you must install the OpenSSL PKCS#11 engine for you operating system.  
 
-This version of the capability does not persist your PIN number automatically.  If you would like to do
-this and are aware of the security implications of doing so, see the end of this document.
+This version of the capability does not persist your PIN number automatically.  If you would like to do this and are aware of the security implications of doing so, see the end of this document.
 
-To build the CA on a token use the `pkcs11` parameter when calling `build-ca`.  If desired you can also use the `subca` command.  The following environment variables can be used and they have equivalant command line
-arguments.
+To build the CA on a token use the `pkcs11` parameter when calling `build-ca`.  If desired you can also use the `subca` command.  The following environment variables can be used and they have equivalant command line arguments.
 
 Environment Variables
 

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -2,42 +2,71 @@ PKCS#11 support for EasyRSA
 ============================
 
 OpenSSL only ever operates on one key at time for any given command. Leveraging this fact we can provide support for private keys stored in PKCS#11 tokens with a relatively simple configuration.
-In order to use this capability, you must install the OpenSSL PKCS#11 engine for you operating system.  
 
 This version of the capability does not persist your PIN number automatically.  If you would like to do this and are aware of the security implications of doing so, see the end of this document.
 
-To build the CA on a token use the `pkcs11` parameter when calling `build-ca`.  If desired you can also use the `subca` command.  The following environment variables can be used and they have equivalant command line arguments.
+Requirements
+------------
+In order to use this capability, you must install the OpenSSL PKCS#11 engine for you operating system as well as GnuTLS binaries (in particular, `p11tool`).
+On an Ubuntu/Debian machine, you could achieve it running:
+```sh
+sudo apt-get install gnutls-bin libengine-pkcs11-openssl1.1
+```
 
-Environment Variables
+
+Configuration
+-------------
+The following environment variables can be used and they have equivalent command line arguments:
 
 * `PKCS11_MODULE_PATH` (Required) - The pkcs module to load.
-* `PKCS11_TOKEN_URI` (Required) - The PKCS11 token URI to load objects from  (according to [RFC 7512](https://tools.ietf.org/html/rfc7512)).
+* `PKCS11_TOKEN_URI` (Required) - The PKCS11 token URI to load objects from  (according to [RFC 7512](https://tools.ietf.org/html/rfc7512)). It is a unique identifier of your token. If not specified, the program will list available ones in the system and prompt you for selection.
 
-  **Important**: terminate it with a `;`.
-  Check below examples for various commercial tokens, otherwise verify its value by checking the output of `p11tool --list-tokens` command (you might need to install gnutls-bin package).
-* `PKCS11_SLOT` (Required) - The Slot ID (in hex) to be used for key storage and certificate signing.
+  Check below examples for various commercial tokens, otherwise verify its value by checking the output of `p11tool --list-tokens` command.
+* `PKCS11_KEY_ID` (Required) - The Key CKA_ID (in hex) to be used for key storage and certificate signing.
 
-  **Important**: Format is a sequence of an even number of hex character, without leading `0x`. (i.e. Valid examples: `01`,`012A`,`123A`; Invalid examples: `1`,`0x1`, `123`)
+  Public/Private keypair share the same CKA_ID.
+When using pre-existing key from a token, you can check the ID value of the corresponding public key by running `pkcs11-tool -O|grep -A4 "Public Key Object"` (or from `p11tool --list-all <your PKCS11_TOKEN_URI here>`, modifying the format to remove all semicolons).
+
+  **Important**: Format is a sequence of an even number of hex characters, without leading `0x`. (i.e. Valid examples: `01`,`012A`,`123A`; Invalid examples: `1`,`0x1`, `123`)
+
+* `PKCS11_KEY_LABEL` - The label of the key to use.  
+This is required for key generation.  
+When using an existing key, the script uses it to check and warns of any label mismatch before proceeding. Depending on token type, it is generally NOT an unique identifier.
 * `PKCS11_PINPAD` (Optional) -  Boolean, set to `true` to enable pin entry directly from PINPAD reader.
-* `PKCS11_LABEL` - The label of the key to use.  (Not de-duplicated!!)
-* `PKCS11_EXTRA_OPTIONS` (Optional) - *Use with caution!* Extra options for `pkcs11-tool` (might be useful for non-standard implementation).
+
+* `PKCS11_PIN` (Test/Automation only - *INSECURE*)-  useful for testing and automatically logs the user in.
+
+The following extra option might be useful for generating keys using `buildca` option on some token which requires Admin/SO PIN (i.e. Yubikey, Nitrokey Pro, etc).  
+**Important:** Please consider that these tokens are usually not a complete HSM solution (and -in some cases- they follow special key-generation procedure). For that reason,  I would instead recommend to first generate the keys following the manufacturer instructions (or specific application).  
+Generated keys could than be selected for usage with easy-RSA using the previous options.
 * `PKCS11_REQUIRE_SOPIN` (Optional) - Boolean, set to `true` for devices which require SO PIN login to generate keypairs (i.e. Yubikeys)
-* `PKCS11_PIN` (Test/Automation only - *INSECURE*)-  useful for testing and automatically logs the user in
 *  `PKCS11_SO_PIN` (Test/Automation only - *HIGHLY INSECURE*) -  useful for testing,  automatically logs the SO user in.
+
+
+Usage
+-----
+To build the CA on a token use the `pkcs11` parameter when calling `build-ca`.  If desired you can also use the `subca` command.
+```sh
+./easyrsa build-ca pkcs11tool
+```
 
 Once you've created your CA, `./pki/private/ca.key` will not be a normal PEM key file.  Instead it will look like the following:
 
-```bash
+```sh
 # EasyRSA variables pointing to the private key object
 PKCS11_MODULE_PATH=/usr/lib/libsofthsm2.so
-PKCS11_TOKEN_URI="pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=bcc3ef4e731fb246;token=test-token;"
-PKCS11_SLOT=0x23aa5c05
-PKCS11_LABEL=Fancy-SoftHSM-CA
+PKCS11_TOKEN_URI="pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=bcc3ef4e731fb246;token=test-token"
+PKCS11_KEY_ID=23aa5c05
+PKCS11_KEY_LABEL=Fancy-SoftHSM-CA
 ```
 
 If desired you can also include the `PKCS11_PIN` variable.  Note: This is a big risk for sensitive keys but very useful for automation.
 
+After building the CA, you can proceed as usual to generate new server/client certificates.
 Now all operations for that CA operate on the token and the only extra interaction will be entering the token PIN.
+
+Specific configurations examples
+================================
 
 Nitrokey HSM - Smartcard HSM
 ----------------------------
@@ -46,12 +75,12 @@ Nitrokey HSM - Smartcard HSM
 (Adapted from [OpenSC Wiki](https://github.com/OpenSC/OpenSC/wiki/SmartCardHSM)).
 0. Initialize the token. Choose one option:
     - Simple initialization: (No DKEK shares, meaning no possibility to export a backup)
-    ```bash
+    ```sh
     #Initialize the token
     sc-hsm-tool --initialize
     ```
     - Initialization with DKEK share(s): (Enable to export encrypted backup --> more info)
-    ```bash
+    ```sh
     # Generate DKEK share
     sc-hsm-tool --create-dkek-share dkek-share-1.pbe
     # Initialize the token with 1 DKEK share
@@ -59,20 +88,21 @@ Nitrokey HSM - Smartcard HSM
     # Import your DKEK share
     sc-hsm-tool --import-dkek-share dkek-share-1.pbe
     ```
-1. Required settings:
-Set `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_LABEL` and `PKCS11_SLOT`.
-```bash
+1. Suggested settings:
+Set `PKCS11_TOKEN_URI` according to your device serial or select it from the list during execution; choose fresh `PKCS11_KEY_LABEL` and `PKCS11_KEY_ID` for key generation or set them according to your existing keys.
+```sh
 set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
-set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=www.CardContact.de;serial=DENK0000000;token=SmartCard-HSM%20%28UserPIN%29%00%00%00%00%00%00%00%00%00;"
-set_var PKCS11_LABEL	"test-CA-key"
-set_var PKCS11_SLOT "123456"
+set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=www.CardContact.de;serial=DENK0000000;token=SmartCard-HSM%20%28UserPIN%29%00%00%00%00%00%00%00%00%00"
+set_var PKCS11_KEY_LABEL	"test-CA-key"
+set_var PKCS11_KEY_ID "123456"
 # Only for testing & automation purpose.
 # Never write your production PIN to file.
 #set_var PKCS11_PIN 123456
 ```
 
+
 2. Build the CA
-```bash
+```sh
 easyrsa build-ca pkcs11
 ```
 
@@ -80,28 +110,29 @@ Nitrokey Pro
 ------------
 [Nitrokey Pro](https://www.nitrokey.com/#comparison)is an open-source USB key used to enable the secure encryption and signing of data. Among other features, it provides two emulated PKCS15 card, one using OpenPGP and one Using S/MIME. It can store 3 keys (more specifically, one identity, 3 subkeys).
 
-0. Initialize the token.
-IMPORTANT: CA Keypair generation using `pkcs11-tool` on Nitrokey Pro only works if no keys are present on the device. You might need to factory reset it.
-There is possibility to add a feature to EasyRSA in the future to enable signing CA certificate using existing keys from PKCS11 token (without keypair generation).
+0. Initialize the token.  
+We suggest to [initialize the token](https://www.nitrokey.com/documentation/installation#p:nitrokey-pro) and [generate your keys](https://www.nitrokey.com/documentation/openpgp-email-encryption) following the respective manufacturer guides.
 
-1. Required settings:
-Set `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_LABEL`.
+1. Suggested settings:  
+Nitrokey Pro shows up as 2 different slots:
+  * The first one labeled `(OpenPGP card (User PIN)`, containing subkeys for Encryption and Authentication (CKA_ID 02 and 03, respectively);
 
-  `PKCS11_SLOT` should not be changed.
-```bash
+  * The second one labeled `(OpenPGP card (User PIN (sig))`, containing the subkey for Signature (CKA_ID=01) we are looking for.  
+Select `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_KEY_LABEL`.
+
+  Set `PKCS11_TOKEN_URI` to the second one (or choose it interactively); `PKCS11_KEY_ID` should not be set to `01`.
+```sh
 set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
 set_var PKCS11_TOKEN_URI "pkcs11:model=PKCS%2315%20emulated;manufacturer=ZeitControl;serial=123456789123;token=OpenPGP%20card%20%28User%20PIN%20%28sig%29%29%00%00%00;"
-set_var PKCS11_LABEL "test-CA-key"
-set_var PKCS11_SLOT "01"
-set_var PKCS11_REQUIRE_SOPIN true
+set_var PKCS11_KEY_LABEL "Signature key"
+set_var PKCS11_KEY_ID "01"
 # Only for testing & automation purpose.
 # Never write your production PIN to file.
 #set_var PKCS11_PIN 123456
-#set_var PKCS11_SO_PIN "12345678"
 ```
 
 2. Build the CA
-```bash
+```sh
 easyrsa build-ca pkcs11
 ```
 
@@ -111,22 +142,26 @@ SoftHSM2
 [SoftHSM](https://www.opendnssec.org/softhsm/) is an implementation of a cryptographic store accessible through a PKCS #11 interface. You can use it to explore PKCS #11 without having a Hardware Security Module. It is being developed as a part of the OpenDNSSEC project. SoftHSM uses Botan for its cryptographic operations. (Adapted from [OpenDNSSEC wiki](https://www.opendnssec.org/softhsm/))
 
 0. Initialize a token
-`softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234`
+```sh
+softhsm2-util --init-token --free --label my-test-token --so-pin 123456 --pin 1234
+```
+  **Important:** Verify your user has sufficient permissions on `/var/lib/softhsm/tokens/`.
 
-1. Required settings:
-Set `PKCS11_TOKEN_URI` according to your device serial, choose `PKCS11_LABEL` and `PKCS11_SLOT`.
-```bash
+1. Required settings:  
+Select `PKCS11_TOKEN_URI` according to your device serial and token name, choose `PKCS11_KEY_LABEL` and `PKCS11_KEY_ID`.
+
+  ```sh
 set_var PKCS11_MODULE_PATH "/usr/lib/softhsm/libsofthsm2.so"
 set_var PKCS11_TOKEN_URI "pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=f609a0b66832b468;token=my-test-token;"
-set_var PKCS11_SLOT "01"
-set_var PKCS11_LABEL "test-CA-key"
+set_var PKCS11_KEY_ID "01"
+set_var PKCS11_KEY_LABEL "test-CA-key"
 # Only for testing & automation purpose.
 # Never write your production PIN to file.
 #set_var PKCS11_PIN "1234"
 ```
 
 2. Build the CA
-```bash
+```sh
 easyrsa build-ca pkcs11
 ```
 
@@ -136,31 +171,31 @@ YubiKey
 [Yubikey](https://www.yubico.com/products/) is a Hardware authentication device manufactured by [Yubico](https://www.yubico.com/).
 The following guide has been adapted from [Yubico Dev Pages](https://developers.yubico.com/yubico-piv-tool/YKCS11/Supported_applications/pkcs11tool.html). It was tested on Yubikey 5 NFC, but should work on other models as well.
 
-Following Yubikey's [PIV Certificate slots description](https://developers.yubico.com/PIV/Introduction/Certificate_slots.html), I would suggest using slot `9c` (`PKCS11_SLOT`: `02`, `PKCS11_LABEL`: `Private key for Digital Signature`) to store your CA keys.
+Following Yubikey's [PIV Certificate slots description](https://developers.yubico.com/PIV/Introduction/Certificate_slots.html), I would suggest using slot `9c` (`PKCS11_KEY_ID`: `02`, `PKCS11_KEY_LABEL`: `Private key for Digital Signature`) to store your CA keys.
 
-I could not find a `PKCS11_TOKEN_URI` which is working apart from an empty one (`"pkcs11:"`), so please be do not connect other PKCS11 tokens during EasyRSA operation.
 
 Other slots requiring PIN should be valid, too. Nonetheless, take into account necessary URI and label changes. Object labels for Yubikey's slots are fixed, so check [Key Alias per Slot and Object Type](https://developers.yubico.com/yubico-piv-tool/YKCS11/Functions_and_values.html) section and change it accordingly.
 
 
 
-0. Initialize the key, changing PIN and SO PIN.
+0. Initialize the key. Use Yubikey Manager to change PIN/SO PIN and to generate the required keys (Digital Signature).
+  **Important:** Possibly a Yubikey bug, but serial in PKCS11 URI appear as 00000000000000 until you generate keys from Yubikey Manager.
 
-1. Required settings:
-```bash
-set_var PKCS11_MODULE_PATH	"path/to/libykcs11.so"
-set_var PKCS11_LABEL	"Private key for Digital Signature"
-set_var PKCS11_TOKEN_URI	"pkcs11:"
-set_var PKCS11_SLOT "02"
-set_var PKCS11_REQUIRE_SOPIN true
+1. Required settings:  
+Use `opensc-pkcs11.so`, select your device `PKCS11_TOKEN_URI`, do not change `PKCS11_KEY_LABEL` and `PKCS11_KEY_ID` unless you are using a different key.
+```sh
+set_var PKCS11_MODULE_PATH	"path/to/opensc-pkcs11.so"
+set_var PKCS11_KEY_LABEL	"SIGN"
+set_var PKCS11_TOKEN_URI	"pkcs11:model=PKCS%2315%20emulated;manufacturer=piv_II;serial=0123456789abcdef;token=testkey
+"
+set_var PKCS11_KEY_ID "02"
 # Only for testing & automation purpose.
 # Never write your production PIN to file.
-#set_var PKCS11_SO_PIN "010203040506070801020304050607080102030405060708"
 #set_var PKCS11_PIN 123456
 ```
 
 2. Build CA
-```bash
+```sh
 easyrsa build-ca pkcs11
 ```
 Note: Yubikeys might require a second PIN entry during signing operations, even when `PKCS11_PIN` var is set.
@@ -183,6 +218,15 @@ TODO
 * [x] Get PKCS11 module information from key file (if configured)
 * [x] Add SO login and extra options support for different implementations (i.e. Yubikey)
 * [x] Test support with Nitrokeys
-* [ ] If a key is being created on a device, ensure the label isn't already used by the same type of key
-* [ ] Add check to ensure openssl pkcs11 engine is installed and library able to be found.
+* [ ] Add sanity checks
+  - [x] if no `PKCS11_URI` is selected, list available ones and ask the user to select
+  - [x] check to ensure GnuTLS is installed
+  - [ ] check to ensure openssl pkcs11 engine is installed and library is able to be found
+  - [ ] check to ensure token exists
+  - [ ] check to ensure token is connected
+  - [ ] check to ensure key type and size are supported by the token
+  - [x] check to ensure if corresponding public key exist; ask to use it instead or print an error
+
+* [ ] if supported (verify how to check it), save the generated CA certificate to HSM (might ask the user fro confirmation)
 * [ ] Create command to extract a certificate from a key and bootstrap a new CA (maybe ask the user if that is what they want if the slot has everything that is needed)
+* [x] Move key generation from `pkcs11-tool` to GNU-tls `p11tool` (single dependency)

--- a/PKCS11.md
+++ b/PKCS11.md
@@ -20,7 +20,7 @@ Environment Variables
 * `PKCS11_LABEL` - The label of the key to use.  (Not de-duplicated!!)
 * `PKCS11_EXTRA_OPTIONS` - Extra options for `pkcs11-tool` (i.e. `--id` for Yubikeys). *Use with caution!*
 * `PKCS11_REQUIRE_SOPIN` - Boolean, set to `true` for devices which require SO PIN login to generate keypairs (i.e. Yubikeys)
-*  `PKCS11_SOPIN` - *HIGLY INSECURE* useful for testing,  automatically logs the SO user in.
+*  `PKCS11_SO_PIN` - *HIGLY INSECURE* useful for testing,  automatically logs the SO user in.
 
 Once you've created your CA, `./pki/private/ca.key` will not be a normal PEM key file.  Instead it will look
 like the following:
@@ -95,7 +95,7 @@ set_var PKCS11_EXTRA_OPTIONS	"--id 2"
 set_var PKCS11_REQUIRE_SOPIN true
 # WARNING: Following settings are for test purpose only.
 # Writing PIN and SO PIN to config is highly discouraged for security reasons.
-set_var PKCS11_SOPIN "010203040506070801020304050607080102030405060708"
+set_var PKCS11_SO_PIN "010203040506070801020304050607080102030405060708"
 set_var PKCS11_PIN 123456
 ```
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -246,10 +246,12 @@ Certificate & Request options: (these impact cert/req field values)
 
 PKCS#11 Options:
 --module=PATH 	: Path to the module to use for the PKCS#11 interface
+--token-uri=PKCS11_TOKEN_URI : PKCS11 Token URI (according to RFC 7512)
 --slot=SLOT_ID  : Hexidecimal slot identifier
 --label=CA_KEY_LABEL : Unique name for CA key in the specified slot
---pin=PIN		: Token PIN, if not specified will be asked for
---pinpad		: Use external pinpad for pin entry.
+--pin=PIN				: Token PIN, if not specified will be asked for
+--sopin					: Token SO PIN
+--pinpad				: Use external pinpad for pin entry.
 
 Organizational DN options: (only used with the 'org' DN mode)
   (values may be blank for org DN options)
@@ -367,25 +369,21 @@ easyrsa_pkcs11_tool() {
 	if [ "$PKCS11_PINPAD" = true ]; then
 		print "Please enter PIN on external pinpad to generate CA keypair."
 		"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
-					--slot "$PKCS11_SLOT" \
-					--login "$@" \
+					--login "$@" --id "$PKCS11_SLOT" \
 					$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
 	else
 		# Command line Input - Requires SO-PIN
 		if [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
 			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
-						--slot "$PKCS11_SLOT" \
 						--login --login-type so \
 						--so-pin "$PKCS11_SO_PIN" \
-						$PKCS11_EXTRA_OPTIONS \
-						"$@" \
+						"$@" --id "$PKCS11_SLOT" \
 						$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
 		else
 			# Command line Input - Requires standard PIN
 			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
-						--slot "$PKCS11_SLOT" \
 						--login --pin "$PKCS11_PIN" \
-						"$@" \
+						"$@" --id "$PKCS11_SLOT" \
 						$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
 		fi
 	fi
@@ -481,17 +479,20 @@ EOF
 	#		to openssl.  This will be important if we really want to put the PIN in the config so there isn't a chance
 	#       of it being exposed through temp files.
 
-	if [ $pkcs11 ]; then
-		sed -i'' -e "s/=.*\/private\/ca.key/= label_$PKCS11_LABEL/g" "$easyrsa_openssl_conf" \
-			|| die "Failed to configure PKCS#11 token"
-	fi
 	echo
 	if [ "$openssl_command" = "makesafeconf" ]; then
 		cp "$easyrsa_openssl_conf" "$EASYRSA_SAFE_CONF"
 		err=$?
 	else
-		"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" $openssl_pkcs11_params "$@"
-		err=$?
+		if [ "$pkcs11" ] && [ "$openssl_command" = "ca" ]; then
+			"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" $openssl_pkcs11_params \
+			"$@" \
+			-keyfile "${PKCS11_TOKEN_URI}id=$(echo $PKCS11_SLOT|sed 's/.\{2\}/%&/g');object=$PKCS11_LABEL;type=private"
+			err=$?
+		else
+			"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" $openssl_pkcs11_params "$@"
+			err=$?
+		fi
 	fi
 
 	rm -f "$easyrsa_openssl_conf"
@@ -738,10 +739,6 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		if [ -z "$PKCS11_MODULE_PATH" ]; then
 			printf "PKCS#11 Module Library: " && read -r PKCS11_MODULE_PATH
 		fi
-		if [ -z "$PKCS11_SLOT" ]; then
-			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" --list-slots || die "unable to list slots using" "$PKCS11_MODULE_PATH"
-			printf "PKCS#11 Slot ID (hex): " && read -r PKCS11_SLOT
-		fi
 		if [ -z "$PKCS11_LABEL" ]; then
 			# TODO: "Validate PKCS11_LABEL otherwise a segfault is appearing"
 			printf "PKCS#11 Object Label: " && read -r PKCS11_LABEL
@@ -750,7 +747,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			printf "PKCS#11 PIN: " && hide_read_pass PKCS11_PIN
 		fi
 		if [ -z "$PKCS11_SO_PIN" ] && [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
-		  printf "\nPKCS#11 SOPIN: " && hide_read_pass PKCS11_SO_PIN
+		  printf "\nPKCS#11 SO PIN: " && hide_read_pass PKCS11_SO_PIN
 		fi
 
 	elif [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then
@@ -781,7 +778,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			die "Unsupported \$EASYRSA_ALGO=$EASYRSA_ALGO"
 		fi
 		easyrsa_pkcs11_tool --keypairgen --key-type "$KEY_TYPE" \
-			--label "'$PKCS11_LABEL'" \
+			--label "$PKCS11_LABEL" \
 			--usage-sign \
 			--private
 			# TODO: figure out how to determine if the --sensitive flag is available on pkcs11-tool
@@ -791,8 +788,8 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		cat > "$out_key_tmp" << EOF
 # EasyRSA variables pointing to the private key object
 PKCS11_MODULE_PATH=${PKCS11_MODULE_PATH}
-PKCS11_SLOT=${PKCS11_SLOT}
-PKCS11_LABEL=${PKCS11_LABEL}
+PKCS11_TOKEN_URI='${PKCS11_TOKEN_URI}'
+PKCS11_LABEL='${PKCS11_LABEL}'
 EOF
 	else
 		crypto_opts=""
@@ -838,7 +835,8 @@ EOF
 			print "Please enter PIN on external pinpad to sign CA root certificate."
 		fi
 		easyrsa_openssl req -utf8 -new -sha256 \
-			-key "label_$PKCS11_LABEL" -out "$out_file_tmp" \
+			-key "${PKCS11_TOKEN_URI}id=$(echo $PKCS11_SLOT|sed 's/.\{2\}/%&/g');object=$PKCS11_LABEL;type=private" \
+			-out "$out_file_tmp" \
 			$crypto_opts $opts || \
 			die "Failed to build the CA using PKCS#11 token"
 	else
@@ -2614,15 +2612,22 @@ while :; do
 		export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS
 subjectAltName = $val" ;;
-    --module)
+  --module)
 		empty_ok=1
 		export PKCS11_MODULE_PATH="$val" ;;
+	--token-uri)
+		empty_ok=1
+		export PKCS11_TOKEN_URI="$val" ;;
 	--slot)
 		empty_ok=1
 		export PKCS11_SLOT="$val" ;;
 	--pin)
 		empty_ok=1
 		export PKCS11_PIN="$val" ;;
+	--sopin)
+		empty_ok=1
+		export PKCS11_SO_PIN="$val"
+		export PKCS11_REQUIRE_SOPIN=true ;;
 	--label)
 		empty_ok=1
 		export PKCS11_LABEL="$val" ;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -376,7 +376,7 @@ easyrsa_pkcs11_tool() {
 			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
 						--slot "$PKCS11_SLOT" \
 						--login --login-type so \
-						--so-pin "$PKCS11_SOPIN" \
+						--so-pin "$PKCS11_SO_PIN" \
 						$PKCS11_EXTRA_OPTIONS \
 						"$@" \
 						$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
@@ -749,8 +749,8 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		if [ -z "$PKCS11_PIN" ] && [ -z "$PKCS11_PINPAD" ]; then
 			printf "PKCS#11 PIN: " && hide_read_pass PKCS11_PIN
 		fi
-		if [ -z "$PKCS11_SOPIN" ] && [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
-		  printf "\nPKCS#11 SOPIN: " && hide_read_pass PKCS11_SOPIN
+		if [ -z "$PKCS11_SO_PIN" ] && [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
+		  printf "\nPKCS#11 SOPIN: " && hide_read_pass PKCS11_SO_PIN
 		fi
 
 	elif [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -76,7 +76,8 @@ cmd_help() {
       			opts="
         nopass  - do not encrypt the CA key (default is encrypted)
         subca   - create an intermediate CA keypair and request (default is a root CA)
-        intca   - alias to the above" ;;
+        intca   - alias to the above
+		pkcs11  - use a PKCS#11 token for key storage" ;;
 		gen-dh) text="
   gen-dh
       Generates DH (Diffie-Hellman) parameters" ;;
@@ -243,6 +244,13 @@ Certificate & Request options: (these impact cert/req field values)
 --curve=NAME    : for elliptic curve, sets the named curve to use
 --copy-ext      : Copy included request X509 extensions (namely subjAltName
 
+PKCS#11 Options:
+--module=PATH 	: Path to the module to use for the PKCS#11 interface
+--slot=SLOT_ID  : Hexidecimal slot identifier
+--label=CA_KEY_LABEL : Unique name for CA key in the specified slot
+--pin=PIN		: Token PIN, if not specified will be asked for
+--pinpad		: Use external pinpad for pin entry.
+
 Organizational DN options: (only used with the 'org' DN mode)
   (values may be blank for org DN options)
 
@@ -325,6 +333,17 @@ Type the word '$value' to continue, or any other input to abort."
 	exit 9
 } # => confirm()
 
+# pkcs11_pin wrapper
+pkcs11_pin(){
+   if [ -n "$PKCS11_PINPAD" ]; then
+       if [ "$PKCS11_PINPAD" = true ]; then
+           echo ""
+           return
+       fi
+   fi
+   echo "--pin $PKCS11_PIN"
+} # => pkcs11_pin()
+
 # mktemp wrapper
 easyrsa_mktemp() {
 	[ -n "$EASYRSA_TEMP_DIR_session" ] || die "EASYRSA_TEMP_DIR_session not initialized!"
@@ -353,6 +372,17 @@ cleanup() {
 	echo "" # just to get a clean line
 } # => cleanup()
 
+easyrsa_pkcs11_tool() {
+	if [ "$PKCS11_PINPAD" = true ]; then
+		print "Please enter PIN on external pinpad to generate CA keypar."
+	fi
+	print "Generating keypair on PKCS#11 Module..."
+	"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
+					--slot "$PKCS11_SLOT" \
+					--login "$(pkcs11_pin)" \
+					"$@" || die "Failed to access PKCS#11. Wrong PIN?"
+} # => easyrsa_pkcs11_tool
+
 easyrsa_openssl() {
 	openssl_command=$1; shift
 
@@ -377,6 +407,46 @@ easyrsa_openssl() {
 			$EASYRSA_EXTRA_EXTS
 		EOF
 	fi
+	# Find the private key file
+	ca_key_file="${EASYRSA_PKI}/private/ca.key"
+
+	# Check to see that it exists
+	if [ -f "$ca_key_file" ]; then
+		grep PRIVATE "$ca_key_file"
+		is_pkcs11_config=$?
+		# If the file isn't an actual key, source it
+		# TODO: implement same method as vars file for loading config?
+		if [ $is_pkcs11_config -eq 1 ]; then
+			# shellcheck disable=SC1090
+			. "$ca_key_file"
+			pkcs11=1 # a hint for when we call the engine later
+		fi
+	fi
+
+	if [ -n "$PKCS11_PIN" ] && [ $pkcs11 ]	; then
+		PKCS11_PIN_EXPANDED="PIN=${PKCS11_PIN}"
+	fi
+
+	if [ $pkcs11 ]; then
+		# Insert OpenSSL PKCS#11 Engine configuration first
+		cat > "$easyrsa_openssl_conf" << EOF
+openssl_conf = openssl_def
+
+[openssl_def]
+engines = engine_section
+
+[engine_section]
+pkcs11 = pkcs11_section
+
+[pkcs11_section]
+engine_id = pkcs11
+MODULE_PATH = ${PKCS11_MODULE_PATH}
+${PKCS11_PIN_EXPANDED}
+EOF
+
+		# Setup parameters to use OpenSSL Engine
+		openssl_pkcs11_params="-engine pkcs11 -keyform engine"
+	fi
 
 	# Make LibreSSL safe config file from OpenSSL config file
 	sed \
@@ -397,14 +467,22 @@ easyrsa_openssl() {
 		-e "s\`\$EASYRSA_REQ_CN\`$EASYRSA_REQ_CN\`g" \
 		-e "s\`\$EASYRSA_REQ_EMAIL\`$EASYRSA_REQ_EMAIL\`g" \
 		${EASYRSA_EXTRA_EXTS:+-e "/^#%EXTRA_EXTS%/r $easyrsa_extra_exts"} \
-		"$EASYRSA_SSL_CONF" > "$easyrsa_openssl_conf" ||
+		"$EASYRSA_SSL_CONF" >> "$easyrsa_openssl_conf" ||
 		die "Failed to update $easyrsa_openssl_conf"
+	# TODO: Consider using bash redirection to create file handles only readable by this process for temp files passed
+	#		to openssl.  This will be important if we really want to put the PIN in the config so there isn't a chance
+	#       of it being exposed through temp files.
+
+	if [ $pkcs11 ]; then
+		sed -i'' -e "s/=.*\/private\/ca.key/= label_$PKCS11_LABEL/g" "$easyrsa_openssl_conf" \
+			|| die "Failed to configure PKCS#11 token"
+	fi
 
 	if [ "$openssl_command" = "makesafeconf" ]; then
 		cp "$easyrsa_openssl_conf" "$EASYRSA_SAFE_CONF"
 		err=$?
 	else
-		"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" "$@"
+		"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" $openssl_pkcs11_params "$@"
 		err=$?
 	fi
 
@@ -588,11 +666,13 @@ build_ca() {
 	sub_ca=""
 	nopass=""
 	crypto="-aes256"
+	pkcs11=""
 	while [ -n "$1" ]; do
 		case "$1" in
 			intca) sub_ca=1 ;;
 			subca) sub_ca=1 ;;
 			nopass) nopass=1 ;;
+			pkcs11) pkcs11=1 ;;
 			*) warn "Ignoring unknown command option: '$1'" ;;
 		esac
 		shift
@@ -644,7 +724,25 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	out_key_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	out_file_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	# Get password from user if necessary
-	if [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then
+	if [ $pkcs11 ]; then
+		# Prepare parameters for PKCS11
+		echo "easy-rsa stores the key specific configuration in the appropriate key file and will not store sensitive information"
+		if [ -z "$PKCS11_MODULE_PATH" ]; then
+			printf "PKCS#11 Module Library: " && read -r PKCS11_MODULE_PATH
+		fi
+		if [ -z "$PKCS11_SLOT" ]; then
+			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" --list-slots || die "unable to list slots using" "$PKCS11_MODULE_PATH"
+			printf "PKCS#11 Slot ID (hex): " && read -r PKCS11_SLOT
+		fi
+		if [ -z "$PKCS11_LABEL" ]; then
+			# TODO: "Validate PKCS11_LABEL otherwise a segfault is appearing"
+			printf "PKCS#11 Object Label: " && read -r PKCS11_LABEL
+		fi
+		if [ -z "$PKCS11_PIN" ] && [ -z "$PKCS11_PINPAD" ]; then
+			printf "PKCS#11 PIN: " && hide_read_pass PKCS11_PIN
+		fi
+
+	elif [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then
 		out_key_pass_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 		echo
 		printf "Enter New CA Key Passphrase: "
@@ -663,45 +761,82 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	fi
 
 	# create the CA key using AES256
-	crypto_opts=""
-	if [ ! $nopass ]; then
-		crypto_opts="$crypto"
-		if [ -z "$EASYRSA_PASSOUT" ]; then
-		    if [ "ed" = "$EASYRSA_ALGO" ]; then
-                crypto_opts="$crypto_opts -pass file:$out_key_pass_tmp"
-            else
-                crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
-            fi
-        fi
-	fi
-	if [ "$EASYRSA_ALGO" = "rsa" ]; then
-		#shellcheck disable=SC2086
-		"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} "$EASYRSA_ALGO_PARAMS" || \
-			die "Failed create CA private key"
-	elif [ "$EASYRSA_ALGO" = "ec" ]; then
-		#shellcheck disable=SC2086
-		"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
-			"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
-			die "Failed create CA private key"
-	elif [ "ed" = "$EASYRSA_ALGO" ]; then
-		if [ "ed25519" = "$EASYRSA_CURVE" ]; then
-			"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-			die "Failed create CA private key"
-		elif [ "ed448" = "$EASYRSA_CURVE" ]; then
-			"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-			die "Failed create CA private key"
+	if [ $pkcs11 ]; then
+		if [ "$EASYRSA_ALGO" = "rsa" ]; then
+			KEY_TYPE=rsa:$EASYRSA_KEY_SIZE
+		elif [ "$EASYRSA_ALGO" = "ec" ]; then
+			KEY_TYPE=EC:$EASYRSA_CURVE
+		else
+			die "Unsupported \$EASYRSA_ALGO=$EASYRSA_ALGO"
+		fi
+		easyrsa_pkcs11_tool --keypairgen --key-type "$KEY_TYPE" \
+			--label "$PKCS11_LABEL" \
+			--usage-sign \
+			--private
+			# TODO: figure out how to determine if the --sensitive flag is available on pkcs11-tool
+			# --sensitive
+			# Save the parameters for future usage to the out_key file
+			# TODO: Consider replacing with a pkcs11 url passed directly to the engine instead
+		cat > "$out_key_tmp" << EOF
+# EasyRSA variables pointing to the private key object
+PKCS11_MODULE_PATH=${PKCS11_MODULE_PATH}
+PKCS11_SLOT=${PKCS11_SLOT}
+PKCS11_LABEL=${PKCS11_LABEL}
+EOF
+	else
+		crypto_opts=""
+		if [ ! $nopass ]; then
+			crypto_opts="$crypto"
+			if [ -z "$EASYRSA_PASSOUT" ]; then
+			    if [ "ed" = "$EASYRSA_ALGO" ]; then
+	                crypto_opts="$crypto_opts -pass file:$out_key_pass_tmp"
+	            else
+	                crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
+	            fi
+	        fi
+		fi
+		if [ "$EASYRSA_ALGO" = "rsa" ]; then
+			#shellcheck disable=SC2086
+			"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} "$EASYRSA_ALGO_PARAMS" || \
+				die "Failed create CA private key"
+		elif [ "$EASYRSA_ALGO" = "ec" ]; then
+			#shellcheck disable=SC2086
+			"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
+				"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
+				die "Failed create CA private key"
+		elif [ "ed" = "$EASYRSA_ALGO" ]; then
+			if [ "ed25519" = "$EASYRSA_CURVE" ]; then
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+				die "Failed create CA private key"
+			elif [ "ed448" = "$EASYRSA_CURVE" ]; then
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+				die "Failed create CA private key"
+			fi
 		fi
 	fi
 
 	# create the CA keypair:
 	crypto_opts=""
-	[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && crypto_opts="-passin file:$out_key_pass_tmp"
 
-	#shellcheck disable=SC2086
-	easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
-		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
-		die "Failed to build the CA"
+	# create the CA CSR:
+	if [ $pkcs11 ]; then
 
+		# Create a request where the key is in the PKCS11 device
+		#shellcheck disable=SC2086
+		if [ "$PKCS11_PINPAD" = true ]; then
+			print "Please enter PIN on external pinpad to sign CA root certificate."
+		fi
+		easyrsa_openssl req -utf8 -new -sha256 \
+			-key "label_$PKCS11_LABEL" -out "$out_file_tmp" \
+			$crypto_opts $opts || \
+			die "Failed to build the CA using PKCS#11 token"
+	else
+		[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && crypto_opts="-passin file:$out_key_pass_tmp"
+		#shellcheck disable=SC2086
+		easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
+			-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
+			die "Failed to build the CA"
+	fi
 	mv "$out_key_tmp" "$out_key"
 	mv "$out_file_tmp" "$out_file"
 	[ -f "$out_key_pass_tmp" ] && rm "$out_key_pass_tmp"
@@ -942,6 +1077,11 @@ $ext_tmp"
 
 	# sign request
 	crt_out_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	if [ "$PKCS11_PINPAD" = true ]; then
+		print "
+		    --> Please enter PIN on external pinpad to sign the new certificate.
+		"
+	fi
 	easyrsa_openssl ca -utf8 -in "$req_in" -out "$crt_out_tmp" \
 		-extfile "$ext_tmp" -days "$EASYRSA_CERT_EXPIRE" -batch $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} \
 		|| die "signing failed (openssl output above may have more detail)"
@@ -1734,6 +1874,7 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
 	set_var EASYRSA_SAFE_CONF	"$EASYRSA_PKI/safessl-easyrsa.cnf"
 	set_var EASYRSA_KDC_REALM	"CHANGEME.EXAMPLE.COM"
+	set_var EASYRSA_PKCS11TOOL  pkcs11-tool
 
 	# Same as above for the x509-types extensions dir
 	if [ -d "$EASYRSA_PKI/x509-types" ]; then
@@ -2462,6 +2603,21 @@ while :; do
 		export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS
 subjectAltName = $val" ;;
+    --module)
+		empty_ok=1
+		export PKCS11_MODULE_PATH="$val" ;;
+	--slot)
+		empty_ok=1
+		export PKCS11_SLOT="$val" ;;
+	--pin)
+		empty_ok=1
+		export PKCS11_PIN="$val" ;;
+	--label)
+		empty_ok=1
+		export PKCS11_LABEL="$val" ;;
+	--pinpad)
+		empty_ok=1
+		export PKCS11_PINPAD=1 ;;
 	--version)
 		print_version
 		;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -789,6 +789,7 @@ and run the command again.\n"
 
 	# create the CA key using AES256
 	if [ $pkcs11 ]; then
+		echo "Checking existing keys on the token..."
 		keyexists=$(p11tool --list-all "$(echo $PKCS11_TOKEN_URI | sed 's/\;$//')"|\
 		grep -e "ID: " -e "Label" -e "URL: " -e "Type: "|\
 		grep -B2 "ID: $(echo ${PKCS11_KEY_ID}|sed 's/..\B/&:/g')"|\
@@ -803,7 +804,7 @@ and run the command again.\n"
 				grep -B2 "ID: $(echo ${PKCS11_KEY_ID}|sed 's/..\B/&:/g')"|\
 				grep -A1 "Type: Public key"|sed -rn 's/^.*Label: (.*)$/\1/p')
 				echo "\nFound existing key (ID: '$PKCS11_KEY_ID', Type: '$keyexists', Label: '$existing_label')"
-				if [ "$existing_label" != $PKCS11_KEY_LABEL ]; then
+				if [ "$existing_label" != "$PKCS11_KEY_LABEL" ]; then
 					echo " WARNING!!	Label mismatch!"
 				fi
 				confirm "Confirm using this key to generate the CA: " "yes" "

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -790,7 +790,7 @@ and run the command again.\n"
 	# create the CA key using AES256
 	if [ $pkcs11 ]; then
 		echo "Checking existing keys on the token..."
-		keyexists=$(p11tool --list-all "$(echo $PKCS11_TOKEN_URI | sed 's/\;$//')"|\
+		keyexists=$($EASYRSA_P11TOOL --list-all "$(echo $PKCS11_TOKEN_URI | sed 's/\;$//')"|\
 		grep -e "ID: " -e "Label" -e "URL: " -e "Type: "|\
 		grep -B2 "ID: $(echo ${PKCS11_KEY_ID}|sed 's/..\B/&:/g')"|\
 		sed -rn "s/^.*Type: Public key \((.*)\)/\1/p")
@@ -799,7 +799,7 @@ and run the command again.\n"
 		if [ -n "$keyexists" ]; then
 			# Key is correct algorithm
 			if [ -n "$(echo $keyexists|grep -i $EASYRSA_ALGO)" ]; then
-				existing_label=$(p11tool --list-all "$(echo $PKCS11_TOKEN_URI | sed 's/\;$//')"|\
+				existing_label=$($EASYRSA_P11TOOL --list-all "$(echo $PKCS11_TOKEN_URI | sed 's/\;$//')"|\
 				grep -e "ID: " -e "Label" -e "URL: " -e "Type: "|\
 				grep -B2 "ID: $(echo ${PKCS11_KEY_ID}|sed 's/..\B/&:/g')"|\
 				grep -A1 "Type: Public key"|sed -rn 's/^.*Label: (.*)$/\1/p')

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -77,7 +77,7 @@ cmd_help() {
         nopass  - do not encrypt the CA key (default is encrypted)
         subca   - create an intermediate CA keypair and request (default is a root CA)
         intca   - alias to the above
-		pkcs11  - use a PKCS#11 token for key storage" ;;
+				pkcs11  - use a PKCS#11 token for key storage" ;;
 		gen-dh) text="
   gen-dh
       Generates DH (Diffie-Hellman) parameters" ;;
@@ -362,32 +362,27 @@ cleanup() {
 	(stty echo 2>/dev/null) || { (set -o echo 2>/dev/null) && set -o echo; }
 	echo "" # just to get a clean line
 } # => cleanup()
-
-easyrsa_pkcs11_tool() {
+easyrsa_p11_tool() {
 	print "Generating keypair on PKCS#11 Module..."
 	# External pinpad input
 	if [ "$PKCS11_PINPAD" = true ]; then
 		print "Please enter PIN on external pinpad to generate CA keypair."
-		"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
-					--login "$@" --id "$PKCS11_SLOT" \
-					$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
+		"$EASYRSA_P11TOOL" --provider="$PKCS11_MODULE_PATH" \
+					--login "$@" || die "Failed to access PKCS#11. Wrong PIN?"
 	else
 		# Command line Input - Requires SO-PIN
 		if [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
-			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
-						--login --login-type so \
-						--so-pin "$PKCS11_SO_PIN" \
-						"$@" --id "$PKCS11_SLOT" \
-						$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
+			"$EASYRSA_P11TOOL" --provider="$PKCS11_MODULE_PATH" \
+						--so-login --set-so-pin="$PKCS11_SO_PIN" \
+						"$@" || die "Failed to access PKCS#11. Wrong PIN?"
 		else
 			# Command line Input - Requires standard PIN
-			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
-						--login --pin "$PKCS11_PIN" \
-						"$@" --id "$PKCS11_SLOT" \
-						$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
+						"$EASYRSA_P11TOOL" --provider="$PKCS11_MODULE_PATH" \
+									--login --set-pin="$PKCS11_PIN" \
+									"$@" || die "Failed to access PKCS#11. Wrong PIN?"
 		fi
 	fi
-} # => easyrsa_pkcs11_tool
+} # => easyrsa_p11_tool
 
 easyrsa_openssl() {
 	openssl_command=$1; shift
@@ -487,7 +482,7 @@ EOF
 		if [ "$pkcs11" ] && [ "$openssl_command" = "ca" ]; then
 			"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" $openssl_pkcs11_params \
 			"$@" \
-			-keyfile "${PKCS11_TOKEN_URI}id=$(echo $PKCS11_SLOT|sed 's/.\{2\}/%&/g');object=$PKCS11_LABEL;type=private"
+			-keyfile "${PKCS11_TOKEN_URI};id=$(echo $PKCS11_KEY_ID|sed 's/.\{2\}/%&/g');object=$PKCS11_KEY_LABEL;type=private"
 			err=$?
 		else
 			"$EASYRSA_OPENSSL" "$openssl_command" -config "$easyrsa_openssl_conf" $openssl_pkcs11_params "$@"
@@ -734,14 +729,18 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	out_file_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	# Get password from user if necessary
 	if [ $pkcs11 ]; then
+		# Test PKCS11 requirements
+		if [ -z "$(which $EASYRSA_P11TOOL)" ]; then
+			die "${EASYRSA_P11TOOL} not found. Please install GnuTLS."
+		fi
 		# Prepare parameters for PKCS11
 		echo "\neasy-rsa stores the key specific configuration in the appropriate key file and will not store sensitive information"
 		if [ -z "$PKCS11_MODULE_PATH" ]; then
 			printf "PKCS#11 Module Library: " && read -r PKCS11_MODULE_PATH
 		fi
-		if [ -z "$PKCS11_LABEL" ]; then
-			# TODO: "Validate PKCS11_LABEL otherwise a segfault is appearing"
-			printf "PKCS#11 Object Label: " && read -r PKCS11_LABEL
+		if [ -z "$PKCS11_KEY_LABEL" ]; then
+			# TODO: "Validate PKCS11_KEY_LABEL otherwise a segfault is appearing"
+			printf "PKCS#11 Object Label: " && read -r PKCS11_KEY_LABEL
 		fi
 		if [ -z "$PKCS11_PIN" ] && [ -z "$PKCS11_PINPAD" ]; then
 			printf "PKCS#11 PIN: " && hide_read_pass PKCS11_PIN
@@ -749,6 +748,26 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		if [ -z "$PKCS11_SO_PIN" ] && [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
 		  printf "\nPKCS#11 SO PIN: " && hide_read_pass PKCS11_SO_PIN
 		fi
+		if [ -z "$PKCS11_TOKEN_URI" ]; then
+			echo "PKCS11 mode was selected, but no token URI was specified.
+Please select one of the available ones.
+If your device do not appear in the list, please verify it is connected
+and run the command again.\n"
+			tokens="$($EASYRSA_P11TOOL --list-token-urls| sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\|/g')"
+			for token_count in $(seq $(echo ${tokens}|awk -F"|" '{print NF}'))
+			do
+				echo "\t[${token_count}] : \"$(echo $tokens|cut -d '|' -f${token_count})\""
+				token_count=$(( ${token_count} + 1 ))
+			done
+			echo -n "Enter PKCS11 Token number:"
+			read userinput
+			if [ ${userinput} -lt 1 ] || [ ${userinput} -gt $(echo ${tokens}|awk -F"|" '{print NF}') ]; then
+				die "Invalid PKCS11 Token number selected."
+			fi
+			PKCS11_TOKEN_URI="$(echo ${tokens}|cut -d '|' -f${userinput})"
+			echo "Selected token: \"${PKCS11_TOKEN_URI}\""
+		fi
+
 
 	elif [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then
 		out_key_pass_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
@@ -770,6 +789,48 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 
 	# create the CA key using AES256
 	if [ $pkcs11 ]; then
+		keyexists=$(p11tool --list-all "$(echo $PKCS11_TOKEN_URI | sed 's/\;$//')"|\
+		grep -e "ID: " -e "Label" -e "URL: " -e "Type: "|\
+		grep -B2 "ID: $(echo ${PKCS11_KEY_ID}|sed 's/..\B/&:/g')"|\
+		sed -rn "s/^.*Type: Public key \((.*)\)/\1/p")
+
+		# Key with selected ID exists
+		if [ -n "$keyexists" ]; then
+			# Key is correct algorithm
+			if [ -n "$(echo $keyexists|grep -i $EASYRSA_ALGO)" ]; then
+				existing_label=$(p11tool --list-all "$(echo $PKCS11_TOKEN_URI | sed 's/\;$//')"|\
+				grep -e "ID: " -e "Label" -e "URL: " -e "Type: "|\
+				grep -B2 "ID: $(echo ${PKCS11_KEY_ID}|sed 's/..\B/&:/g')"|\
+				grep -A1 "Type: Public key"|sed -rn 's/^.*Label: (.*)$/\1/p')
+				echo "\nFound existing key (ID: '$PKCS11_KEY_ID', Type: '$keyexists', Label: '$existing_label')"
+				if [ "$existing_label" != $PKCS11_KEY_LABEL ]; then
+					echo " WARNING!!	Label mismatch!"
+				fi
+				confirm "Confirm using this key to generate the CA: " "yes" "
+WARNING:
+Existing Public key found on ID '${PKCS11_KEY_ID}'.
+(Type: '$keyexists', Label: '$existing_label').
+You are about to use the pre-existing key."
+				#set_var PKCS11_KEY_LABEL "$existing_label"
+				PKCS11_KEY_LABEL="$existing_label"
+				# Key exist, but wrong algorithm
+			else
+				echo "Key found at ID ${PKCS11_KEY_ID}, but it is not of required type.
+Expected '${EASYRSA_ALGO}', found '${existing_label}'."
+				die "Wrong key type found."
+			fi
+			#key not found
+		else
+			if [ "$EASYRSA_ALGO" = "rsa" ]; then
+				easyrsa_p11_tool --generate-privkey=$EASYRSA_ALGO \
+				 --bits=$EASYRSA_KEY_SIZE --label="$PKCS11_KEY_LABEL" --id="$PKCS11_KEY_ID" "$PKCS11_TOKEN_URI" --mark-sign
+			else
+				easyrsa_p11_tool --generate-privkey=$EASYRSA_ALGO \
+				--curve=$EASYRSA_CURVE --label="$PKCS11_KEY_LABEL" --id="$PKCS11_KEY_ID" "$PKCS11_TOKEN_URI" --mark-sign
+			fi
+		fi
+
+
 		if [ "$EASYRSA_ALGO" = "rsa" ]; then
 			KEY_TYPE=rsa:$EASYRSA_KEY_SIZE
 		elif [ "$EASYRSA_ALGO" = "ec" ]; then
@@ -777,19 +838,13 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		else
 			die "Unsupported \$EASYRSA_ALGO=$EASYRSA_ALGO"
 		fi
-		easyrsa_pkcs11_tool --keypairgen --key-type "$KEY_TYPE" \
-			--label "$PKCS11_LABEL" \
-			--usage-sign \
-			--private
-			# TODO: figure out how to determine if the --sensitive flag is available on pkcs11-tool
-			# --sensitive
 			# Save the parameters for future usage to the out_key file
 			# TODO: Consider replacing with a pkcs11 url passed directly to the engine instead
 		cat > "$out_key_tmp" << EOF
 # EasyRSA variables pointing to the private key object
 PKCS11_MODULE_PATH=${PKCS11_MODULE_PATH}
 PKCS11_TOKEN_URI='${PKCS11_TOKEN_URI}'
-PKCS11_LABEL='${PKCS11_LABEL}'
+PKCS11_KEY_LABEL='${PKCS11_KEY_LABEL}'
 EOF
 	else
 		crypto_opts=""
@@ -835,7 +890,7 @@ EOF
 			print "Please enter PIN on external pinpad to sign CA root certificate."
 		fi
 		easyrsa_openssl req -utf8 -new -sha256 \
-			-key "${PKCS11_TOKEN_URI}id=$(echo $PKCS11_SLOT|sed 's/.\{2\}/%&/g');object=$PKCS11_LABEL;type=private" \
+			-key "${PKCS11_TOKEN_URI};id=$(echo $PKCS11_KEY_ID|sed 's/.\{2\}/%&/g');object=$PKCS11_KEY_LABEL;type=private" \
 			-out "$out_file_tmp" \
 			$crypto_opts $opts || \
 			die "Failed to build the CA using PKCS#11 token"
@@ -1883,7 +1938,7 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
 	set_var EASYRSA_SAFE_CONF	"$EASYRSA_PKI/safessl-easyrsa.cnf"
 	set_var EASYRSA_KDC_REALM	"CHANGEME.EXAMPLE.COM"
-	set_var EASYRSA_PKCS11TOOL  pkcs11-tool
+	set_var EASYRSA_P11TOOL  p11tool
 
 	# Same as above for the x509-types extensions dir
 	if [ -d "$EASYRSA_PKI/x509-types" ]; then
@@ -2620,7 +2675,7 @@ subjectAltName = $val" ;;
 		export PKCS11_TOKEN_URI="$val" ;;
 	--slot)
 		empty_ok=1
-		export PKCS11_SLOT="$val" ;;
+		export PKCS11_KEY_ID="$val" ;;
 	--pin)
 		empty_ok=1
 		export PKCS11_PIN="$val" ;;
@@ -2630,7 +2685,7 @@ subjectAltName = $val" ;;
 		export PKCS11_REQUIRE_SOPIN=true ;;
 	--label)
 		empty_ok=1
-		export PKCS11_LABEL="$val" ;;
+		export PKCS11_KEY_LABEL="$val" ;;
 	--pinpad)
 		empty_ok=1
 		export PKCS11_PINPAD=1 ;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -822,7 +822,6 @@ Expected '${EASYRSA_ALGO}', found '${existing_label}'."
 			#key not found
 		else
 			if [ "$EASYRSA_ALGO" = "rsa" ]; then
-				easyrsa_p11_tool --generate-privkey=$EASYRSA_ALGO \
 				easyrsa_p11_tool --generate-rsa \
 				 --bits=$EASYRSA_KEY_SIZE --label="$PKCS11_KEY_LABEL" --id="$PKCS11_KEY_ID" "$PKCS11_TOKEN_URI" --mark-sign
 			else
@@ -831,6 +830,7 @@ Expected '${EASYRSA_ALGO}', found '${existing_label}'."
 					 --curve=$EASYRSA_CURVE --label="$PKCS11_KEY_LABEL" --id="$PKCS11_KEY_ID" "$PKCS11_TOKEN_URI" --mark-sign
 				else
 					die "Unsupported $EASYRSA_ALGO key generation for PKCS11 tool."
+				fi
 			fi
 		fi
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -754,14 +754,14 @@ Please select one of the available ones.
 If your device do not appear in the list, please verify it is connected
 and run the command again.\n"
 			tokens="$($EASYRSA_P11TOOL --list-token-urls| sed -e ':a' -e 'N' -e '$!ba' -e 's/\n/\|/g')"
-			for token_count in $(seq $(echo ${tokens}|awk -F"|" '{print NF}'))
+			for token_count in $(seq "$(echo ${tokens}|awk -F"|" '{print NF}')")
 			do
 				echo "\t[${token_count}] : \"$(echo $tokens|cut -d '|' -f${token_count})\""
 				token_count=$(( ${token_count} + 1 ))
 			done
-			echo -n "Enter PKCS11 Token number:"
+			echo "Enter PKCS11 Token number:"
 			read userinput
-			if [ ${userinput} -lt 1 ] || [ ${userinput} -gt $(echo ${tokens}|awk -F"|" '{print NF}') ]; then
+			if [ "${userinput}" -lt "1" ] || [ "${userinput}" -gt "$(echo ${tokens}|awk -F"|" '{print NF}')" ]; then
 				die "Invalid PKCS11 Token number selected."
 			fi
 			PKCS11_TOKEN_URI="$(echo ${tokens}|cut -d '|' -f${userinput})"
@@ -830,14 +830,6 @@ Expected '${EASYRSA_ALGO}', found '${existing_label}'."
 			fi
 		fi
 
-
-		if [ "$EASYRSA_ALGO" = "rsa" ]; then
-			KEY_TYPE=rsa:$EASYRSA_KEY_SIZE
-		elif [ "$EASYRSA_ALGO" = "ec" ]; then
-			KEY_TYPE=EC:$EASYRSA_CURVE
-		else
-			die "Unsupported \$EASYRSA_ALGO=$EASYRSA_ALGO"
-		fi
 			# Save the parameters for future usage to the out_key file
 			# TODO: Consider replacing with a pkcs11 url passed directly to the engine instead
 		cat > "$out_key_tmp" << EOF

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -823,10 +823,14 @@ Expected '${EASYRSA_ALGO}', found '${existing_label}'."
 		else
 			if [ "$EASYRSA_ALGO" = "rsa" ]; then
 				easyrsa_p11_tool --generate-privkey=$EASYRSA_ALGO \
+				easyrsa_p11_tool --generate-rsa \
 				 --bits=$EASYRSA_KEY_SIZE --label="$PKCS11_KEY_LABEL" --id="$PKCS11_KEY_ID" "$PKCS11_TOKEN_URI" --mark-sign
 			else
-				easyrsa_p11_tool --generate-privkey=$EASYRSA_ALGO \
-				--curve=$EASYRSA_CURVE --label="$PKCS11_KEY_LABEL" --id="$PKCS11_KEY_ID" "$PKCS11_TOKEN_URI" --mark-sign
+				if [ "$EASYRSA_ALGO" = "ec" ]; then
+					easyrsa_p11_tool --generate-ecc \
+					 --curve=$EASYRSA_CURVE --label="$PKCS11_KEY_LABEL" --id="$PKCS11_KEY_ID" "$PKCS11_TOKEN_URI" --mark-sign
+				else
+					die "Unsupported $EASYRSA_ALGO key generation for PKCS11 tool."
 			fi
 		fi
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -333,17 +333,6 @@ Type the word '$value' to continue, or any other input to abort."
 	exit 9
 } # => confirm()
 
-# pkcs11_pin wrapper
-pkcs11_pin(){
-   if [ -n "$PKCS11_PINPAD" ]; then
-       if [ "$PKCS11_PINPAD" = true ]; then
-           echo ""
-           return
-       fi
-   fi
-   echo "--pin $PKCS11_PIN"
-} # => pkcs11_pin()
-
 # mktemp wrapper
 easyrsa_mktemp() {
 	[ -n "$EASYRSA_TEMP_DIR_session" ] || die "EASYRSA_TEMP_DIR_session not initialized!"
@@ -373,14 +362,33 @@ cleanup() {
 } # => cleanup()
 
 easyrsa_pkcs11_tool() {
-	if [ "$PKCS11_PINPAD" = true ]; then
-		print "Please enter PIN on external pinpad to generate CA keypar."
-	fi
 	print "Generating keypair on PKCS#11 Module..."
-	"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
+	# External pinpad input
+	if [ "$PKCS11_PINPAD" = true ]; then
+		print "Please enter PIN on external pinpad to generate CA keypair."
+		"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
 					--slot "$PKCS11_SLOT" \
-					--login "$(pkcs11_pin)" \
-					"$@" || die "Failed to access PKCS#11. Wrong PIN?"
+					--login "$@" \
+					$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
+	else
+		# Command line Input - Requires SO-PIN
+		if [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
+			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
+						--slot "$PKCS11_SLOT" \
+						--login --login-type so \
+						--so-pin "$PKCS11_SOPIN" \
+						$PKCS11_EXTRA_OPTIONS \
+						"$@" \
+						$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
+		else
+			# Command line Input - Requires standard PIN
+			"$EASYRSA_PKCS11TOOL" --module "$PKCS11_MODULE_PATH" \
+						--slot "$PKCS11_SLOT" \
+						--login --pin "$PKCS11_PIN" \
+						"$@" \
+						$PKCS11_EXTRA_OPTIONS || die "Failed to access PKCS#11. Wrong PIN?"
+		fi
+	fi
 } # => easyrsa_pkcs11_tool
 
 easyrsa_openssl() {
@@ -477,7 +485,7 @@ EOF
 		sed -i'' -e "s/=.*\/private\/ca.key/= label_$PKCS11_LABEL/g" "$easyrsa_openssl_conf" \
 			|| die "Failed to configure PKCS#11 token"
 	fi
-
+	echo
 	if [ "$openssl_command" = "makesafeconf" ]; then
 		cp "$easyrsa_openssl_conf" "$EASYRSA_SAFE_CONF"
 		err=$?
@@ -726,7 +734,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	# Get password from user if necessary
 	if [ $pkcs11 ]; then
 		# Prepare parameters for PKCS11
-		echo "easy-rsa stores the key specific configuration in the appropriate key file and will not store sensitive information"
+		echo "\neasy-rsa stores the key specific configuration in the appropriate key file and will not store sensitive information"
 		if [ -z "$PKCS11_MODULE_PATH" ]; then
 			printf "PKCS#11 Module Library: " && read -r PKCS11_MODULE_PATH
 		fi
@@ -740,6 +748,9 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		fi
 		if [ -z "$PKCS11_PIN" ] && [ -z "$PKCS11_PINPAD" ]; then
 			printf "PKCS#11 PIN: " && hide_read_pass PKCS11_PIN
+		fi
+		if [ -z "$PKCS11_SOPIN" ] && [ -n "$PKCS11_REQUIRE_SOPIN" ]; then
+		  printf "\nPKCS#11 SOPIN: " && hide_read_pass PKCS11_SOPIN
 		fi
 
 	elif [ ! $nopass ] && ( [ -z "$EASYRSA_PASSOUT" ] || [ -z "$EASYRSA_PASSIN" ] ); then
@@ -770,7 +781,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			die "Unsupported \$EASYRSA_ALGO=$EASYRSA_ALGO"
 		fi
 		easyrsa_pkcs11_tool --keypairgen --key-type "$KEY_TYPE" \
-			--label "$PKCS11_LABEL" \
+			--label "'$PKCS11_LABEL'" \
 			--usage-sign \
 			--private
 			# TODO: figure out how to determine if the --sensitive flag is available on pkcs11-tool
@@ -820,7 +831,7 @@ EOF
 
 	# create the CA CSR:
 	if [ $pkcs11 ]; then
-
+		echo "\nSigning CA Certificate..."
 		# Create a request where the key is in the PKCS11 device
 		#shellcheck disable=SC2086
 		if [ "$PKCS11_PINPAD" = true ]; then

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -221,7 +221,7 @@ fi
 
 # PKCS11 Module options
 # Default PKCS#11 tool to be used.
-set_var EASYRSA_PKCS11TOOL	"pkcs11-tool"
+set_var EASYRSA_P11TOOL	"p11tool"
 
 # Path to load the pkcs module
 #set_var PKCS11_MODULE_PATH "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so"
@@ -240,17 +240,14 @@ set_var EASYRSA_PKCS11TOOL	"pkcs11-tool"
 # (You might need to install gnutls-bin package.)
 #set_var PKCS11_TOKEN_URI	"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=390ab91a4f4faf7a;token=test-token;"
 
-# Set PKCS11 Slot ID.
-# Find correct slot checking output of 'pkcs11-tool -L'
+# Set PKCS11 Key ID.
+# Find correct CKA_ID checking output of 'p11tool '
 # Format is hex sequence, without leading '0x' characters.
-#set_var PKCS11_SLOT	"00"
+#set_var PKCS11_KEY_ID	"01"
 
 # Set CA keypair label.
-#set_var PKCS11_LABEL	"EasyRSA-CA-Key"
+#set_var PKCS11_KEY_LABEL	"EasyRSA-CA-Key"
 
-# Set extra pkcs11-tool options.
-# Might be useful for non-standard implementations.
-#set_var PKCS11_EXTRA_OPTIONS ""
 
 # Enable SO login when creating CA keys.
 #set_var PKCS11_REQUIRE_SOPIN true

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -27,7 +27,7 @@
 # "C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
 
 # A little housekeeping: DON'T EDIT THIS SECTION
-# 
+#
 # Easy-RSA 3.x doesn't source into the environment directly.
 # Complain if a user tries to do this:
 if [ -z "$EASYRSA_CALLER" ]; then
@@ -219,3 +219,24 @@ fi
 
 #set_var EASYRSA_BATCH		""
 
+# PKCS11 Module options
+# Default PKCS#11 tool to be used.
+set_var EASYRSA_PKCS11TOOL	"pkcs11-tool"
+
+# Path to load the pkcs module
+#set_var PKCS11_MODULE_PATH "/usr/lib/x86_64-linux-gnu/opensc-pkcs11.so"
+
+# Enable pin entry through external pinpad
+#set_var PKCS11_PINPAD  true
+
+# Use default Pin.
+# *This setting is UNSECURE*
+# Useful for testing and automatically logs the user in
+#set_var PKCS11_PIN		"1234"
+
+# Set PKCS11 Slot.
+# Find correct slot checking output of 'pkcs11-tool -L'
+#set_var PKCS11_SLOT	"0x0"
+
+# Set CA keypair label.
+#set_var PKCS11_LABEL	"EasyRSA-CA-Key"

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -234,15 +234,22 @@ set_var EASYRSA_PKCS11TOOL	"pkcs11-tool"
 # Useful for testing and automatically logs the user in
 #set_var PKCS11_PIN		"1234"
 
-# Set PKCS11 Slot.
+# Set PKCS11 Token URI (according to RFC 7512).
+# If using Yubikey check PKCS11.md, otherwise
+# find correct token checking the output of 'p11tool --list-tokens'.
+# (You might need to install gnutls-bin package.)
+#set_var PKCS11_TOKEN_URI	"pkcs11:model=SoftHSM%20v2;manufacturer=SoftHSM%20project;serial=390ab91a4f4faf7a;token=test-token;"
+
+# Set PKCS11 Slot ID.
 # Find correct slot checking output of 'pkcs11-tool -L'
-#set_var PKCS11_SLOT	"0x0"
+# Format is hex sequence, without leading '0x' characters.
+#set_var PKCS11_SLOT	"00"
 
 # Set CA keypair label.
 #set_var PKCS11_LABEL	"EasyRSA-CA-Key"
 
 # Set extra pkcs11-tool options.
-# Useful for different implementations (i.e. "--login-type so" for Yubikeys).
+# Might be useful for non-standard implementations.
 #set_var PKCS11_EXTRA_OPTIONS ""
 
 # Enable SO login when creating CA keys.

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -250,4 +250,4 @@ set_var EASYRSA_PKCS11TOOL	"pkcs11-tool"
 
 # Use default SO Pin
 # *This setting is UNSECURE*
-#set_var PKCS11_SOPIN "123456"
+#set_var PKCS11_SO_PIN "123456"

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -7,7 +7,7 @@
 # HOW TO USE THIS FILE
 #
 # vars.example contains built-in examples to Easy-RSA settings. You MUST name
-# this file 'vars' if you want it to be used as a configuration file. If you do
+# this file 'vars' if you want it to be usecat d as a configuration file. If you do
 # not, it WILL NOT be automatically read when you call easyrsa commands.
 #
 # It is not necessary to use this config file unless you wish to change
@@ -240,3 +240,14 @@ set_var EASYRSA_PKCS11TOOL	"pkcs11-tool"
 
 # Set CA keypair label.
 #set_var PKCS11_LABEL	"EasyRSA-CA-Key"
+
+# Set extra pkcs11-tool options.
+# Useful for different implementations (i.e. "--login-type so" for Yubikeys).
+#set_var PKCS11_EXTRA_OPTIONS ""
+
+# Enable SO login when creating CA keys.
+#set_var PKCS11_REQUIRE_SOPIN true
+
+# Use default SO Pin
+# *This setting is UNSECURE*
+#set_var PKCS11_SOPIN "123456"

--- a/op_test.orig
+++ b/op_test.orig
@@ -356,7 +356,11 @@ init_pki ()
 
 build_ca ()
 {
-	STEP_NAME="build-ca nopass"
+	if [ -z $TEST_PKCS11 ]; then
+		STEP_NAME="build-ca nopass"
+	else
+		STEP_NAME="build-ca pkcs11"
+	fi
 	export EASYRSA_REQ_CN="penelope"
 	action
 	unset EASYRSA_REQ_CN


### PR DESCRIPTION
Add support for PKCS11 tokens, based on initial proposal #332 in response to #268.
In comparison to previous implementation, this one makes use of [RFC 7512](https://tools.ietf.org/html/rfc7512) scheme to address tokens and keys, instead of legacy engine_PKCS11 ID (apparently going to be deprecated in openssl). 

Tested on Smartcard-HSM, Nitrokey HSM, Nitrokey Pro, SoftHSM2 and Yubikey 5 NFC. 

Introduces a new format for the `./pki/private/ca.key` which can specify environment variables to point to the PKCS#11 private key on a specific token.

Modification of `op_test.orig` support initial testing on SoftHSM2.

Please see `./PKCS11.md` for more details on the changes as well as tested configurations for Smartcard-HSM, Nitrokey HSM, Nitrokey Pro, SoftHSM2 and Yubikey 5 NFC.

Please share any useful feedback needed to get this PR merged.