### PR TITLE
Change $EASYRSA_SSL_CONF to correct default value

### DIFF
--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -199,7 +199,7 @@ fi
 # specific and you cannot just use a standard config file, so this is an
 # advanced feature.
 
-#set_var EASYRSA_SSL_CONF	"$EASYRSA/openssl-easyrsa.cnf"
+#set_var EASYRSA_SSL_CONF	"$EASYRSA_PKI/openssl-easyrsa.cnf"
 
 # Default CN:
 # This is best left alone. Interactively you will set this manually, and BATCH


### PR DESCRIPTION
The default value from the vars.example did not match the one from the script.
This fixes Issue #429