### PR TITLE
adjust critical extensions and key usage

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1115,7 +1115,7 @@ $(display_dn req "$req_in")
 
 		# Support a dynamic CA path length when present:
 		[ "$crt_type" = "ca" ] && [ -n "$EASYRSA_SUBCA_LEN" ] && \
-			print "basicConstraints = CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
+			print "basicConstraints = critical, CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
 
 		# Deprecated Netscape extension support, if enabled
 		if print "$EASYRSA_NS_SUPPORT" | awk_yesno; then

--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -123,7 +123,7 @@ basicConstraints = critical, CA:true
 
 # Limit key usage to CA tasks. If you really want to use the generated pair as
 # a self-signed cert, comment this out.
-keyUsage = critical, cRLSign, keyCertSign
+keyUsage = critical, cRLSign, digitalSignature, keyCertSign
 
 # nsCertType omitted by default. Let's try to let the deprecated stuff die.
 # nsCertType = sslCA

--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -119,11 +119,11 @@ authorityKeyIdentifier=keyid:always,issuer:always
 
 # This could be marked critical, but it's nice to support reading by any
 # broken clients who attempt to do so.
-basicConstraints = CA:true
+basicConstraints = critical, CA:true
 
 # Limit key usage to CA tasks. If you really want to use the generated pair as
 # a self-signed cert, comment this out.
-keyUsage = cRLSign, keyCertSign
+keyUsage = critical, cRLSign, keyCertSign
 
 # nsCertType omitted by default. Let's try to let the deprecated stuff die.
 # nsCertType = sslCA

--- a/easyrsa3/x509-types/ca
+++ b/easyrsa3/x509-types/ca
@@ -4,9 +4,9 @@
 # CA_PATH_LEN for CA path length limits. You could also do this here
 # manually as in the following example in place of the existing line:
 #
-# basicConstraints = CA:TRUE, pathlen:1
+# basicConstraints = critical, CA:TRUE, pathlen:1
 
-basicConstraints = CA:TRUE
+basicConstraints = critical, CA:TRUE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer:always
-keyUsage = cRLSign, keyCertSign
+keyUsage = critical, cRLSign, keyCertSign

--- a/easyrsa3/x509-types/ca
+++ b/easyrsa3/x509-types/ca
@@ -9,4 +9,4 @@
 basicConstraints = critical, CA:TRUE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer:always
-keyUsage = critical, cRLSign, keyCertSign
+keyUsage = critical, cRLSign, digitalSignature, keyCertSign

--- a/easyrsa3/x509-types/client
+++ b/easyrsa3/x509-types/client
@@ -4,4 +4,4 @@ basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 extendedKeyUsage = clientAuth
-keyUsage = digitalSignature
+keyUsage = critical, digitalSignature

--- a/easyrsa3/x509-types/code-signing
+++ b/easyrsa3/x509-types/code-signing
@@ -3,5 +3,5 @@
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
-extendedKeyUsage = codeSigning
-keyUsage = digitalSignature
+extendedKeyUsage = critical, codeSigning
+keyUsage = critical, digitalSignature

--- a/easyrsa3/x509-types/server
+++ b/easyrsa3/x509-types/server
@@ -4,4 +4,4 @@ basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 extendedKeyUsage = serverAuth
-keyUsage = digitalSignature,keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment

--- a/easyrsa3/x509-types/serverClient
+++ b/easyrsa3/x509-types/serverClient
@@ -4,4 +4,4 @@ basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 extendedKeyUsage = serverAuth,clientAuth
-keyUsage = digitalSignature,keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment


### PR DESCRIPTION
I would like to use easy-rsa to manage some general purpose PKI. This change makes it conform to common practice.

supersedes #187 