### PR TITLE
openssl: don't use -keyout if -key is present

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -699,7 +699,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 
 	#shellcheck disable=SC2086
 	easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
-		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
+		-out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
 		die "Failed to build the CA"
 
 	mv "$out_key_tmp" "$out_key"


### PR DESCRIPTION
The OpenSSL 1.1.1l states that

> -keyout filename:
> This gives the filename to write the newly created private key to.
> If this option is not specified then the filename present in the
> configuration file is used.

We can thus conclude that in this configuration, the option is useless
as we provide the `-key` argument.

However, the OpenSSL 3.0 states that:

> -keyout filename:
> This gives the filename to write any private key to that has been newly
> created or read from -key.  If neither the -keyout option nor the -key
> option are given then the filename specified in the configuration file
> with the default_keyfile option is used, if present. Thus, if you want
> to write the private key and the -key option is provided, you should
> provide the -keyout option explicitly. If a new key is generated and no
> filename is specified the key is written to standard output.

This means that, since we have the same argument in -key and -keyout,
the file is overwritten. However, before writing out the new key,
`openssl` asks for a passphrase. Since we already have the correct key
in the correct file, we can simply omit the option, and all should be
well.

Closes #454.