### PR TITLE
Introduce support for OpenSSL version 3

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -459,6 +459,12 @@ verify_ssl_lib () {
 		val="$("$EASYRSA_OPENSSL" version)"
 		case "${val%% *}" in
 			OpenSSL|LibreSSL)
+				osslv_major="${val#* }"
+				osslv_major="${osslv_major%%.*}"
+				case "$osslv_major" in
+					1|3) : ;; # OK
+					*) die "Unsupported SSL library: $osslv_major"
+				esac
 				print "\
 Using SSL: $EASYRSA_OPENSSL $("$EASYRSA_OPENSSL" version)" ;;
 			*) die "\
@@ -674,6 +680,79 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
             fi
         fi
 	fi
+
+	# Generate the CA with AES256
+
+	# => BEGIN SSL lib version
+	case "$osslv_major" in
+
+	# BEGIN SSL V3
+	3)
+		# OpenSSL v3: '-nodes' is deprecate, use '-noenc'
+		unset -v no_password; [ -z "$nopass" ] || no_password='-noenc'
+
+		# Generate CA
+		case "$EASYRSA_ALGO" in
+		rsa)
+			# OpenSSL v3: 'genrsa' is deprecate, use 'req'
+				easyrsa_openssl req -utf8 "${no_password}" \
+					-newkey "$EASYRSA_ALGO":"$EASYRSA_KEY_SIZE" \
+					-keyout "$out_key_tmp" -out "$out_file_tmp" \
+					${opts} ${crypto_opts} \
+					${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
+						die "Failed to build the CA" ;;
+		ec)
+			# EC params
+			param_file="$(easyrsa_mktemp)"
+			easyrsa_openssl ecparam -name "$EASYRSA_CURVE" > "$param_file"
+
+				easyrsa_openssl req -utf8 "${no_password}" \
+					-newkey "$EASYRSA_ALGO":"$param_file" \
+					-keyout "$out_key_tmp" -out "$out_file_tmp" \
+					${opts} ${crypto_opts} \
+					${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
+						die "Failed to build the CA" ;;
+		ed)
+			# OpenSSL v3: 'genpkey' is not compatible with:
+			# easyrsa $opts, do NOT use
+			# easyrsa $no_password, do NOT use
+			case "$EASYRSA_CURVE" in
+			ed25519)
+				easyrsa_openssl genpkey -algorithm "$EASYRSA_CURVE" \
+					-out "$out_key_tmp" \
+					${crypto_opts} \
+					${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key" ;;
+			ed448)
+				easyrsa_openssl genpkey -algorithm "$EASYRSA_CURVE" \
+					-out "$out_key_tmp" \
+					${crypto_opts} \
+					${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key" ;;
+			*)
+				die "Unknown curve: $EASYRSA_CURVE"
+			esac
+
+			# create the CA keypair:
+			crypto_opts=""
+			[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && \
+				crypto_opts="-passin file:$out_key_pass_tmp"
+
+			# shellcheck disable=SC2086
+			easyrsa_openssl req -utf8 "${no_password}" -new -key "$out_key_tmp" \
+				-keyout "$out_key_tmp" -out "$out_file_tmp" \
+				${opts} ${crypto_opts} \
+				${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
+					die "Failed to build the CA" ;;
+		*)
+			die "Unknown algorithm: $EASYRSA_ALGO"
+		esac
+	;;
+	# END SSL V3
+
+	# BEGIN SSL V1
+	1)
+
 	if [ "$EASYRSA_ALGO" = "rsa" ]; then
 		#shellcheck disable=SC2086
 		"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} "$EASYRSA_ALGO_PARAMS" || \
@@ -701,6 +780,13 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
 		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
 		die "Failed to build the CA"
+	;;
+	# END SSL V1
+
+	*) die "build-ca ssl lib: $osslv_major"
+
+	# => END SSL lib version
+	esac
 
 	mv "$out_key_tmp" "$out_key"
 	mv "$out_file_tmp" "$out_file"


### PR DESCRIPTION
Required changes:

* Use 'verify_ssl_lib()' to determine SSL Library version.
  Returns '1', '3' OR error.

* Replace openssl paramater '-nodes' [DEPRECATED], with '-noenc'.
  Ref: https://www.openssl.org/docs/man3.0/man1/openssl-req.html
  This effects All Easy-RSA CAs built using OpenSSL version 3.

* Replace openssl command 'genrsa' [DEPRECATED], with 'req'.
  Ref: https://www.openssl.org/docs/man3.0/man1/openssl-genrsa.html
  This effects Easy-RSA 'RSA' CAs built using OpenSSL version 3.

* Edwards Curve CAs must ignore easyrsa $opts and $no_password.
  OpenSSL 'genpkey' does not accpet the parameters defined.

Optional changes:

* Use 'easyrsa_openssl()' wrapper function to build All CAs.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>