### PR TITLE
Introduce support for OpenSSL version 3

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -450,12 +450,8 @@ $out"
 
 # Verify if Edward Curve exists
 verify_curve_ed() {
-	if [ "ed25519" = "$EASYRSA_CURVE" ] && "$EASYRSA_OPENSSL" genpkey -algorithm ED25519 > /dev/null; then
-		return 0
-	elif [ "ed448" = "$EASYRSA_CURVE" ] && "$EASYRSA_OPENSSL" genpkey -algorithm ED448 > /dev/null; then
-		return 0
-	fi
-		die "Curve $EASYRSA_CURVE not found."
+	easyrsa_openssl genpkey -algorithm "$EASYRSA_CURVE" > /dev/null && return 0
+	die "Edward Curve $EASYRSA_CURVE not found."
 }
 
 verify_ssl_lib () {
@@ -699,26 +695,22 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 				-out "$out_key_tmp" ${crypto_opts} \
 				-pkeyopt rsa_keygen_bits:"$EASYRSA_ALGO_PARAMS" \
 				${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-					die "Failed create CA private key" ;;
+					die "Failed create CA private key"
+		;;
 		ec)
 			easyrsa_openssl genpkey -paramfile "$EASYRSA_ALGO_PARAMS" \
 				-out "$out_key_tmp" ${crypto_opts} \
 				${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-					die "Failed create CA private key" ;;
+					die "Failed create CA private key"
+		;;
 		ed)
 			case "$EASYRSA_CURVE" in
-			ed25519)
+			[eE][dD]25519|[eE][dD]448)
 				easyrsa_openssl genpkey -algorithm "$EASYRSA_CURVE" \
 					-out "$out_key_tmp" ${crypto_opts} \
 					${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
 						die "Failed create CA private key" ;;
-			ed448)
-				easyrsa_openssl genpkey -algorithm "$EASYRSA_CURVE" \
-					-out "$out_key_tmp" ${crypto_opts} \
-					${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-						die "Failed create CA private key" ;;
-			*)
-				die "Unknown curve: $EASYRSA_CURVE"
+			*)	die "Unknown curve: $EASYRSA_CURVE"
 			esac
 		;;
 		*)
@@ -745,7 +737,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 
 	# BEGIN SSL V1
 	1)
-		# create the CA key using AES256
+		# If encrypted then create the CA key using AES256 cipher ($crypto)
 		crypto_opts=""
 		if [ ! $nopass ]; then
 			crypto_opts="$crypto"
@@ -758,28 +750,33 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			fi
 		fi
 
+		# create the CA key
 		#shellcheck disable=SC2086
-		if [ "$EASYRSA_ALGO" = "rsa" ]; then
+		case "$EASYRSA_ALGO" in
+		rsa)
 			"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts \
 				${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} \
 				"$EASYRSA_ALGO_PARAMS" || \
 					die "Failed create CA private key"
-		elif [ "$EASYRSA_ALGO" = "ec" ]; then
+		;;
+		ec)
 			"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
 				"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts \
 					${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
 						die "Failed create CA private key"
-		elif [ "ed" = "$EASYRSA_ALGO" ]; then
-			if [ "ed25519" = "$EASYRSA_CURVE" ]; then
-				"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out "$out_key_tmp" \
-					$crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-						die "Failed create CA private key"
-			elif [ "ed448" = "$EASYRSA_CURVE" ]; then
-				"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out "$out_key_tmp" \
-					$crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-						die "Failed create CA private key"
-			fi
-		fi
+		;;
+		ed)
+			case "$EASYRSA_CURVE" in
+			[eE][dD]25519|[eE][dD]448)
+				"$EASYRSA_OPENSSL" genpkey -algorithm "$EASYRSA_CURVE" \
+					-out "$out_key_tmp" $crypto_opts \
+					${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key" ;;
+			*)	die "Unknown curve: $EASYRSA_CURVE"
+			esac
+		;;
+		*)	die "Unknown algorithm: $EASYRSA_ALGO"
+		esac
 
 		# create the CA keypair:
 		crypto_opts=""
@@ -1844,13 +1841,12 @@ Note: using Easy-RSA configuration from: $vars"
 	fi
 
 	# EASYRSA_ALGO_PARAMS must be set depending on selected algo
-	if [ "ec" = "$EASYRSA_ALGO" ]; then
-		EASYRSA_ALGO_PARAMS="$EASYRSA_EC_DIR/${EASYRSA_CURVE}.pem"
-	elif [ "rsa" = "$EASYRSA_ALGO" ]; then
-		EASYRSA_ALGO_PARAMS="${EASYRSA_KEY_SIZE}"
-	elif [ "ed" != "$EASYRSA_ALGO" ]; then
-		die "Alg '$EASYRSA_ALGO' is invalid: must be 'rsa', 'ec' or 'ed' "
-	fi
+	case "$EASYRSA_ALGO" in
+	ec)		EASYRSA_ALGO_PARAMS="$EASYRSA_EC_DIR/${EASYRSA_CURVE}.pem" ;;
+	rsa)	EASYRSA_ALGO_PARAMS="${EASYRSA_KEY_SIZE}" ;;
+	ed)		: ;; # ok
+	*)		die "Alg '$EASYRSA_ALGO' is invalid: must be 'rsa', 'ec' or 'ed' "
+	esac
 
 	# Assign value to $EASYRSA_TEMP_DIR_session and work around Windows mktemp bug when parent dir is missing
 	if [ -z "$EASYRSA_TEMP_DIR_session" ]; then

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -351,7 +351,7 @@ easyrsa_openssl() {
 
 	case $openssl_command in
 		makesafeconf) has_config=true;;
-		ca|req|srp|ts) has_config=true;;
+		ca|req|srp|ts|genpkey) has_config=true;;
 		*) has_config=false;;
 	esac
 
@@ -452,6 +452,13 @@ verify_ssl_lib () {
 		val="$("$EASYRSA_OPENSSL" version)"
 		case "${val%% *}" in
 			OpenSSL|LibreSSL)
+				osslv_major="${val#* }"
+				osslv_major="${osslv_major%%.*}"
+				case "$osslv_major" in
+					1) no_password='-nodes' ;;
+					3) no_password='-noenc' ;;
+					*) die "Unsupported SSL library: $osslv_major"
+				esac
 				print "\
 Using SSL: $EASYRSA_OPENSSL $("$EASYRSA_OPENSSL" version)" ;;
 			*) die "\
@@ -667,33 +674,98 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
             fi
         fi
 	fi
-	if [ "$EASYRSA_ALGO" = "rsa" ]; then
-		#shellcheck disable=SC2086
-		"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} "$EASYRSA_ALGO_PARAMS" || \
-			die "Failed create CA private key"
-	elif [ "$EASYRSA_ALGO" = "ec" ]; then
-		#shellcheck disable=SC2086
-		"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
-			"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
-			die "Failed create CA private key"
-	elif [ "ed" = "$EASYRSA_ALGO" ]; then
-		if [ "ed25519" = "$EASYRSA_CURVE" ]; then
-			"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-			die "Failed create CA private key"
-		elif [ "ed448" = "$EASYRSA_CURVE" ]; then
-			"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-			die "Failed create CA private key"
+
+	# Choose SSL Library version (1 or 3) and build CA
+	case "$osslv_major" in # => BEGIN SSL lib version
+
+	# BEGIN SSL V3
+	3)
+		# Generate CA Key - OpenSSL v3 'genpkey' is not compatible
+		# with easyrsa $opts and $no_password, do NOT use them here
+		# shellcheck disable=SC2086 # Ignore unquoted variables
+		case "$EASYRSA_ALGO" in
+		rsa)
+			# OpenSSL v3: 'genrsa' is deprecate, use 'genpkey'
+			easyrsa_openssl genpkey -algorithm "$EASYRSA_ALGO" \
+				-out "$out_key_tmp" ${crypto_opts} \
+				-pkeyopt rsa_keygen_bits:"$EASYRSA_ALGO_PARAMS" \
+				${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+					die "Failed create CA private key" ;;
+		ec)
+			easyrsa_openssl genpkey -paramfile "$EASYRSA_ALGO_PARAMS" \
+				-out "$out_key_tmp" ${crypto_opts} \
+				${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+					die "Failed create CA private key" ;;
+		ed)
+			case "$EASYRSA_CURVE" in
+			ed25519)
+				easyrsa_openssl genpkey -algorithm "$EASYRSA_CURVE" \
+					-out "$out_key_tmp" ${crypto_opts} \
+					${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key" ;;
+			ed448)
+				easyrsa_openssl genpkey -algorithm "$EASYRSA_CURVE" \
+					-out "$out_key_tmp" ${crypto_opts} \
+					${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key" ;;
+			*)
+				die "Unknown curve: $EASYRSA_CURVE"
+			esac
+		;;
+		*)
+			die "Unknown algorithm: $EASYRSA_ALGO"
+		esac
+
+		# OpenSSL v3: '-nodes' is deprecate, use '-noenc'
+		unset -v no_password; [ ! $nopass ] || no_password='-noenc'
+
+		# create the CA keypair:
+		crypto_opts=""
+		[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && \
+			crypto_opts="-passin file:$out_key_pass_tmp"
+
+		# shellcheck disable=SC2086
+		easyrsa_openssl req -utf8 "${no_password}" -new -key "$out_key_tmp" \
+			-keyout "$out_key_tmp" -out "$out_file_tmp" ${opts} ${crypto_opts} \
+			${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
+				die "Failed to build the CA"
+	;;
+	# END SSL V3
+
+	# BEGIN SSL V1
+	1)
+		if [ "$EASYRSA_ALGO" = "rsa" ]; then
+			#shellcheck disable=SC2086
+			"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} "$EASYRSA_ALGO_PARAMS" || \
+				die "Failed create CA private key"
+		elif [ "$EASYRSA_ALGO" = "ec" ]; then
+			#shellcheck disable=SC2086
+			"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
+				"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
+				die "Failed create CA private key"
+		elif [ "ed" = "$EASYRSA_ALGO" ]; then
+			if [ "ed25519" = "$EASYRSA_CURVE" ]; then
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+				die "Failed create CA private key"
+			elif [ "ed448" = "$EASYRSA_CURVE" ]; then
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+				die "Failed create CA private key"
+			fi
 		fi
-	fi
 
-	# create the CA keypair:
-	crypto_opts=""
-	[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && crypto_opts="-passin file:$out_key_pass_tmp"
+		# create the CA keypair:
+		crypto_opts=""
+		[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && crypto_opts="-passin file:$out_key_pass_tmp"
 
-	#shellcheck disable=SC2086
-	easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
-		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
-		die "Failed to build the CA"
+		#shellcheck disable=SC2086
+		easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
+			-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
+			die "Failed to build the CA"
+	;;
+	# END SSL V1
+
+	*)	die "build-ca ssl lib: $osslv_major"
+	esac # => END SSL lib version
 
 	mv "$out_key_tmp" "$out_key"
 	mv "$out_file_tmp" "$out_file"
@@ -751,11 +823,14 @@ Run easyrsa without commands for usage and commands."
 	[ ! "$EASYRSA_BATCH" ] && EASYRSA_REQ_CN="$1"
 	shift
 
+	# Require SSL Lib version for 'nopass' -> $no_password
+	verify_pki_init
+
 	# function opts support
 	opts=
 	while [ -n "$1" ]; do
 		case "$1" in
-			nopass) opts="$opts -nodes" ;;
+			nopass) opts="$opts $no_password" ;;
 			# batch flag supports internal callers needing silent operation
 			batch) EASYRSA_BATCH=1 ;;
 			*) warn "Ignoring unknown command option: '$1'" ;;
@@ -763,7 +838,6 @@ Run easyrsa without commands for usage and commands."
 		shift
 	done
 
-	verify_pki_init
 	[ "$EASYRSA_ALGO" = "ec" ] && verify_curve_ec
 	[ "$EASYRSA_ALGO" = "ed" ] && verify_curve_ed
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -759,11 +759,11 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 						die "Failed create CA private key"
 		elif [ "ed" = "$EASYRSA_ALGO" ]; then
 			if [ "ed25519" = "$EASYRSA_CURVE" ]; then
-				"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp \
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out "$out_key_tmp" \
 					$crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
 						die "Failed create CA private key"
 			elif [ "ed448" = "$EASYRSA_CURVE" ]; then
-				"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp \
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out "$out_key_tmp" \
 					$crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
 						die "Failed create CA private key"
 			fi
@@ -779,7 +779,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 
 		#shellcheck disable=SC2086
 		easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
-		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts \
+			-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts \
 			${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
 				die "Failed to build the CA"
 	;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -680,6 +680,16 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 
 	# BEGIN SSL V3
 	3)
+		# If encrypted then create the CA key using AES256 cipher ($crypto)
+		# 'genpkey' requires '-pass'
+		crypto_opts=""
+		if [ ! $nopass ]; then
+			crypto_opts="$crypto"
+			if [ -z "$EASYRSA_PASSOUT" ]; then
+				crypto_opts="$crypto_opts -pass file:$out_key_pass_tmp"
+			fi
+		fi
+
 		# Generate CA Key - OpenSSL v3 'genpkey' is not compatible
 		# with easyrsa $opts and $no_password, do NOT use them here
 		# shellcheck disable=SC2086 # Ignore unquoted variables
@@ -717,6 +727,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		esac
 
 		# Private key encryption password or use no_password
+		# 'req' requires '-passin'
 		crypto_opts=""
 		if [ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ]; then
 			crypto_opts="-passin file:$out_key_pass_tmp"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -908,11 +908,11 @@ $EASYRSA_EXTRA_EXTS"
 	# shellcheck disable=2086,2148
 	algo_opts=""
 	if [ "ed" = "$EASYRSA_ALGO" ]; then
-		algo_opts=" -newkey $EASYRSA_CURVE "
+		algo_opts="$EASYRSA_CURVE"
 	else
-		algo_opts=" -newkey $EASYRSA_ALGO:$EASYRSA_ALGO_PARAMS "
+		algo_opts="$EASYRSA_ALGO:$EASYRSA_ALGO_PARAMS"
 	fi
-	easyrsa_openssl req -utf8 -new $algo_opts \
+	easyrsa_openssl req -utf8 -new -newkey "$algo_opts" \
 		-keyout "$key_out_tmp" -out "$req_out_tmp" $opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} \
 		|| die "Failed to generate request"
 	mv "$key_out_tmp" "$key_out"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -716,17 +716,18 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 			die "Unknown algorithm: $EASYRSA_ALGO"
 		esac
 
-		# OpenSSL v3: '-nodes' is deprecate, use '-noenc'
-		unset -v no_password; [ ! $nopass ] || no_password='-noenc'
+		# Private key encryption password or use no_password
+		crypto_opts=""
+		if [ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ]; then
+			crypto_opts="-passin file:$out_key_pass_tmp"
+		else
+			crypto_opts="$no_password"
+		fi
 
 		# create the CA keypair:
-		crypto_opts=""
-		[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && \
-			crypto_opts="-passin file:$out_key_pass_tmp"
-
 		# shellcheck disable=SC2086
-		easyrsa_openssl req -utf8 "${no_password}" -new -key "$out_key_tmp" \
-			-keyout "$out_key_tmp" -out "$out_file_tmp" ${opts} ${crypto_opts} \
+		easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
+			-out "$out_file_tmp" ${opts} ${crypto_opts} \
 			${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
 				die "Failed to build the CA"
 	;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -351,8 +351,20 @@ easyrsa_openssl() {
 
 	case $openssl_command in
 		makesafeconf) has_config=true;;
-		ca|req|srp|ts|genpkey) has_config=true;;
+		ca|req|srp|ts) has_config=true;;
 		*) has_config=false;;
+	esac
+
+	case "$osslv_major" in
+	3)
+		case $openssl_command in
+		genpkey) has_config=true;;
+		*) : ;; # ok
+		esac
+	;;
+	1)	: ;; # ok
+	'')	: ;; # Unset then this is init-pki
+	*)	die "Unsupported openssl version: $osslv_major"
 	esac
 
 	if ! $has_config; then

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -662,19 +662,6 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		fi
 	fi
 
-	# create the CA key using AES256
-	crypto_opts=""
-	if [ ! $nopass ]; then
-		crypto_opts="$crypto"
-		if [ -z "$EASYRSA_PASSOUT" ]; then
-		    if [ "ed" = "$EASYRSA_ALGO" ]; then
-                crypto_opts="$crypto_opts -pass file:$out_key_pass_tmp"
-            else
-                crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
-            fi
-        fi
-	fi
-
 	# Choose SSL Library version (1 or 3) and build CA
 	case "$osslv_major" in # => BEGIN SSL lib version
 
@@ -746,33 +733,55 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 
 	# BEGIN SSL V1
 	1)
+		# create the CA key using AES256
+		crypto_opts=""
+		if [ ! $nopass ]; then
+			crypto_opts="$crypto"
+			if [ -z "$EASYRSA_PASSOUT" ]; then
+				if [ "ed" = "$EASYRSA_ALGO" ]; then
+					crypto_opts="$crypto_opts -pass file:$out_key_pass_tmp"
+				else
+					crypto_opts="$crypto_opts -passout file:$out_key_pass_tmp"
+				fi
+			fi
+		fi
+
+		#shellcheck disable=SC2086
 		if [ "$EASYRSA_ALGO" = "rsa" ]; then
-			#shellcheck disable=SC2086
-			"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} "$EASYRSA_ALGO_PARAMS" || \
-				die "Failed create CA private key"
+			"$EASYRSA_OPENSSL" genrsa -out "$out_key_tmp" $crypto_opts \
+				${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} \
+				"$EASYRSA_ALGO_PARAMS" || \
+					die "Failed create CA private key"
 		elif [ "$EASYRSA_ALGO" = "ec" ]; then
-			#shellcheck disable=SC2086
 			"$EASYRSA_OPENSSL" ecparam -in "$EASYRSA_ALGO_PARAMS" -genkey | \
-				"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts ${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
-				die "Failed create CA private key"
+				"$EASYRSA_OPENSSL" ec -out "$out_key_tmp" $crypto_opts \
+					${EASYRSA_PASSOUT:+-passout "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key"
 		elif [ "ed" = "$EASYRSA_ALGO" ]; then
 			if [ "ed25519" = "$EASYRSA_CURVE" ]; then
-				"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-				die "Failed create CA private key"
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED25519 -out $out_key_tmp \
+					$crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key"
 			elif [ "ed448" = "$EASYRSA_CURVE" ]; then
-				"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp $crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
-				die "Failed create CA private key"
+				"$EASYRSA_OPENSSL" genpkey -algorithm ED448 -out $out_key_tmp \
+					$crypto_opts ${EASYRSA_PASSOUT:+-pass "$EASYRSA_PASSOUT"} || \
+						die "Failed create CA private key"
 			fi
 		fi
 
 		# create the CA keypair:
 		crypto_opts=""
-		[ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ] && crypto_opts="-passin file:$out_key_pass_tmp"
+		if [ ! $nopass ] && [ -z "$EASYRSA_PASSIN" ]; then
+			crypto_opts="-passin file:$out_key_pass_tmp"
+		else
+			crypto_opts="$no_password"
+		fi
 
 		#shellcheck disable=SC2086
 		easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
-			-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts ${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
-			die "Failed to build the CA"
+		-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts \
+			${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
+				die "Failed to build the CA"
 	;;
 	# END SSL V1
 


### PR DESCRIPTION
Required changes:

* Use 'verify_ssl_lib()' to determine SSL Library version.
  Returns '1', '3' OR error.
  Sets 'no_password' to either '-nodes' (SSLv1) or '-noenc' (SSLv3)

* Replace OpenSSL paramater '-nodes' [DEPRECATED], with '-noenc'.
  Ref: https://www.openssl.org/docs/man3.0/man1/openssl-req.html
  This effects All Easy-RSA CAs built using OpenSSL version 3.

* Replace OpenSSL command 'genrsa' [DEPRECATED], with 'genpkey'.
  Ref: https://www.openssl.org/docs/man3.0/man1/openssl-genrsa.html
  This effects Easy-RSA 'RSA' CAs built using OpenSSL version 3.
  OpenSSL advises using 'genpkey' over 'genrsa'.

* OpenSSL 'genpkey' does not accept the parameters defined by
  easyrsa $opts and $no_password when generating CA private keys.
  Do not use these variables for OpenSSL-v3 'genpkey'.

Optional changes:

* Use 'easyrsa_openssl()' wrapper function to build All CAs.

* Add 'genpkey' to easyrsa_openssl() wrapper, to include using the
  EasyRSA/OpenSSL Configuration file $EASYRSA_SAFE_CONF.

* Change EasyRSA Elliptic Curve (ec) CA's to also use OpenSSL 'genpkey',
  instead of OpenSSL 'ec'.  This change is not required, however, this
  means that all EasyRSA CA Private keys are created using 'genpkey'
  with OpenSSL v3.

* EasyRSA 'gen_req()' is the only other code which uses OpenSSL '-nodes'.
  Make 'gen_req()' aware of the SSL Library version and therefore the
  correct parameter for an unencrypted private key. (-noenc vs -nodes)
  Note: OpenSSL '-nodes' is only deprecated not removed.

* Indent OpenSSL version 1 code block to match. No functional changes.

Tests Passed:

Full extended unit tests, with both OpenSSL version 1.1.x and 3.0.1
(Includes standard test for Edwards Curve PKI)

Manual building of All OpenSSL *v3* CAs with passwords and subsequent
building and signing of a server or client certificate.

Manual building of OpenSSL *v1* EC CA with password and subsequent
building and signing of a server or client certificate.
Tested due to changing CA key from OpenSSL 'ec' to 'genpkey'.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>