### PR TITLE
improve init-pki config import behaviour (draft)

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -558,12 +558,35 @@ and initialize a fresh PKI here."
 		mkdir -p "$EASYRSA_PKI/$i" || die "Failed to create PKI file structure (permissions?)"
 	done
 
-	# Create $EASYRSA_SAFE_CONF ($OPENSSL_CONF) prevents bogus warnings (especially useful on win32)
-	if [ ! -f "$EASYRSA_SSL_CONF" ] && [ -f "$EASYRSA/openssl-easyrsa.cnf" ];
+
+	# import default openssl-easyrsa.cnf into $EASYRSA_PKI, if no other config is specified, and if it doesn't exist already
+	if [ ! -f "$EASYRSA_SSL_CONF" ] && [ ! -f "$EASYRSA_PKI/openssl-easyrsa.cnf" ];
 	then
-		cp "$EASYRSA/openssl-easyrsa.cnf" "$EASYRSA_SSL_CONF"
-		easyrsa_openssl makesafeconf
+		# Default Config Location, if pulled directly from GitHub
+		if [ -f "$EASYRSA/openssl-easyrsa.cnf" ];
+		then
+			cp "$EASYRSA/openssl-easyrsa.cnf" "$EASYRSA_PKI/openssl-easyrsa.cnf"
+		# Default Config Location User
+		elif [ -f "$XDG_CONFIG_HOME/easy-rsa/openssl-easyrsa.cnf" ];
+		then
+			cp "$XDG_CONFIG_HOME/easy-rsa/openssl-easyrsa.cnf" "$EASYRSA_PKI/openssl-easyrsa.cnf"
+		# Default Config Location system wide
+		elif [ -f "/etc/easy-rsa/openssl-easyrsa.cnf" ];
+		then
+			cp "/etc/easy-rsa/openssl-easyrsa.cnf" "$EASYRSA_PKI/openssl-easyrsa.cnf"
+		# Detault Config Location system wide (possible alternative)
+		elif [ -f "/usr/etc/easy-rsa/openssl-easyrsa.cnf" ];
+		then
+			cp "/usr/etc/easy-rsa/openssl-easyrsa.cnf" "$EASYRSA_PKI/openssl-easyrsa.cnf"
+		else
+			die "Default openssl-easyrsa.cnf not found!"
+		fi
+		EASYRSA_SSL_CONF="$EASYRSA_PKI/openssl-easyrsa.cnf"
 	fi
+	
+	# Create $EASYRSA_SAFE_CONF ($OPENSSL_CONF) prevents bogus warnings (especially useful on win32) 
+	[ -f "$EASYRSA_SSL_CONF" ] && easyrsa_openssl makesafeconf  || die "$EASYRSA_SSL_CONF does not exist!"
+
 
 	notice "\
 init-pki complete; you may now create a CA or requests.


### PR DESCRIPTION
If no - or a nonexistent - configuration file is specified in `$EASYRSA_SSL_CONFIG`
a default configuration is imported from a standard location before calling `easyrsa_openssl makesafeconf`.

This is a first draft, and was not tested properly.
Proposed Answer to #429 