### PR TITLE
adjust Authority Key Identifier X.509 extension

### DIFF
--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -113,7 +113,7 @@ serialNumber_default	= $ENV::EASYRSA_REQ_SERIAL
 [ basic_exts ]
 basicConstraints	= CA:FALSE
 subjectKeyIdentifier	= hash
-authorityKeyIdentifier	= keyid,issuer:always
+authorityKeyIdentifier	= keyid:always
 
 # The Easy-RSA CA extensions
 [ easyrsa_ca ]
@@ -121,7 +121,6 @@ authorityKeyIdentifier	= keyid,issuer:always
 # PKIX recommendations:
 
 subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid:always,issuer:always
 
 # This could be marked critical, but it's nice to support reading by any
 # broken clients who attempt to do so.
@@ -143,4 +142,4 @@ keyUsage = cRLSign, keyCertSign
 # Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
 
 # issuerAltName=issuer:copy
-authorityKeyIdentifier=keyid:always,issuer:always
+authorityKeyIdentifier=keyid:always

--- a/easyrsa3/x509-types/ca
+++ b/easyrsa3/x509-types/ca
@@ -8,5 +8,5 @@
 
 basicConstraints = CA:TRUE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer:always
+authorityKeyIdentifier = keyid:always
 keyUsage = cRLSign, keyCertSign

--- a/easyrsa3/x509-types/client
+++ b/easyrsa3/x509-types/client
@@ -2,6 +2,6 @@
 
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
+authorityKeyIdentifier = keyid:always
 extendedKeyUsage = clientAuth
 keyUsage = digitalSignature

--- a/easyrsa3/x509-types/code-signing
+++ b/easyrsa3/x509-types/code-signing
@@ -2,6 +2,6 @@
 
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
+authorityKeyIdentifier = keyid:always
 extendedKeyUsage = codeSigning
 keyUsage = digitalSignature

--- a/easyrsa3/x509-types/email
+++ b/easyrsa3/x509-types/email
@@ -2,6 +2,6 @@
 
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
+authorityKeyIdentifier = keyid:always
 extendedKeyUsage = emailProtection
 keyUsage = digitalSignature,keyEncipherment,nonRepudiation

--- a/easyrsa3/x509-types/kdc
+++ b/easyrsa3/x509-types/kdc
@@ -2,7 +2,7 @@
 
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
+authorityKeyIdentifier = keyid:always
 extendedKeyUsage = 1.3.6.1.5.2.3.5
 keyUsage = nonRepudiation,digitalSignature,keyEncipherment,keyAgreement
 issuerAltName = issuer:copy

--- a/easyrsa3/x509-types/server
+++ b/easyrsa3/x509-types/server
@@ -2,6 +2,6 @@
 
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
+authorityKeyIdentifier = keyid:always
 extendedKeyUsage = serverAuth
 keyUsage = digitalSignature,keyEncipherment

--- a/easyrsa3/x509-types/serverClient
+++ b/easyrsa3/x509-types/serverClient
@@ -2,6 +2,6 @@
 
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
+authorityKeyIdentifier = keyid:always
 extendedKeyUsage = serverAuth,clientAuth
 keyUsage = digitalSignature,keyEncipherment


### PR DESCRIPTION
remove AKI issuer from every X.509 types
remove AKI completely for self-signed root CA

fix #417

This change was commited 8 months ago in my local repo. Tested in Web Browser and EAP-TLS as my private PKI. Not tested against OpenVPN though.