### PR TITLE
Insert non-functional code: install_data_to_pki()

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -680,7 +680,7 @@ install_data_to_pki () {
 
 # Copy the source to the PKI
 copy_data_to_pki () {
-	cp ${2:+-r} "$1" "$EASYRSA_PKI"
+	cp ${2:+-R} "$1" "$EASYRSA_PKI"
 } # => copy_data_to_pki ()
 
 # Disable terminal echo, if possible, otherwise warn

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -559,11 +559,15 @@ and initialize a fresh PKI here."
 		mkdir -p "$EASYRSA_PKI/$i" || die "Failed to create PKI file structure (permissions?)"
 	done
 
-	# Create $EASYRSA_SAFE_CONF ($OPENSSL_CONF) prevents bogus warnings (especially useful on win32)
-	if [ ! -f "$EASYRSA_SSL_CONF" ] && [ -f "$EASYRSA/openssl-easyrsa.cnf" ];
-	then
-		cp "$EASYRSA/openssl-easyrsa.cnf" "$EASYRSA_SSL_CONF"
-		easyrsa_openssl makesafeconf
+	# Install data-files into ALL new PKIs
+	install_data_to_pki || die "Failed to install required data-files to PKI."
+
+	# Verify that $EASYRSA_SAFE_CONF exists ($OPENSSL_CONF)
+	# Prevents bogus warnings (especially useful on win32)
+	if [ -n "$EASYRSA_SAFE_CONF" ] && [ -e "$EASYRSA_SAFE_CONF" ]; then
+		: # ok
+	else
+		die "init-pki failed to create safe SSL conf: $EASYRSA_SAFE_CONF"
 	fi
 
 	notice "\
@@ -787,9 +791,8 @@ install_data_to_pki () {
 		fi
 	fi
 
-	# Check or error
-	easyrsa_openssl makesafeconf || \
-		die "Failed to make safe SSL config file in PKI."
+	# Complete or error
+	[ -e "$EASYRSA_PKI_SAFE_CONF" ] || easyrsa_openssl makesafeconf
 } # => install_data_to_pki ()
 
 # Copy the source to the PKI
@@ -2089,10 +2092,12 @@ Note: using Easy-RSA configuration from: $vars"
 			else
 
 			#TODO: This should be removed.  Not really suitable for packaging.
-			set_var EASYRSA_EXT_DIR		"$EASYRSA/x509-types"
+			#set_var EASYRSA_EXT_DIR		"$EASYRSA/x509-types"
 
+			# Hard break from 'old' Easy-RSA, see obsolete comment above.
 				# Install data-files into ALL PKIs
-				#install_data_to_pki || die "Failed to install new required data-dir to PKI."
+				install_data_to_pki || die "Failed to install new required data-dir to PKI."
+				set_var EASYRSA_EXT_DIR		"$EASYRSA_PKI/x509-types"
 			fi
 
 			# Setting EasyRSA specific OPENSSL_CONF to sanatized safe conf
@@ -2100,8 +2105,10 @@ Note: using Easy-RSA configuration from: $vars"
 				export OPENSSL_CONF="$EASYRSA_SAFE_CONF"
 			else
 				# Install data-files into ALL PKIs
-				#install_data_to_pki || die "Failed to install new required data-files to PKI."
-				: # ok
+				install_data_to_pki || die "Failed to install new required data-files to PKI."
+				# EASYRSA_PKI_SAFE_CONF is output by
+				# 'install_data_to_pki()' via 'easyrsa_openssl() makesafeconf'
+				export OPENSSL_CONF="$EASYRSA_PKI_SAFE_CONF"
 			fi
 
 			# Upgrade to 306: Create $EASYRSA_SSL_CONF if it does not exist

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -607,10 +607,10 @@ install_data_to_pki () {
 	# Copying 'vars' to the PKI is complicated, code is included but DISABLED.
 
 	# Set supported sources
-	source_vars="vars"
-	source_vars_example="vars.example"
-	source_file="openssl-easyrsa.cnf"
-	source_dir="x509-types"
+	source_vars='vars'
+	source_vars_example='vars.example'
+	source_file='openssl-easyrsa.cnf'
+	source_dir='x509-types'
 
 	# Only use if required
 	# Omit 'vars' - [ -e "${EASYRSA_PKI}/${source_vars}" ] &&
@@ -624,42 +624,47 @@ install_data_to_pki () {
 
 	# PWD covers EasyRSA-Windows installed by OpenVPN, and git forks
 	area_pwd="$PWD"
-	# I have no idea
+	# Old way
 	area_prog="${0%/*}"
 	# Sensible default - Includes: Arch-Linux
-	area_etc="/etc/easy-rsa"
-	# Exandable distros
-	area_ubuntu="/usr/share/easy-rsa"
+	area_etc='/etc/easy-rsa'
+	# Expandable distros
+	area_ubuntu='/usr/share/easy-rsa'
 	# Add more distros here
 
 	# Find and copy data-files, in specific order
 	for area in \
-				"$area_pwd" \
-				"$area_prog" \
-				"$area_etc" \
-				"$area_ubuntu" \
-				# EOL - # Add more distros here
+		"$area_pwd" \
+		"$area_prog" \
+		"$area_etc" \
+		"$area_ubuntu" \
+		# EOL - # Add more distros here
 	do
 		# Omitting "$source_vars"
-		for source in "$source_vars_example" "$source_file"; do
+		for source in \
+			"$source_vars_example" \
+			"$source_file" \
+			# EOL - Do x509-types separately
+		do
 			# Find each item
 			[ -e "${area}/${source}" ] || continue
+
 			# If the item does not exist in the PKI then copy it.
 			if [ -e "${EASYRSA_PKI}/${source}" ]; then
 				continue
 			else
-				unset -v recurse
 				copy_data_to_pki "${area}/${source}" || return
 			fi
 		done
+
 		# Find x509-types
 		[ -e "${area}/${source_dir}" ] || continue
-		# If the item does not exist in the PKI then copy it.
+
+		# If x509-types does not exist in the PKI then copy it.
 		if [ -e "${EASYRSA_PKI}/${source_dir}" ]; then
 			continue
 		else
-			recurse=1
-			copy_data_to_pki "${area}/${source_dir}" || return
+			copy_data_to_pki "${area}/${source_dir}" recurse || return
 		fi
 	done
 
@@ -675,7 +680,7 @@ install_data_to_pki () {
 
 # Copy the source to the PKI
 copy_data_to_pki () {
-	cp ${recurse:+-r} "$1" "$EASYRSA_PKI"
+	cp ${2:+-r} "$1" "$EASYRSA_PKI"
 } # => copy_data_to_pki ()
 
 # Disable terminal echo, if possible, otherwise warn

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2031,7 +2031,7 @@ Note: using Easy-RSA configuration from: $vars"
 	fi
 
 	# Set defaults, preferring existing env-vars if present
-	set_var EASYRSA		"$prog_dir"
+	set_var EASYRSA		"$PWD"
 	set_var EASYRSA_OPENSSL	openssl
 	set_var EASYRSA_PKI	"$PWD/pki"
 	set_var EASYRSA_DN	cn_only

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2058,14 +2058,6 @@ Note: using Easy-RSA configuration from: $vars"
 	set_var EASYRSA_SAFE_CONF	"$EASYRSA_PKI/safessl-easyrsa.cnf"
 	set_var EASYRSA_KDC_REALM	"CHANGEME.EXAMPLE.COM"
 
-	# Same as above for the x509-types extensions dir
-	if [ -d "$EASYRSA_PKI/x509-types" ]; then
-		set_var EASYRSA_EXT_DIR		"$EASYRSA_PKI/x509-types"
-	else
-		#TODO: This should be removed.  Not really suitable for packaging.
-		set_var EASYRSA_EXT_DIR		"$EASYRSA/x509-types"
-	fi
-
 	# EASYRSA_ALGO_PARAMS must be set depending on selected algo
 	case "$EASYRSA_ALGO" in
 	ec)		EASYRSA_ALGO_PARAMS="$EASYRSA_EC_DIR/${EASYRSA_CURVE}.pem" ;;
@@ -2074,26 +2066,62 @@ Note: using Easy-RSA configuration from: $vars"
 	*)		die "Alg '$EASYRSA_ALGO' is invalid: must be 'rsa', 'ec' or 'ed' "
 	esac
 
-	# Assign value to $EASYRSA_TEMP_DIR_session and work around Windows mktemp bug when parent dir is missing
+	# Assign value to $EASYRSA_TEMP_DIR_session
+	# and work-around Windows mktemp bug when parent dir is missing
+	#
+	# Bug: When the parent-dir is missing Windows'mktemp -du' fails.
+	# The work-around is to create the parent-dir, if it does not exist.
+	# The reason it does not exist is because 'init-pki' has not been run.
+	# Use the same gaurd against a missing PKI; Only set variables which
+	# require a PKI, eg '$EASYRSA_PKI', if there is a PKI !
+	#
+	# Also, integrate a partial 'init-pki' by using 'install_data_to_pki()'
+	#
 	if [ -z "$EASYRSA_TEMP_DIR_session" ]; then
 		if [ -d "$EASYRSA_TEMP_DIR" ]; then
-			EASYRSA_TEMP_DIR_session="$(mktemp -du "$EASYRSA_TEMP_DIR/easy-rsa-$$.XXXXXX")"
+			EASYRSA_TEMP_DIR_session="$(
+					mktemp -du "$EASYRSA_TEMP_DIR/easy-rsa-$$.XXXXXX"
+				)"
+
+			# Same as above for the x509-types extensions dir
+			if [ -d "$EASYRSA_PKI/x509-types" ]; then
+				set_var EASYRSA_EXT_DIR		"$EASYRSA_PKI/x509-types"
+			else
+
+			#TODO: This should be removed.  Not really suitable for packaging.
+			set_var EASYRSA_EXT_DIR		"$EASYRSA/x509-types"
+
+				# Install data-files into ALL PKIs
+				#install_data_to_pki || die "Failed to install new required data-dir to PKI."
+			fi
+
+			# Setting EasyRSA specific OPENSSL_CONF to sanatized safe conf
+			if [ -e "$EASYRSA_SAFE_CONF" ]; then
+				export OPENSSL_CONF="$EASYRSA_SAFE_CONF"
+			else
+				# Install data-files into ALL PKIs
+				#install_data_to_pki || die "Failed to install new required data-files to PKI."
+				: # ok
+			fi
+
+			# Upgrade to 306: Create $EASYRSA_SSL_CONF if it does not exist
+			# but only if $EASYRSA_PKI exists.
+			if [ ! -f "$EASYRSA_SSL_CONF" ] && \
+				[ -f "$EASYRSA/openssl-easyrsa.cnf" ] && [ -d "$EASYRSA_PKI" ];
+			then
+				cp "$EASYRSA/openssl-easyrsa.cnf" "$EASYRSA_SSL_CONF"
+				easyrsa_openssl makesafeconf
+			fi
+
 		else
 			# If the directory does not exist then we have not run init-pki
-			mkdir -p "$EASYRSA_TEMP_DIR" || die "Cannot create $EASYRSA_TEMP_DIR (permission?)"
-			EASYRSA_TEMP_DIR_session="$(mktemp -du "$EASYRSA_TEMP_DIR/easy-rsa-$$.XXXXXX")"
+			mkdir -p "$EASYRSA_TEMP_DIR" || \
+				die "Cannot create $EASYRSA_TEMP_DIR (permission?)"
+			EASYRSA_TEMP_DIR_session="$(
+					mktemp -du "$EASYRSA_TEMP_DIR/easy-rsa-$$.XXXXXX"
+				)"
 			rm -rf "$EASYRSA_TEMP_DIR"
 		fi
-	fi
-
-	# Setting OPENSSL_CONF prevents bogus warnings (especially useful on win32)
-	export OPENSSL_CONF="$EASYRSA_SAFE_CONF"
-
-	# Upgrade to 306: Create $EASYRSA_SSL_CONF if it does not exist but only if $EASYRSA_PKI exists.
-	if [ ! -f "$EASYRSA_SSL_CONF" ] && [ -f "$EASYRSA/openssl-easyrsa.cnf" ] && [ -d "$EASYRSA_PKI" ];
-	then
-		cp "$EASYRSA/openssl-easyrsa.cnf" "$EASYRSA_SSL_CONF"
-		easyrsa_openssl makesafeconf
 	fi
 
 } # vars_setup()

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -573,6 +573,233 @@ Your newly created PKI dir is: $EASYRSA_PKI
 	return 0
 } # => init_pki()
 
+# Copy data-files from various sources
+install_data_to_pki ()
+{
+	# This function is here to explicitly copy data-files to the PKI.
+	# During 'init-pki' this is the new default.
+	# During all other functions these requirements are tested for and
+	# files will be copied to the PKI, if they do not already exist there.
+	#
+	# One of the reasons for this change is to make packing EasyRSA work.
+	# This function searches favoured and then common 'areas' for the
+	# EasyRSA data-files*:
+	#   'openssl-easyrsa.cnf' 'x509-types':(folder).
+	#
+	# These files MUST be found in at least one location and will be copied
+	# to the current PKI, if they do not already exist there.
+	#
+	#
+	# Other EasyRSA data-files*: it is not crucial that these are found
+	# but if they are then they are also copied to the PKI.
+	#   'vars' 'vars.example'
+	#
+	#
+	# For 'vars' consideration must be given to:
+	#   "Where the user expects to find vars!"
+	#
+	# Currently, *if* 'vars' is copied to the PKI then the PKI 'vars' will take
+	# priority over './vars'. But it will not be updated if './vars' is changed.
+	#
+	# Copying 'vars' to the PKI is complicated, code is included but DISABLED.
+
+	# Set supported sources
+	source_vars="vars"
+	source_vars_example="vars.example"
+	source_file="openssl-easyrsa.cnf"
+	source_dir="x509-types"
+
+	# Only use if required
+	if [ -e "$EASYRSA_PKI_SAFE_CONF" ] && \
+		[ -e "${EASYRSA_PKI}/${source_vars}" ] && \
+		[ -e "${EASYRSA_PKI}/${source_vars_example}" ] && \
+		[ -e "${EASYRSA_PKI}/${source_file}" ] && \
+		[ -e "${EASYRSA_PKI}/${source_dir}" ]
+	then
+		return 0
+	fi
+
+	# PWD covers EasyRSA-Windows installed by OpenVPN, and git forks
+	area_pwd="$PWD"
+	# I have no idea
+	area_prog="${0%/*}"
+	# Sensible default - Includes: Arch-Linux
+	area_etc="/etc/easy-rsa"
+	# Exandable distros
+	area_ubuntu="/usr/share/easy-rsa"
+	# Add more distros here
+
+	# Initialize
+	unset -v \
+		found_pwd_vars \
+		found_pwd_vars_example \
+		found_pwd_file \
+		found_pwd_dir \
+		found_prog_vars \
+		found_prog_vars_example \
+		found_prog_file \
+		found_prog_dir \
+		found_etc_vars \
+		found_etc_vars_example \
+		found_etc_file \
+		found_etc_dir \
+		found_ubuntu_vars \
+		found_ubuntu_vars_example \
+		found_ubuntu_file \
+		found_ubuntu_dir
+	# EOL - Add more distros here
+
+	# Find source
+	# PWD
+	[ -e "${area_pwd}/${source_vars}" ] && \
+		found_pwd_vars="${area_pwd}/${source_vars}"
+	[ -e "${area_pwd}/${source_vars_example}" ] && \
+		found_pwd_vars_example="${area_pwd}/${source_vars_example}"
+	[ -e "${area_pwd}/${source_file}" ] && \
+		found_pwd_file="${area_pwd}/${source_file}"
+	[ -d "${area_pwd}/${source_dir}" ] && \
+		found_pwd_dir="${area_pwd}/${source_dir}"
+	# prog_dir
+	[ -e "${area_prog}/${source_vars}" ] && \
+		found_prog_vars="${area_prog}/${source_vars}"
+	[ -e "${area_prog}/${source_vars_example}" ] && \
+		found_prog_vars_example="${area_prog}/${source_vars_example}"
+	[ -e "${area_prog}/${source_file}" ] && \
+		found_prog_file="${area_prog}/${source_file}"
+	[ -d "${area_prog}/${source_dir}" ] && \
+		found_prog_dir="${area_prog}/${source_dir}"
+	# etc
+	[ -e "${area_etc}/${source_vars}" ] && \
+		found_etc_vars="${area_etc}/${source_vars}"
+	[ -e "${area_etc}/${source_vars_example}" ] && \
+		found_etc_vars_example="${area_etc}/${source_vars_example}"
+	[ -e "${area_etc}/${source_file}" ] && \
+		found_etc_file="${area_etc}/${source_file}"
+	[ -d "${area_etc}/${source_dir}" ] && \
+		found_etc_dir="${area_etc}/${source_dir}"
+	# ubuntu
+	[ -e "${area_ubuntu}/${source_vars}" ] && \
+		found_ubuntu_vars="${area_ubuntu}/${source_vars}"
+	[ -e "${area_ubuntu}/${source_vars_example}" ] && \
+		found_ubuntu_vars_example="${area_ubuntu}/${source_vars_example}"
+	[ -e "${area_ubuntu}/${source_file}" ] && \
+		found_ubuntu_file="${area_ubuntu}/${source_file}"
+	[ -d "${area_ubuntu}/${source_dir}" ] && \
+		found_ubuntu_dir="${area_ubuntu}/${source_dir}"
+	# Add more distros here
+
+	# Copy 'vars' from source by specific priority
+	if [ -e "${EASYRSA_PKI}/${source_vars}" ]; then
+		: # ok
+	elif : ; then
+		# Disable copying 'vars' for the time being
+		: # ok
+	else
+		unset -v recurse
+		# PWD
+		if [ "$found_pwd_vars" ]; then
+			copy_data_to_pki "$found_pwd_file" || return
+			#mv "$found_pwd_file" "$EASYRSA_PKI" || return
+		# prog_dir
+		elif [ "$found_prog_vars" ]; then
+			copy_data_to_pki "$found_prog_file" || return
+		# etc
+		elif [ "$found_etc_vars" ]; then
+			copy_data_to_pki "$found_etc_file" || return
+		# ubuntu
+		elif [ "$found_ubuntu_vars" ]; then
+			copy_data_to_pki "$found_ubuntu_file" || return
+		# Add more distros here
+		# ERROR
+		else
+			die "install_data_to_pki - cannot find a vars file."
+		fi
+	fi
+
+	# Copy 'vars.example' from source by specific priority
+	if [ -e "${EASYRSA_PKI}/${source_vars_example}" ]; then
+		: # ok
+	else
+		unset -v recurse
+		# PWD
+		if [ "$found_pwd_vars_example" ]; then
+			copy_data_to_pki "$found_pwd_vars_example" || return
+		# prog_dir
+		elif [ "$found_prog_vars_example" ]; then
+			copy_data_to_pki "$found_prog_vars_example" || return
+		# etc
+		elif [ "$found_etc_vars_example" ]; then
+			copy_data_to_pki "$found_etc_vars_example" || return
+		# ubuntu
+		elif [ "$found_ubuntu_vars_example" ]; then
+			copy_data_to_pki "$found_ubuntu_vars_example" || return
+		# Add more distros here
+		# ERROR
+		else
+			die "install_data_to_pki - cannot find a vars file."
+		fi
+	fi
+
+	# Copy FILE from source by specific priority
+	if [ -e "${EASYRSA_PKI}/${source_file}" ]; then
+		: # ok
+	else
+		unset -v recurse
+		# PWD
+		if [ "$found_pwd_file" ]; then
+			copy_data_to_pki "$found_pwd_file" || return
+		# prog_dir
+		elif [ "$found_prog_file" ]; then
+			copy_data_to_pki "$found_prog_file" || return
+		# etc
+		elif [ "$found_etc_file" ]; then
+			copy_data_to_pki "$found_etc_file" || return
+		# ubuntu
+		elif [ "$found_ubuntu_file" ]; then
+			copy_data_to_pki "$found_ubuntu_file" || return
+		# Add more distros here
+		# ERROR
+		else
+			die "install_data_to_pki - cannot find a source file."
+		fi
+	fi
+
+	# Copy DIR from source by specific priority
+	if [ -e "${EASYRSA_PKI}/${source_dir}" ]; then
+		: # ok
+	else
+		recurse=1
+		# PWD
+		if [ "$found_pwd_dir" ]; then
+			copy_data_to_pki "$found_pwd_dir" || return
+		# prog_dir
+		elif [ "$found_prog_dir" ]; then
+			copy_data_to_pki "$found_prog_dir" || return
+		# etc
+		elif [ "$found_etc_dir" ]; then
+			copy_data_to_pki "$found_etc_dir" || return
+		# ubuntu
+		elif [ "$found_ubuntu_dir" ]; then
+			copy_data_to_pki "$found_ubuntu_dir" || return
+		# Add more distros here
+		# ERROR
+		else
+			die "install_data_to_pki - cannot find a source dir."
+		fi
+	fi
+
+	# Check or error
+	easyrsa_openssl makesafeconf || \
+		die "Failed to make safe SSL config file in PKI."
+} # => install_data_to_pki ()
+
+# Copy the source to the PKI
+copy_data_to_pki ()
+{
+	cp ${recurse:+-r} "$1" "$EASYRSA_PKI"
+} # => copy_data_to_pki ()
+
+# Disable terminal echo, if possible, otherwise warn
 hide_read_pass()
 {
 	# shellcheck disable=SC2039

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -632,164 +632,36 @@ install_data_to_pki () {
 	area_ubuntu="/usr/share/easy-rsa"
 	# Add more distros here
 
-	# Initialize
-	unset -v \
-		found_pwd_vars \
-		found_pwd_vars_example \
-		found_pwd_file \
-		found_pwd_dir \
-		found_prog_vars \
-		found_prog_vars_example \
-		found_prog_file \
-		found_prog_dir \
-		found_etc_vars \
-		found_etc_vars_example \
-		found_etc_file \
-		found_etc_dir \
-		found_ubuntu_vars \
-		found_ubuntu_vars_example \
-		found_ubuntu_file \
-		found_ubuntu_dir
-	# EOL - Add more distros here
-
-	# Find source
-	# PWD
-	[ -e "${area_pwd}/${source_vars}" ] && \
-		found_pwd_vars="${area_pwd}/${source_vars}"
-	[ -e "${area_pwd}/${source_vars_example}" ] && \
-		found_pwd_vars_example="${area_pwd}/${source_vars_example}"
-	[ -e "${area_pwd}/${source_file}" ] && \
-		found_pwd_file="${area_pwd}/${source_file}"
-	[ -d "${area_pwd}/${source_dir}" ] && \
-		found_pwd_dir="${area_pwd}/${source_dir}"
-	# prog_dir
-	[ -e "${area_prog}/${source_vars}" ] && \
-		found_prog_vars="${area_prog}/${source_vars}"
-	[ -e "${area_prog}/${source_vars_example}" ] && \
-		found_prog_vars_example="${area_prog}/${source_vars_example}"
-	[ -e "${area_prog}/${source_file}" ] && \
-		found_prog_file="${area_prog}/${source_file}"
-	[ -d "${area_prog}/${source_dir}" ] && \
-		found_prog_dir="${area_prog}/${source_dir}"
-	# etc
-	[ -e "${area_etc}/${source_vars}" ] && \
-		found_etc_vars="${area_etc}/${source_vars}"
-	[ -e "${area_etc}/${source_vars_example}" ] && \
-		found_etc_vars_example="${area_etc}/${source_vars_example}"
-	[ -e "${area_etc}/${source_file}" ] && \
-		found_etc_file="${area_etc}/${source_file}"
-	[ -d "${area_etc}/${source_dir}" ] && \
-		found_etc_dir="${area_etc}/${source_dir}"
-	# ubuntu
-	[ -e "${area_ubuntu}/${source_vars}" ] && \
-		found_ubuntu_vars="${area_ubuntu}/${source_vars}"
-	[ -e "${area_ubuntu}/${source_vars_example}" ] && \
-		found_ubuntu_vars_example="${area_ubuntu}/${source_vars_example}"
-	[ -e "${area_ubuntu}/${source_file}" ] && \
-		found_ubuntu_file="${area_ubuntu}/${source_file}"
-	[ -d "${area_ubuntu}/${source_dir}" ] && \
-		found_ubuntu_dir="${area_ubuntu}/${source_dir}"
-	# Add more distros here
-
-	# Copy 'vars' from source by specific priority
-	if [ -e "${EASYRSA_PKI}/${source_vars}" ]; then
-		: # ok
-	elif : ; then
-		# Disable copying 'vars' for the time being
-		: # ok
-	else
-		unset -v recurse
-		# PWD
-		if [ "$found_pwd_vars" ]; then
-			copy_data_to_pki "$found_pwd_file" || return
-			#mv "$found_pwd_file" "$EASYRSA_PKI" || return
-		# prog_dir
-		elif [ "$found_prog_vars" ]; then
-			copy_data_to_pki "$found_prog_file" || return
-		# etc
-		elif [ "$found_etc_vars" ]; then
-			copy_data_to_pki "$found_etc_file" || return
-		# ubuntu
-		elif [ "$found_ubuntu_vars" ]; then
-			copy_data_to_pki "$found_ubuntu_file" || return
-		# Add more distros here
-		# ERROR
+	# Find and copy data-files, in specific order
+	for area in "$area_pwd" "$area_prog" "$area_etc" "$area_ubuntu"; do
+		# Omitting "$source_vars"
+		for source in "$source_vars_example" "$source_file"; do
+			# Find each item
+			[ -e "${area}/${source}" ] || continue
+			# If the item does not exist in the PKI then copy it.
+			if [ -e "${EASYRSA_PKI}/${source}" ]; then
+				continue
+			else
+				unset -v recurse
+				copy_data_to_pki "${area}/${source}" || return
+			fi
+		done
+		# Find x509-types
+		[ -e "${area}/${source_dir}" ] || continue
+		# If the item does not exist in the PKI then copy it.
+		if [ -e "${EASYRSA_PKI}/${source_dir}" ]; then
+			continue
 		else
-			die "install_data_to_pki - cannot find a vars file."
+			recurse=1
+			copy_data_to_pki "${area}/${source_dir}" || return
 		fi
-	fi
+	done
 
-	# Copy 'vars.example' from source by specific priority
-	if [ -e "${EASYRSA_PKI}/${source_vars_example}" ]; then
-		: # ok
-	else
-		unset -v recurse
-		# PWD
-		if [ "$found_pwd_vars_example" ]; then
-			copy_data_to_pki "$found_pwd_vars_example" || return
-		# prog_dir
-		elif [ "$found_prog_vars_example" ]; then
-			copy_data_to_pki "$found_prog_vars_example" || return
-		# etc
-		elif [ "$found_etc_vars_example" ]; then
-			copy_data_to_pki "$found_etc_vars_example" || return
-		# ubuntu
-		elif [ "$found_ubuntu_vars_example" ]; then
-			copy_data_to_pki "$found_ubuntu_vars_example" || return
-		# Add more distros here
-		# ERROR
-		else
-			warn "install_data_to_pki - cannot find a vars.example file."
-		fi
-	fi
-
-	# Copy FILE from source by specific priority
-	if [ -e "${EASYRSA_PKI}/${source_file}" ]; then
-		: # ok
-	else
-		unset -v recurse
-		# PWD
-		if [ "$found_pwd_file" ]; then
-			copy_data_to_pki "$found_pwd_file" || return
-		# prog_dir
-		elif [ "$found_prog_file" ]; then
-			copy_data_to_pki "$found_prog_file" || return
-		# etc
-		elif [ "$found_etc_file" ]; then
-			copy_data_to_pki "$found_etc_file" || return
-		# ubuntu
-		elif [ "$found_ubuntu_file" ]; then
-			copy_data_to_pki "$found_ubuntu_file" || return
-		# Add more distros here
-		# ERROR
-		else
-			die "install_data_to_pki - cannot find a source file."
-		fi
-	fi
-
-	# Copy DIR from source by specific priority
-	if [ -e "${EASYRSA_PKI}/${source_dir}" ]; then
-		: # ok
-	else
-		recurse=1
-		# PWD
-		if [ "$found_pwd_dir" ]; then
-			copy_data_to_pki "$found_pwd_dir" || return
-		# prog_dir
-		elif [ "$found_prog_dir" ]; then
-			copy_data_to_pki "$found_prog_dir" || return
-		# etc
-		elif [ "$found_etc_dir" ]; then
-			copy_data_to_pki "$found_etc_dir" || return
-		# ubuntu
-		elif [ "$found_ubuntu_dir" ]; then
-			copy_data_to_pki "$found_ubuntu_dir" || return
-		# Add more distros here
-		# ERROR
-		else
-			die "install_data_to_pki - cannot find a source dir."
-		fi
-	fi
+	# Check PKI is updated - Omit 'vars'
+	#[ -e "${EASYRSA_PKI}/${source_vars}" ] || return
+	[ -e "${EASYRSA_PKI}/${source_vars_example}" ] || return
+	[ -e "${EASYRSA_PKI}/${source_file}" ] || return
+	[ -e "${EASYRSA_PKI}/${source_dir}" ] || return
 
 	# Complete or error
 	[ -e "$EASYRSA_PKI_SAFE_CONF" ] || easyrsa_openssl makesafeconf

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -613,8 +613,8 @@ install_data_to_pki () {
 	source_dir="x509-types"
 
 	# Only use if required
+	# Omit 'vars' - [ -e "${EASYRSA_PKI}/${source_vars}" ] &&
 	if [ -e "$EASYRSA_PKI_SAFE_CONF" ] && \
-		[ -e "${EASYRSA_PKI}/${source_vars}" ] && \
 		[ -e "${EASYRSA_PKI}/${source_vars_example}" ] && \
 		[ -e "${EASYRSA_PKI}/${source_file}" ] && \
 		[ -e "${EASYRSA_PKI}/${source_dir}" ]
@@ -633,7 +633,13 @@ install_data_to_pki () {
 	# Add more distros here
 
 	# Find and copy data-files, in specific order
-	for area in "$area_pwd" "$area_prog" "$area_etc" "$area_ubuntu"; do
+	for area in \
+				"$area_pwd" \
+				"$area_prog" \
+				"$area_etc" \
+				"$area_ubuntu" \
+				# EOL - # Add more distros here
+	do
 		# Omitting "$source_vars"
 		for source in "$source_vars_example" "$source_file"; do
 			# Find each item

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -574,8 +574,7 @@ Your newly created PKI dir is: $EASYRSA_PKI
 } # => init_pki()
 
 # Copy data-files from various sources
-install_data_to_pki ()
-{
+install_data_to_pki () {
 	# This function is here to explicitly copy data-files to the PKI.
 	# During 'init-pki' this is the new default.
 	# During all other functions these requirements are tested for and
@@ -736,7 +735,7 @@ install_data_to_pki ()
 		# Add more distros here
 		# ERROR
 		else
-			die "install_data_to_pki - cannot find a vars file."
+			warn "install_data_to_pki - cannot find a vars.example file."
 		fi
 	fi
 
@@ -794,8 +793,7 @@ install_data_to_pki ()
 } # => install_data_to_pki ()
 
 # Copy the source to the PKI
-copy_data_to_pki ()
-{
+copy_data_to_pki () {
 	cp ${recurse:+-r} "$1" "$EASYRSA_PKI"
 } # => copy_data_to_pki ()
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -579,34 +579,35 @@ Your newly created PKI dir is: $EASYRSA_PKI
 
 # Copy data-files from various sources
 install_data_to_pki () {
-	# This function is here to explicitly copy data-files to the PKI.
-	# During 'init-pki' this is the new default.
-	# During all other functions these requirements are tested for and
-	# files will be copied to the PKI, if they do not already exist there.
-	#
-	# One of the reasons for this change is to make packing EasyRSA work.
-	# This function searches favoured and then common 'areas' for the
-	# EasyRSA data-files*:
-	#   'openssl-easyrsa.cnf' 'x509-types':(folder).
-	#
-	# These files MUST be found in at least one location and will be copied
-	# to the current PKI, if they do not already exist there.
-	#
-	#
-	# Other EasyRSA data-files*: it is not crucial that these are found
-	# but if they are then they are also copied to the PKI.
-	#   'vars' 'vars.example'
-	#
-	#
-	# For 'vars' consideration must be given to:
-	#   "Where the user expects to find vars!"
-	#
-	# Currently, *if* 'vars' is copied to the PKI then the PKI 'vars' will take
-	# priority over './vars'. But it will not be updated if './vars' is changed.
-	#
-	# Copying 'vars' to the PKI is complicated, code is included but DISABLED.
+#
+# This function is here to explicitly copy data-files to the PKI.
+# During 'init-pki' this is the new default.
+# During all other functions these requirements are tested for and
+# files will be copied to the PKI, if they do not already exist there.
+#
+# One of the reasons for this change is to make packing EasyRSA work.
+# This function searches favoured and then common 'areas' for the
+#   EasyRSA data-files(A):
+#     'openssl-easyrsa.cnf' 'x509-types':(folder).
+#
+# These files MUST be found in at least one location and will be copied
+# to the current PKI, if they do not already exist there.
+#
+#
+# Other EasyRSA data-files(B): it is not crucial that these are found
+# but if they are then they are also copied to the PKI.
+#   'vars' 'vars.example'
+#
+#
+# For 'vars' consideration must be given to:
+#   "Where the user expects to find vars!"
+#
+# Currently, *if* 'vars' is copied to the PKI then the PKI 'vars' will take
+# priority over './vars'. But it will not be updated if './vars' is changed.
+#
+# Copying 'vars' to the PKI is complicated, code is included but DISABLED.
 
-	# Set supported sources
+	# Set required sources
 	source_vars='vars'
 	source_vars_example='vars.example'
 	source_file='openssl-easyrsa.cnf'
@@ -668,9 +669,9 @@ install_data_to_pki () {
 		fi
 	done
 
-	# Check PKI is updated - Omit 'vars'
+	# Check PKI is updated - Omit 'vars' and example.
 	#[ -e "${EASYRSA_PKI}/${source_vars}" ] || return
-	[ -e "${EASYRSA_PKI}/${source_vars_example}" ] || return
+	#[ -e "${EASYRSA_PKI}/${source_vars_example}" ] || return
 	[ -e "${EASYRSA_PKI}/${source_file}" ] || return
 	[ -e "${EASYRSA_PKI}/${source_dir}" ] || return
 


### PR DESCRIPTION
Note: This is function is not called in this patch.

The purpose here is to force EasyRSA find the required data-files:
- 'vars', 'vars.example', 'openssl-easyrsa.cnf' and 'x509-types':(dir)

* 'openssl-easyrsa.cnf' and 'x509-types' MUST be found.
* 'vars.example' should be found
  This patch forgot to make this a soft requirement. (Patch required)
* 'vars'
  The 'vars' file is more complicated due to user expectations.
  This version of this patch does not copy 'vars'

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>