### PR TITLE
copy_data_to_pki(): Immediate exit-with-error or 'shift' on success

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -700,7 +700,8 @@ install_data_to_pki () {
 
 # Copy the source to the PKI
 copy_data_to_pki () {
-	cp ${2:+-R} "$1" "$EASYRSA_PKI"
+	cp ${2:+-R} "$1" "$EASYRSA_PKI" || return
+	shift # Clear recurse
 } # => copy_data_to_pki ()
 
 # Disable terminal echo, if possible, otherwise warn


### PR DESCRIPTION
This captures any copy errors and/or clears the excess second parameter.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>