### PR TITLE
Introduce: x509-alt-types (folder) and '--x509-alt' option

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -646,7 +646,11 @@ install_data_to_pki () {
 	vars_file='vars'
 	vars_file_example='vars.example'
 	ssl_cnf_file='openssl-easyrsa.cnf'
-	x509_types_dir='x509-types'
+	if [ -z "$alt_x509" ]; then
+		x509_types_dir='x509-types'
+	else
+		x509_types_dir='x509-alt-types'
+	fi
 
 	# PWD - Covers EasyRSA-Windows installed by OpenVPN, and git forks
 	# "prog_dir" - Old way (Who installs data files in /usr/bin ?)
@@ -676,7 +680,7 @@ install_data_to_pki () {
 			if [ -e "${EASYRSA_PKI}/${source}" ]; then
 				continue
 			else
-				cp "${area}/${source}" "$EASYRSA_PKI" || return
+				copy_data_to_pki "${area}/${source}" || return
 			fi
 		done
 
@@ -728,6 +732,12 @@ install_data_to_pki () {
 	# Complete or error
 	[ -e "$EASYRSA_SAFE_CONF" ] || easyrsa_openssl makesafeconf
 } # => install_data_to_pki ()
+
+# Copy the source to the PKI
+copy_data_to_pki () {
+	cp "$1" "$EASYRSA_PKI" || return
+	shift
+} # => copy_data_to_pki ()
 
 # Disable terminal echo, if possible, otherwise warn
 hide_read_pass()
@@ -2754,6 +2764,9 @@ while :; do
 	--copy-ext)
 		empty_ok=1
 		export EASYRSA_CP_EXT=1 ;;
+	--x509-alt)
+		empty_ok=1
+		alt_x509=1 ;;
 	--subject-alt-name)
 		export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS

--- a/easyrsa3/x509-alt-types/COMMON
+++ b/easyrsa3/x509-alt-types/COMMON
@@ -1,0 +1,12 @@
+# X509 extensions added to every signed cert
+
+# This file is included for every cert signed, and by default does nothing.
+# It could be used to add values every cert should have, such as a CDP as
+# demonstrated in the following example:
+
+#crlDistributionPoints = URI:http://example.net/pki/my_ca.crl
+
+# The authority information access extension gives details about how to access
+# certain information relating to the CA.
+
+#authorityInfoAccess = caIssuers;URI:http://example.net/pki/my_ca.crt

--- a/easyrsa3/x509-alt-types/ca
+++ b/easyrsa3/x509-alt-types/ca
@@ -1,0 +1,12 @@
+# X509 extensions for a ca
+
+# Note that basicConstraints will be overridden by Easy-RSA when defining a
+# CA_PATH_LEN for CA path length limits. You could also do this here
+# manually as in the following example in place of the existing line:
+#
+# basicConstraints = CA:TRUE, pathlen:1
+
+basicConstraints = CA:TRUE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer:always
+keyUsage = cRLSign, keyCertSign

--- a/easyrsa3/x509-alt-types/client
+++ b/easyrsa3/x509-alt-types/client
@@ -1,0 +1,7 @@
+# X509 extensions for a client
+
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+extendedKeyUsage = clientAuth
+keyUsage = digitalSignature

--- a/easyrsa3/x509-alt-types/code-signing
+++ b/easyrsa3/x509-alt-types/code-signing
@@ -1,0 +1,7 @@
+# X509 extensions for a client
+
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+extendedKeyUsage = codeSigning
+keyUsage = digitalSignature

--- a/easyrsa3/x509-alt-types/email
+++ b/easyrsa3/x509-alt-types/email
@@ -1,0 +1,7 @@
+# X509 extensions for email
+
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+extendedKeyUsage = emailProtection
+keyUsage = digitalSignature,keyEncipherment,nonRepudiation

--- a/easyrsa3/x509-alt-types/kdc
+++ b/easyrsa3/x509-alt-types/kdc
@@ -1,0 +1,21 @@
+# X509 extensions for a KDC server certificate
+
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+extendedKeyUsage = 1.3.6.1.5.2.3.5
+keyUsage = nonRepudiation,digitalSignature,keyEncipherment,keyAgreement
+issuerAltName = issuer:copy
+subjectAltName = otherName:1.3.6.1.5.2.2;SEQUENCE:kdc_princ_name
+
+[kdc_princ_name]
+realm = EXP:0,GeneralString:${ENV::EASYRSA_KDC_REALM}
+principal_name = EXP:1,SEQUENCE:kdc_principal_seq
+
+[kdc_principal_seq]
+name_type = EXP:0,INTEGER:1
+name_string = EXP:1,SEQUENCE:kdc_principals
+
+[kdc_principals]
+princ1 = GeneralString:krbtgt
+princ2 = GeneralString:${ENV::EASYRSA_KDC_REALM}

--- a/easyrsa3/x509-alt-types/server
+++ b/easyrsa3/x509-alt-types/server
@@ -1,0 +1,7 @@
+# X509 extensions for a server
+
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+extendedKeyUsage = serverAuth
+keyUsage = digitalSignature,keyEncipherment

--- a/easyrsa3/x509-alt-types/serverClient
+++ b/easyrsa3/x509-alt-types/serverClient
@@ -1,0 +1,7 @@
+# X509 extensions for a client/server
+
+basicConstraints = CA:FALSE
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid,issuer:always
+extendedKeyUsage = serverAuth,clientAuth
+keyUsage = digitalSignature,keyEncipherment

--- a/op-test.sh
+++ b/op-test.sh
@@ -30,7 +30,9 @@ estat=0
 
 if [ -e "easyrsa-unit-tests.sh" ]; then
 	if sh easyrsa-unit-tests.sh "$verb"; then
-		: # ok
+		if [ "$EASYRSA_NIX" ]; then
+			sh easyrsa-unit-tests.sh "$verb" -x || estat=2
+		fi
 	else
 		estat=1
 	fi


### PR DESCRIPTION
'x509-alt-types' allows EasyRSA to maintain some core x509-types
and allow for much more relaxed rules regarding alternatives.

This allows for changes in RFC specification for X509 to be
incorporated in two stages:

* Stage 1: Easy acceptance and subsequent testing of alternatives.
* Stage 2: Greater appeal and ease for EasyRSA to change core types.

Once changes become part of the alternative types, they can be easily
accessed via command line option '--x509-alt', which will select the
alternative x509 folder 'x509-alt-types' for ALL operations.

* The change to 'easyrsa' is minimal, a single option '--x509-alt',
  which effects only install_data_to_pki(). Where the alternative
  folder is searched for and set for use.

* There is a new folder to package: './x509-alt-types'

* There is a unit test included.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>