### PR TITLE
Separate silent-mode from batch-mode - Respect batch-mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Easy-RSA 3 ChangeLog
 
 3.0.9 (TBD)
+   * Warnings are no longer silenced by --batch (#523)
    * Improve packaging options (#510)
    * Introduce basic support for OpenSSL version 3 (#492)
    * Upgrade OpenSSL from 1.1.0j to 1.1.1m (#405, #407) 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -226,6 +226,9 @@ non-empty values to options are mandatory.
 General options:
 
 --batch         : set automatic (no-prompts when possible) mode
+--silent        : Disable all Warnings and Notices
+--sbatch        : Combined --silent and --batch operating mode
+
 --passin=ARG    : set -passin ARG for openssl
 --passout=ARG   : set -passout ARG for openssl
 --pki-dir=DIR   : declares the PKI directory
@@ -280,20 +283,18 @@ $1" 1>&2
 
 # non-fatal warning output
 warn() {
-	[ ! "$EASYRSA_BATCH" ] && \
-		print "
-$1" 1>&2
+	[ "$EASYRSA_SILENT" ] && return
+	print "* Warning:
 
-	return 0
+$1" 1>&2
 } # => warn()
 
 # informational notices to stdout
 notice() {
-	[ ! "$EASYRSA_BATCH" ] && \
-		print "
+	[ "$EASYRSA_SILENT" ] && return
+	[ "$EASYRSA_BATCH" ] && return
+	print "
 $1"
-
-	return 0
 } # => notice()
 
 # yes/no case-insensitive match (operates on stdin pipe)
@@ -984,7 +985,7 @@ gen_dh() {
 
 	# check to see if we already have a dh parameters file
 	if [ -e "$EASYRSA_PKI/dh.pem" ]; then
-		if [ "$EASYRSA_BATCH" = "1" ]; then
+		if [ "$EASYRSA_BATCH" ]; then
 			# if batch is enabled, die
 			die "file $EASYRSA_PKI/dh.pem already exists!"
 		else
@@ -1063,7 +1064,7 @@ $EASYRSA_EXTRA_EXTS"
 	key_out_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	req_out_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
 	# generate request
-	[ $EASYRSA_BATCH ] && opts="$opts -batch"
+	[ "$EASYRSA_BATCH" ] && opts="$opts -batch"
 	# shellcheck disable=2086,2148
 	algo_opts=""
 	if [ "ed" = "$EASYRSA_ALGO" ]; then
@@ -2742,6 +2743,13 @@ while :; do
 		export EASYRSA_NS_COMMENT="$val" ;;
 	--batch)
 		empty_ok=1
+		export EASYRSA_BATCH=1 ;;
+	--silent)
+		empty_ok=1
+		export EASYRSA_SILENT=1 ;;
+	--silent-batch|--sbatch)
+		empty_ok=1
+		export EASYRSA_SILENT=1
 		export EASYRSA_BATCH=1 ;;
 	--passin)
 		export EASYRSA_PASSIN="$val";;


### PR DESCRIPTION
Introduce EASYRSA_SILENT to enhance the use of EASYRSA_BATCH.
Effected functions: warn()

The change in behaviour is that warn() can ONLY be silenced by
option --silent.  Batch-mode is still respected but silence is not.

For scripts which rely on EasyRSA, if they use option --batch then
the change to restore prevous bevaviour is to use option --sbatch.
Otherwise, export EASYRSA_SILENT=1.

This is a minimal change that preserves batch-mode functionality but
also heeds Warnings, unless NEW option --sbatch is specifcally used.

Warnings should not be silenced by batch-mode.

Closes: #512

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>