### PR TITLE
Use x509-types 'ca' and COMMON when building a CA

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -843,6 +843,15 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	# Use this new SSL config for the rest of this function
 	EASYRSA_SSL_CONF="$conf_tmp"
 
+	# When EASYRSA_EXTRA_EXTS is defined, pass it as-is to SSL -addext
+	if [ -n "$EASYRSA_EXTRA_EXTS" ]; then
+		# example: "-addext foo,a:b -addext bah,c:d -addext baz e:f,g"
+		[ "${EASYRSA_EXTRA_EXTS%% *}" = '-addext' ] || \
+			die "EASYRSA_EXTRA_EXTS: $EASYRSA_EXTRA_EXTS"
+		EASYRSA_CA_EXTRA_EXTS="$EASYRSA_EXTRA_EXTS"
+		unset -v EASYRSA_EXTRA_EXTS
+	fi
+
 	# Choose SSL Library version (1 or 3) and build CA
 	case "$osslv_major" in # => BEGIN SSL lib version
 
@@ -903,6 +912,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		# shellcheck disable=SC2086
 		easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
 			-out "$out_file_tmp" ${opts} ${crypto_opts} \
+			${EASYRSA_CA_EXTRA_EXTS} \
 			${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
 				die "Failed to build the CA"
 	;;
@@ -963,6 +973,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		#shellcheck disable=SC2086
 		easyrsa_openssl req -utf8 -new -key "$out_key_tmp" \
 			-keyout "$out_key_tmp" -out "$out_file_tmp" $crypto_opts $opts \
+			${EASYRSA_CA_EXTRA_EXTS} \
 			${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} \
 				|| die "Failed to build the CA"
 	;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -828,6 +828,21 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		fi
 	fi
 
+	# Insert x509-types COMMON and 'ca'
+	#shellcheck disable=SC2016
+	awkscript='
+{if ( match($0, "^#%X509_TYPES%") )
+	{ while ( getline<"/dev/stdin" ) {print} next }
+ {print}
+}'
+	conf_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	cat "${EASYRSA_EXT_DIR}/ca" "${EASYRSA_EXT_DIR}/COMMON" | \
+		awk "$awkscript" "$EASYRSA_SSL_CONF" \
+		> "$conf_tmp" \
+		|| die "Copying SSL config to temp file failed"
+	# Use this new SSL config for the rest of this function
+	EASYRSA_SSL_CONF="$conf_tmp"
+
 	# Choose SSL Library version (1 or 3) and build CA
 	case "$osslv_major" in # => BEGIN SSL lib version
 

--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -128,6 +128,9 @@ keyUsage = cRLSign, keyCertSign
 # nsCertType omitted by default. Let's try to let the deprecated stuff die.
 # nsCertType = sslCA
 
+# A placeholder to handle the $X509_TYPES:
+#%X509_TYPES%	# Do NOT remove or change this line as $X509_TYPES demands it
+
 # CRL extensions.
 [ crl_ext ]
 


### PR DESCRIPTION
To sign a request, easyrsa uses 'openssl ca', which does support -extfile.

To create a CA, easyrsa uses 'openssl req', which does not support -extfile.

Therefore, the x509-types 'ca' and COMMON files cannot be specified using
-extfile to create a CA. Instead, they must be included within the SSL
config file, which 'openssl req' does support.

Using the same awk script from gen_req(), with New Token '#%X509_TYPES%',
the x509-types files 'ca' and COMMON are inserted into the SSL config file.

Closes: #525

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>