### PR TITLE
Disallow use of single quote (') in vars file

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -249,7 +249,7 @@ Certificate & Request options: (these impact cert/req field values)
                      ./easyrsa help altname
 --use-algo=ALG  : crypto alg to use: choose rsa (default), ec or ed
 --curve=NAME    : for elliptic curve, sets the named curve to use
---copy-ext      : Copy included request X509 extensions (namely subjAltName
+--copy-ext      : Copy included request X509 extensions (namely subjAltName)
 
 Organizational DN options: (only used with the 'org' DN mode)
   (values may be blank for org DN options)
@@ -2126,18 +2126,27 @@ Priority should be given to your PKI vars file:
 		if [ -z "$EASYRSA_NO_VARS" ] && [ -z "$want_init_pki" ]; then
 			# If a vars file was located then source it
 			if [ "$vars" ]; then
+				# Sanitize vars
 				if grep -Eq 'EASYRSA_PASSIN|EASYRSA_PASSOUT' "$vars"; then
-					die "\
-Variable EASYRSA_PASSIN or EASYRSA_PASSOUT has been found in the configuration \
-file. Storing sensitive information in the configuration file is not \
-recommended - please remove it from there before continuing."
+					die "
+Variable EASYRSA_PASSIN or EASYRSA_PASSOUT has been found in the configuration
+file. Storing sensitive information in the configuration file is not
+recommended - please remove it from there before continuing.
+"
 				fi
+				if grep -Eq \' "$vars"; then
+					die "
+Single quote (') has been found in the configuration file.
+This character is not allowed in the configuration file.
+Please remove it before continuing.
+"
+				fi
+
 				# shellcheck disable=SC2034 # EASYRSA_CALLER appears unused.
 				EASYRSA_CALLER=1
 				# shellcheck disable=1090 # can't follow non-constant source. vars
 				. "$vars"
-				notice "\
-Note: using Easy-RSA configuration from: $vars"
+				notice "Note: using Easy-RSA configuration from: $vars"
 			else
 				# $vars remains undefined .. no vars found
 				[ "$want_init_pki" ] || warn "  No vars file defined!

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -1,22 +1,22 @@
 # Easy-RSA 3 parameter settings
 
-# NOTE: If you installed Easy-RSA from your distro's package manager, don't edit
+# NOTE: If you installed Easy-RSA from your package manager, do not edit
 # this file in place -- instead, you should copy the entire easy-rsa directory
-# to another location so future upgrades don't wipe out your changes.
+# to another location so future upgrades do not wipe out your changes.
 
 # HOW TO USE THIS FILE
 #
 # vars.example contains built-in examples to Easy-RSA settings. You MUST name
-# this file 'vars' if you want it to be used as a configuration file. If you do
+# this file "vars" if you want it to be used as a configuration file. If you do
 # not, it WILL NOT be automatically read when you call easyrsa commands.
 #
 # It is not necessary to use this config file unless you wish to change
 # operational defaults. These defaults should be fine for many uses without the
-# need to copy and edit the 'vars' file.
+# need to copy and edit the "vars" file.
 #
 # All of the editable settings are shown commented and start with the command
-# 'set_var' -- this means any set_var command that is uncommented has been
-# modified by the user. If you're happy with a default, there is no need to
+# "set_var" -- this means any set_var command that is uncommented has been
+# modified by the user. If you are happy with a default, there is no need to
 # define the value to its default.
 
 # NOTES FOR WINDOWS USERS
@@ -26,14 +26,14 @@
 # the openssl binary might look like this:
 # "C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
 
-# A little housekeeping: DON'T EDIT THIS SECTION
+# A little housekeeping: DO NOT EDIT THIS SECTION
 #
-# Easy-RSA 3.x doesn't source into the environment directly.
+# Easy-RSA 3.x does not source into the environment directly.
 # Complain if a user tries to do this:
 if [ -z "$EASYRSA_CALLER" ]; then
-	echo "You appear to be sourcing an Easy-RSA 'vars' file." >&2
+	echo "You appear to be sourcing an Easy-RSA *vars* file." >&2
 	echo "This is no longer necessary and is disallowed. See the section called" >&2
-	echo "'How to use this file' near the top comments for more details." >&2
+	echo "*How to use this file* near the top comments for more details." >&2
 	return 1
 fi
 
@@ -78,7 +78,7 @@ fi
 # Define X509 DN mode.
 # This is used to adjust what elements are included in the Subject field as the DN
 # (this is the "Distinguished Name.")
-# Note that in cn_only mode the Organizational fields further below aren't used.
+# Note that in cn_only mode the Organizational fields further below are not used.
 #
 # Choices are:
 #   cn_only  - use just a CN value
@@ -86,9 +86,9 @@ fi
 
 #set_var EASYRSA_DN	"cn_only"
 
-# Organizational fields (used with 'org' mode and ignored in 'cn_only' mode.)
+# Organizational fields (used with "org" mode and ignored in "cn_only" mode.)
 # These are the default values for fields which will be placed in the
-# certificate.  Don't leave any of these fields blank, although interactively
+# certificate.  Do not leave any of these fields blank, although interactively
 # you may omit any specific field by typing the "." symbol (not valid for
 # email.)
 
@@ -171,9 +171,9 @@ fi
 # Broken shell command aliases: If you have a largely broken shell that is
 # missing any of these POSIX-required commands used by Easy-RSA, you will need
 # to define an alias to the proper path for the command.  The symptom will be
-# some form of a 'command not found' error from your shell. This means your
+# some form of a "command not found" error from your shell. This means your
 # shell is BROKEN, but you can hack around it here if you really need. These
-# shown values are not defaults: it is up to you to know what you're doing if
+# shown values are not defaults: it is up to you to know what you are doing if
 # you touch these.
 #
 #alias awk="/alt/bin/awk"
@@ -182,9 +182,9 @@ fi
 # X509 extensions directory:
 # If you want to customize the X509 extensions used, set the directory to look
 # for extensions here. Each cert type you sign must have a matching filename,
-# and an optional file named 'COMMON' is included first when present. Note that
+# and an optional file named "COMMON" is included first when present. Note that
 # when undefined here, default behaviour is to look in $EASYRSA_PKI first, then
-# fallback to $EASYRSA for the 'x509-types' dir.  You may override this
+# fallback to $EASYRSA for the "x509-types" dir.  You may override this
 # detection with an explicit dir here.
 #
 #set_var EASYRSA_EXT_DIR	"$EASYRSA/x509-types"


### PR DESCRIPTION
Using single quotes in the vars file does not work:
* Either the vars file syntax is corrupted by an unescaped single quote.
* Or the SSL library will drop the single quote from the signed certificate.

Changes:
* Sanitize vars.example - Remove all single quotes.
* Search vars for single quote before sourcing it.

Closes: #34

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>