### PR TITLE
added option to set PKCS#12 alias name

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -163,9 +163,9 @@ cmd_help() {
   export-p12 <filename_base> [ cmd-opts ]
       Export a PKCS#12 file with the keypair specified by <filename_base>"
 			opts="
-        noca     - do not include the ca.crt file in the PKCS12 output
-        nokey    - do not include the private key in the PKCS12 output
-        usealias - use <filename_base> as friendly name" ;;
+        noca  - do not include the ca.crt file in the PKCS12 output
+        nokey - do not include the private key in the PKCS12 output
+        usefn - use <filename_base> as friendly name" ;;
 		export-p7) text="
   export-p7 <filename_base> [ cmd-opts ]
       Export a PKCS#7 file with the pubkey specified by <filename_base>"
@@ -1764,7 +1764,7 @@ Run easyrsa without commands for usage and command help."
 			noca) want_ca="" ;;
 			nokey) want_key="" ;;
 			nopass) want_pass="" ;;
-			usealias) pkcs_friendly_name=$short_name ;;
+			usefn) pkcs_friendly_name=$short_name ;;
 			*) warn "Ignoring unknown command option: '$1'"
 		esac
 		shift

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -163,8 +163,9 @@ cmd_help() {
   export-p12 <filename_base> [ cmd-opts ]
       Export a PKCS#12 file with the keypair specified by <filename_base>"
 			opts="
-        noca  - do not include the ca.crt file in the PKCS12 output
-        nokey - do not include the private key in the PKCS12 output" ;;
+        noca     - do not include the ca.crt file in the PKCS12 output
+        nokey    - do not include the private key in the PKCS12 output
+        usealias - use <filename_base> as friendly name" ;;
 		export-p7) text="
   export-p7 <filename_base> [ cmd-opts ]
       Export a PKCS#7 file with the pubkey specified by <filename_base>"
@@ -1763,6 +1764,7 @@ Run easyrsa without commands for usage and command help."
 			noca) want_ca="" ;;
 			nokey) want_key="" ;;
 			nopass) want_pass="" ;;
+			usealias) pkcs_friendly_name=$short_name ;;
 			*) warn "Ignoring unknown command option: '$1'"
 		esac
 		shift
@@ -1798,6 +1800,7 @@ Missing key expected at: $key_in"
 		easyrsa_openssl pkcs12 -in "$crt_in" -inkey "$key_in" -export \
 			-out "$pkcs_out" \
 			${nokeys:+ -nokeys} \
+			${pkcs_friendly_name:+ -name "$pkcs_friendly_name"} \
 			${pkcs_certfile_path:+ -certfile "$pkcs_certfile_path"} \
 			${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
 			${EASYRSA_PASSOUT:+ -passout "$EASYRSA_PASSOUT"} || die "\


### PR DESCRIPTION
This change adds a new option "usealias" to the _export-p12_ command.
If set, it uses the `$short_name` as a _friendly name_ for the certificate.

Motivation:
The _friendly name_ aka _alias_ of the certificate/key pair stored in the PKCS#12 container is often used by other software to uniqly select a particular entry. So far, any PKCS#12 container created by EasyRSA was simply unusable by such software.

This probably replaces #45.