### PR TITLE
Allows custom vars file to be used with init-pki

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2613,51 +2613,51 @@ Priority should be given to your PKI vars file:
 			[ "$prog_vars" ] && vars="$prog_vars"
 			[ "$pki_vars" ] && vars="$pki_vars"
 		fi
+	# END: Find vars
+	fi
 
-		# If $EASYRSA_NO_VARS is defined (not blank) then do not use vars
-		# if $no_pki_required then no vars is required.
-		if [ "$EASYRSA_NO_VARS" ] || [ "$no_pki_required" ]; then
+	# If $EASYRSA_NO_VARS is defined (not blank) then do not use vars
+	# if $no_pki_required then no vars is required.
+	if [ "$EASYRSA_NO_VARS" ]; then
+		: # ok
+	else
+		# If a vars file was located then source it
+		if [ -z "$vars" ]; then
+			# $vars remains undefined .. no vars found
 			: # ok
 		else
-			# If a vars file was located then source it
-			if [ -z "$vars" ]; then
-				# $vars remains undefined .. no vars found
-				: # ok
-			else
-				# Sanitize vars
-				if grep -Eq 'EASYRSA_PASSIN|EASYRSA_PASSOUT' "$vars"; then
-					die "\
+			# Sanitize vars
+			if grep -Eq 'EASYRSA_PASSIN|EASYRSA_PASSOUT' "$vars"; then
+				die "\
 Variable EASYRSA_PASSIN or EASYRSA_PASSOUT has been found in the configuration
 file. Storing sensitive information in the configuration file is not
 recommended - please remove it from there before continuing."
-				fi
+			fi
 
-				# Sanitize vars further but ONLY if it is in PKI folder
-				if [ "$pki_vars" ]; then
-					# Warning: Single quote
-					if grep '^[[:blank:]]*set_var[[:blank:]]\+.*' "$vars" | \
-						grep -q -e '&' -e "'" -e '`' -e '\$' -e '#' ; then
-						warn "\
+			# Sanitize vars further but ONLY if it is in PKI folder
+			if [ "$pki_vars" ]; then
+				# Warning: Single quote
+				if grep '^[[:blank:]]*set_var[[:blank:]]\+.*' "$vars" | \
+					grep -q -e '&' -e "'" -e '`' -e '\$' -e '#' ; then
+					warn "\
 Unsupported  characters are present in the vars file.
 These characters are not supported: (') (&) (\`) (\$) (#)
 Sourcing the vars file and building certificates will probably fail .."
-					fi
 				fi
+			fi
 
-				# shellcheck disable=SC2034 # EASYRSA_CALLER appears unused.
-				EASYRSA_CALLER=1
-				# shellcheck disable=1090 # can't follow non-constant source. vars
-				( . "$vars" 2>/dev/null ) || die "\
+			# shellcheck disable=SC2034 # EASYRSA_CALLER appears unused.
+			EASYRSA_CALLER=1
+			# shellcheck disable=1090 # can't follow non-constant source. vars
+			( . "$vars" 2>/dev/null ) || die "\
 Failed to source the vars file, remove any unsupported characters."
 
-				# shellcheck disable=1090 # can't follow non-constant source. vars
-				. "$vars" 2>/dev/null
-				notice "Using Easy-RSA configuration from: $vars"
-				[ "$pki_vars" ] || \
-					warn "Move your vars file to your PKI folder, where it is safe!"
-			fi
+			# shellcheck disable=1090 # can't follow non-constant source. vars
+			. "$vars" 2>/dev/null
+			notice "Using Easy-RSA configuration from: $vars"
+			[ "$pki_vars" ] || \
+				warn "Move your vars file to your PKI folder, where it is safe!"
 		fi
-	# END: Find vars
 	fi
 
 	# Set defaults, preferring existing env-vars if present


### PR DESCRIPTION
Before the changes to the handling of the vars file, I was able to fully automate the process of creating a pki, ca, certs, etc. With the new changes, when I run `easyrsa --vars=/my/vars init-pki` the vars are disregarded, creating problems with automation. In the vars file, `EASYRSA_BATCH=yes` is never read, the pki dir is always the current folder, etc. 

This PR allows a custom vars file to be used with `init-pki`. 