### PR TITLE
Add command for testing which certificates are eligible for renewal

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -36,6 +36,7 @@ Here is the list of commands available with a short syntax reminder. Use the
   revoke <filename_base> [cmd-opts]
   revoke-renewed <filename_base> [cmd-opts]
   renew <filename_base> [cmd-opts]
+  renewable [ <filename_base> ]
   build-serverClient-full <filename_base> [ cmd-opts ]
   gen-crl
   update-db
@@ -138,6 +139,9 @@ cmd_help() {
       Renew a certificate specified by the filename_base"
 			opts="
         nopass  - do not encrypt the private key (default is encrypted)" ;;
+		renewable) text="
+  renewable [ <filename_base> ]
+      Check which certificates can be renewed" ;;
 		gen-crl) text="
   gen-crl
       Generate a CRL" ;;
@@ -2055,6 +2059,32 @@ revoke_renewed_move() {
 	return 0
 } # => revoke_renewed_move()
 
+# renewable backend
+renewable() {
+	verify_ca_init
+
+	in_dir="$EASYRSA_PKI"
+	if [ $# -eq 0 ] ; then
+		candidates=( $(ls ${in_dir}/issued/ | sed -e 's|.crt$||p;d' ) )
+	else
+		candidates=( $@ )
+	fi
+	matches=()
+	for candidate in ${candidates[@]} ; do
+		crt_in="$in_dir/issued/$candidate.crt"
+		cert_dates "$crt_in"
+		if [ "$expire_date" -lt "$allow_renew_date" ] ; then
+		    matches+=( $candidate )
+		fi
+	done
+	if [ ${#matches[@]} -eq 0 ] ; then
+		# Nothing to renew
+		exit 1
+	else
+		print "${matches[@]}"
+	fi
+} # => renewable
+
 # gen-crl backend
 gen_crl() {
 	verify_ca_init
@@ -3578,6 +3608,9 @@ case "$cmd" in
 		;;
 	renew)
 		renew "$@"
+		;;
+	renewable)
+		renewable "$@"
 		;;
 	import-req)
 		import_req "$@"


### PR DESCRIPTION
Since it looks like easy-rsa is intended for automation (assumption based on -sbatch option), the possibilty to test / list which certificates are eligible for renewal might come in handy.