### PR TITLE
Add command for testing which certificates are eligible for renewal

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2064,26 +2064,27 @@ renewable() {
 	verify_ca_init
 
 	in_dir="$EASYRSA_PKI"
-	if [ $# -eq 0 ] ; then
-            awkscript='
+	MATCH=$(echo "$*" | sed -re 's/\s+/|/g')
+	DATE=$(date --date \
+               "+${EASYRSA_CERT_RENEW} days" \
+               +"%y%m%d%H%M%S")
+        { awkscript=$(cat) ; } <<EOF
 BEGIN { FS = "\t" };
-$1 ~ '/V/' {
-  gsub(".*/CN=", "",  $6);
-  gsub("[^-0-9a-zA-Z.].*", "", $6);
-  print $6;
-}'
-		candidates=$(awk "$awkscript" ${in_dir}/index.txt)
-	else
-		candidates=$*
-	fi
-	matches=""
-	for candidate in $candidates ; do
-		crt_in="$in_dir/issued/$candidate.crt"
-		cert_dates "$crt_in"
-		if [ "$expire_date" -lt "$allow_renew_date" ] ; then
-		    matches="$matches $candidate"
-		fi
-	done
+# Only report valid entries
+\$1 ~ /V/ {
+  # Only consider CN
+  gsub(".*/CN=", "",  \$6);
+  gsub("[^-0-9a-zA-Z.].*", "", \$6);
+  # Only report old enough candidates
+  if (\$2 < "${DATE}") {
+    # Only report matches
+    if (\$6 ~ /(${MATCH})/) {
+      print \$6;
+    }
+  }
+}
+EOF
+	matches=$(awk "$awkscript" "${in_dir}/index.txt")
 	if [ -z "$matches" ] ; then
 		# Nothing to renew
 		exit 1

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2065,8 +2065,14 @@ renewable() {
 
 	in_dir="$EASYRSA_PKI"
 	if [ $# -eq 0 ] ; then
-	    candidates=$(find "${in_dir}"/issued/ \
-                             | sort | sed -e 's|^.*/||;s|.crt$||p;d' )
+            awkscript='
+BEGIN { FS = "\t" };
+$1 ~ '/V/' {
+  gsub(".*/CN=", "",  $6);
+  gsub("[^-0-9a-zA-Z.].*", "", $6);
+  print $6;
+}'
+		candidates=$(awk "$awkscript" ${in_dir}/index.txt)
 	else
 		candidates=$*
 	fi

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -36,6 +36,7 @@ Here is the list of commands available with a short syntax reminder. Use the
   revoke <filename_base> [cmd-opts]
   revoke-renewed <filename_base> [cmd-opts]
   renew <filename_base> [cmd-opts]
+  renewable [ <filename_base> ]
   build-serverClient-full <filename_base> [ cmd-opts ]
   gen-crl
   update-db
@@ -138,6 +139,9 @@ cmd_help() {
       Renew a certificate specified by the filename_base"
 			opts="
         nopass  - do not encrypt the private key (default is encrypted)" ;;
+		renewable) text="
+  renewable [ <filename_base> ]
+      Check which certificates can be renewed" ;;
 		gen-crl) text="
   gen-crl
       Generate a CRL" ;;
@@ -2055,6 +2059,32 @@ revoke_renewed_move() {
 	return 0
 } # => revoke_renewed_move()
 
+# renewable backend
+renewable() {
+	verify_ca_init
+
+	in_dir="$EASYRSA_PKI"
+	if [ $# -eq 0 ] ; then
+		candidates=( $(ls ${in_dir}/issued/ | sed -e 's|.crt$||p;d' ) )
+	else
+		candidates=( $@ )
+	fi
+	matches=()
+	for candidate in ${candidates[@]} ; do
+		crt_in="$in_dir/issued/$candidate.crt"
+		cert_dates "$crt_in"
+		if [ "$expire_date" -lt "$allow_renew_date" ] ; then
+		    matches+=( $candidate )
+		fi
+	done
+	if [ ${#matches[@]} -eq 0 ] ; then
+		# Nothing to renew
+		exit 1
+	else
+		print "${matches[@]}"
+	fi
+} # => renewable
+
 # gen-crl backend
 gen_crl() {
 	verify_ca_init
@@ -3578,6 +3608,9 @@ case "$cmd" in
 		;;
 	renew)
 		renew "$@"
+		;;
+	renewable)
+		renewable "$@"
 		;;
 	import-req)
 		import_req "$@"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2065,23 +2065,24 @@ renewable() {
 
 	in_dir="$EASYRSA_PKI"
 	if [ $# -eq 0 ] ; then
-		candidates=( $(ls ${in_dir}/issued/ | sed -e 's|.crt$||p;d' ) )
+	    candidates=$(find "${in_dir}"/issued/ \
+                             | sort | sed -e 's|^.*/||;s|.crt$||p;d' )
 	else
-		candidates=( $@ )
+		candidates=$*
 	fi
-	matches=()
-	for candidate in ${candidates[@]} ; do
+	matches=""
+	for candidate in $candidates ; do
 		crt_in="$in_dir/issued/$candidate.crt"
 		cert_dates "$crt_in"
 		if [ "$expire_date" -lt "$allow_renew_date" ] ; then
-		    matches+=( $candidate )
+		    matches="$matches $candidate"
 		fi
 	done
-	if [ ${#matches[@]} -eq 0 ] ; then
+	if [ -z "$matches" ] ; then
 		# Nothing to renew
 		exit 1
 	else
-		print "${matches[@]}"
+		print "$matches"
 	fi
 } # => renewable
 


### PR DESCRIPTION
Since it looks like easy-rsa is intended for automation (assumption based on -sbatch option), the possibilty to test / list which certificates are eligible for renewal might come in handy.

Re-submitted due to shellcheck errors in CI (deservedly bashed for using bash)