### PR TITLE
Always respect --vars=file

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2717,7 +2717,8 @@ Priority should be given to your PKI vars file:
 	fi
 
 	# If $EASYRSA_NO_VARS is defined (not blank) then do not use vars
-	# if $no_pki_required then no vars is required.
+	# if $no_pki_required then located vars files are not required (user
+	# defined '--vars=file' is still respected though).
 	if [ "$EASYRSA_NO_VARS" ] || [ "$no_pki_required" ]; then
 		: # ok
 	else
@@ -3604,13 +3605,21 @@ trap "exit 14" 15
 cmd="$1"
 [ -n "$1" ] && shift # scrape off command
 
-# This avoids unnecessary warnings and notices
-case "$cmd" in
-	init-pki|clean-all) no_pki_required=1 ;;
-	""|help|-h|--help|--usage) no_pki_required=1 ;;
-	version) no_pki_required=1 ;;
-	*) unset -v no_pki_required
-esac
+# User defined '--vars=file' or defaults
+if [ "$EASYRSA_VARS_FILE" ]; then
+       # User defined --vars=file MUST be sourced, we trust the user knows
+       # better.
+       : # ok
+else
+	# This avoids unnecessary warnings and notices by, among others,
+	# skipping locating and loading vars files.
+	case "$cmd" in
+		init-pki|clean-all) no_pki_required=1 ;;
+		""|help|-h|--help|--usage) no_pki_required=1 ;;
+		version) no_pki_required=1 ;;
+		*) unset -v no_pki_required
+	esac
+fi
 
 # Get host details
 detect_host


### PR DESCRIPTION
This is sth that was included in #552 but was missed in 9f0d4bf16d044d5e0d3a8e6b17c5eaa9b1bcbc39. 

During init-pki, no pki is required. But that does not mean that vars should be ignored. As it stands now, doing sth like `easyrsa --vars=/path/to/vars init-pki` disregards the custom vars that could include things like a custom pki location, etc.