### PR TITLE
Backport patch for #559 to 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist-staging
 easyrsa3/safessl-easyrsa.cnf
 testdeps/*
 shellcheck
+.DS_Store

--- a/ChangeLog
+++ b/ChangeLog
@@ -21,6 +21,7 @@ Easy-RSA 3 ChangeLog
    * Warnings are no longer silenced by --batch (#523)
    * Improve packaging options (#510)
    * Update regex for POSIX compliance (#556)
+   * Correct date format for Darwin/BSD (#559)
 
 3.0.8 (2020-09-09)
    * Provide --version option (#372)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1635,7 +1635,9 @@ Non-decimal value for EASYRSA_FIX_OFFSET: '$EASYRSA_FIX_OFFSET'"
 		allow_renew_date="$(( now_sec + EASYRSA_CERT_RENEW * 86400 ))"
 
 		if [ "$EASYRSA_FIX_OFFSET" ]; then
-			start_fix_sec="$(date -j "${this_year}01010000.00" +%s)"
+			start_fix_sec="$(
+				date -j -f '%Y%m%d%H%M%S' "${this_year}0101000000" +%s
+				)"
 			end_fix_sec="$(( start_fix_sec + fix_days * 86400 ))"
 			# Convert to date-stamps for SSL input
 			start_fixdate="$(date -j -r "$start_fix_sec" +%Y%m%d%H%M%SZ)"


### PR DESCRIPTION
Backport the patch from a4e37cfe54167cca2610aa401b06caae6fa4f724 to 3.0
that fixes the data arguments on Darwin and BSD.  Patch originally
authored by @tincantech.

Update .gitignore to ignore macOS .DS_Store files.

Update ChangeLog for v3.0.9 release

Signed-off-by: Eric F Crist <ecrist@secure-computing.net>