### PR TITLE
Added support for MacPorts date (coreutils) on MacOS

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2476,6 +2476,10 @@ Non-decimal value for EASYRSA_FIX_OFFSET: '$EASYRSA_FIX_OFFSET'"
 	# OS dependencies
 	case "$easyrsa_uname" in
 	"Darwin"|*"BSD")
+	# GNU date (MacPorts coreutils) does not support -j
+	if date -j > /dev/null 2>&1
+	then
+		# Original MacOS date
 		now_sec="$(date -j +%s)"
 		expire_date="$(date -j -f '%b %d %T %Y %Z' "$crt_not_after")"
 		expire_date_s="$(date -j -f '%b %d %T %Y %Z' "$crt_not_after" +%s)"
@@ -2490,6 +2494,28 @@ Non-decimal value for EASYRSA_FIX_OFFSET: '$EASYRSA_FIX_OFFSET'"
 			start_fixdate="$(date -j -r "$start_fix_sec" +%Y%m%d%H%M%SZ)"
 			end_fixdate="$(date -j -r "$end_fix_sec" +%Y%m%d%H%M%SZ)"
 		fi
+	else
+		expire_date_s="$(date -d "$crt_not_after" +%s)"
+		expire_date="$(date -d "$crt_not_after")"
+		allow_renew_date_s="$(date -d "+${EASYRSA_CERT_RENEW}day" +%s)"
+
+		if [ "$EASYRSA_FIX_OFFSET" ]; then
+			# New Years Day, this year
+			New_Year_day="$(
+				date -d "${this_year}-01-01 00:00:00Z" '+%Y-%m-%d %H:%M:%SZ'
+				)"
+			# Convert to date-stamps for SSL input
+			start_fixdate="$(
+				date -d "$New_Year_day" +%Y%m%d%H%M%SZ
+				)"
+			end_fixdate="$(
+				date -d "$New_Year_day +${fix_days}days" +%Y%m%d%H%M%SZ
+				)"
+			end_fix_sec="$(
+				date -d "$New_Year_day +${fix_days}days" +%s
+				)"
+		fi
+	fi
 	;;
 	*)
 		# Linux and Windows (FTR: date.exe does not support format +%s as input)


### PR DESCRIPTION
MacPorts installs GNU `coreutils` in path`${prefix}/bin` (defaults to `/opt/local/bin`). Per the documentation, if you include `${prefix}/libexec/gnubin` in your `$PATH` before `/bin`, you substitute GNU core commands to Darwin's. GNU `date` does not support `-j` option.

The proposed patch tests for support of `-j` option by `date` and avoids any error on Darwin platform. Tested with and without MacPorts, as well as `$PATH` variations.

Hope this PR will be useful to the community using this great tool.