### PR TITLE
Introduce 'serialNumber' field for DN (OID 2.5.4.5)

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -746,6 +746,7 @@ easyrsa_openssl() {
 			-e s\`'$ENV::EASYRSA_REQ_ORG'\`\""$EASYRSA_REQ_ORG"\"\`g \
 			-e s\`'$ENV::EASYRSA_REQ_OU'\`\""$EASYRSA_REQ_OU"\"\`g \
 			-e s\`'$ENV::EASYRSA_REQ_EMAIL'\`\""$EASYRSA_REQ_EMAIL"\"\`g \
+			-e s\`'$ENV::EASYRSA_REQ_SERIAL'\`\""$EASYRSA_REQ_SERIAL"\"\`g \
 				"$EASYRSA_SSL_CONF" > "$easyrsa_openssl_conf" || \
 					die "easyrsa_openssl - Failed to make temporary config (1)"
 
@@ -1180,9 +1181,45 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	printf "" > "$EASYRSA_PKI/index.txt.attr" || die "$err_file"
 	printf '%s\n' "01" > "$EASYRSA_PKI/serial" || die "$err_file"
 
-	# Default CN only when not in global EASYRSA_BATCH mode:
-	[ "$EASYRSA_BATCH" ] && ssl_batch=1
+	# Default CA commonName
 	[ "$EASYRSA_REQ_CN" = ChangeMe ] && export EASYRSA_REQ_CN="Easy-RSA CA"
+
+	# Do not use prompting from SSL config
+	ssl_batch=1
+
+	# Get user confirmation here, not while in SSL
+	if [ "$EASYRSA_BATCH" ]; then
+		: # ok
+	else
+		case "$EASYRSA_DN" in
+		cn_only)
+			confirm "
+  Create CA certificate with these DN settings ? " yes "\
+EasyRSA DN 'commonName-Only' mode (cn_only)
+
+* Current CA Distinguished Name fields:
+
+  commonName                = $EASYRSA_REQ_CN"
+		;;
+		org)
+			confirm "
+  Create CA certificate with these DN settings ? " yes "\
+EasyRSA DN 'Organisation' mode (org)
+
+* Current CA Distinguished Name fields:
+
+  commonName                = $EASYRSA_REQ_CN
+  countryName               = $EASYRSA_REQ_COUNTRY
+  stateOrProvinceName       = $EASYRSA_REQ_PROVINCE
+  localityName              = $EASYRSA_REQ_CITY
+  organizationName          = $EASYRSA_REQ_ORG
+  0.organizationalUnitName  = $EASYRSA_REQ_OU
+  emailAddress              = $EASYRSA_REQ_EMAIL${EASYRSA_REQ_SERIAL:+"
+  serialNumber              = $EASYRSA_REQ_SERIAL"}"
+		;;
+		*) die "Unrecognised DN mode: $EASYRSA_DN"
+		esac
+	fi
 
 	out_key_tmp="$(easyrsa_mktemp)" || die "Failed to create temp-key file"
 	out_file_tmp="$(easyrsa_mktemp)" || die "Failed to create temp-cert file"
@@ -4496,6 +4533,9 @@ while :; do
 	--req-ou)
 		empty_ok=1
 		export EASYRSA_REQ_OU="$val" ;;
+	--req-serial)
+		empty_ok=1
+		export EASYRSA_REQ_SERIAL="$val" ;;
 	--ns-cert)
 		export EASYRSA_NS_SUPPORT="$val" ;;
 	--ns-comment)

--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -51,6 +51,7 @@ organizationalUnitName	= optional
 commonName		= supplied
 name			= optional
 emailAddress		= optional
+serialNumber	= optional
 
 ####################################################################
 # Easy-RSA request handling
@@ -100,6 +101,9 @@ commonName_default		= $ENV::EASYRSA_REQ_CN
 emailAddress			= Email Address
 emailAddress_default		= $ENV::EASYRSA_REQ_EMAIL
 emailAddress_max		= 64
+
+serialNumber		= Serial-number (eg, device serial-number)
+serialNumber_default	= $ENV::EASYRSA_REQ_SERIAL
 
 ####################################################################
 # Easy-RSA cert extension handling


### PR DESCRIPTION
Add a *final* layer of granularity to X509 Distinguished Name.
Only used if --req-serial="\<PRINTABLE\>user data" is specified.

To minimize the noise to the user by this new field, change the way
that OpenSSL is called to build a CA. Always use '-batch' mode to
build the CA certificate.

User visible change when building a CA:
* Instead of being prompted for each individual DN field, now the
  user is presented with a read-out of how the fields are currently
  set. There is now only a single confirmation that all fields are
  correct.
* If '--req-serial' is not set then it is not displayed.

PRINTABLE: a-z,A-Z,0-9, -+/=.,?:()

Closes: #462 - The original proposal and prototype code.
Supersedes: #598 - Introduce 1.organizationalUnitName

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>