### PR TITLE
Introduce 'serialNumber' field for DN (OID 2.5.4.5)

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -749,6 +749,7 @@ easyrsa_openssl() {
 			-e s\`'$ENV::EASYRSA_REQ_ORG'\`\""$EASYRSA_REQ_ORG"\"\`g \
 			-e s\`'$ENV::EASYRSA_REQ_OU'\`\""$EASYRSA_REQ_OU"\"\`g \
 			-e s\`'$ENV::EASYRSA_REQ_EMAIL'\`\""$EASYRSA_REQ_EMAIL"\"\`g \
+			-e s\`'$ENV::EASYRSA_REQ_SERIAL'\`\""$EASYRSA_REQ_SERIAL"\"\`g \
 				"$EASYRSA_SSL_CONF" > "$easyrsa_openssl_conf" || \
 					die "easyrsa_openssl - Failed to make temporary config (1)"
 
@@ -1192,9 +1193,45 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	printf "" > "$EASYRSA_PKI/index.txt.attr" || die "$err_file"
 	printf '%s\n' "01" > "$EASYRSA_PKI/serial" || die "$err_file"
 
-	# Default CN only when not in global EASYRSA_BATCH mode:
-	[ "$EASYRSA_BATCH" ] && ssl_batch=1
+	# Default CA commonName
 	[ "$EASYRSA_REQ_CN" = ChangeMe ] && export EASYRSA_REQ_CN="Easy-RSA CA"
+
+	# Do not use prompting from SSL config
+	ssl_batch=1
+
+	# Get user confirmation here, not while in SSL
+	if [ "$EASYRSA_BATCH" ]; then
+		: # ok
+	else
+		case "$EASYRSA_DN" in
+		cn_only)
+			confirm "
+  Create CA certificate with these DN settings ? " yes "\
+EasyRSA DN 'commonName-Only' mode (cn_only)
+
+* Current CA Distinguished Name fields:
+
+  commonName                = $EASYRSA_REQ_CN"
+		;;
+		org)
+			confirm "
+  Create CA certificate with these DN settings ? " yes "\
+EasyRSA DN 'Organisation' mode (org)
+
+* Current CA Distinguished Name fields:
+
+  commonName                = $EASYRSA_REQ_CN
+  countryName               = $EASYRSA_REQ_COUNTRY
+  stateOrProvinceName       = $EASYRSA_REQ_PROVINCE
+  localityName              = $EASYRSA_REQ_CITY
+  organizationName          = $EASYRSA_REQ_ORG
+  0.organizationalUnitName  = $EASYRSA_REQ_OU
+  emailAddress              = $EASYRSA_REQ_EMAIL${EASYRSA_REQ_SERIAL:+"
+  serialNumber              = $EASYRSA_REQ_SERIAL"}"
+		;;
+		*) die "Unrecognised DN mode: $EASYRSA_DN"
+		esac
+	fi
 
 	out_key_tmp="$(easyrsa_mktemp)" || die "Failed to create temp-key file"
 	out_file_tmp="$(easyrsa_mktemp)" || die "Failed to create temp-cert file"
@@ -4509,6 +4546,9 @@ while :; do
 	--req-ou)
 		empty_ok=1
 		export EASYRSA_REQ_OU="$val" ;;
+	--req-serial)
+		empty_ok=1
+		export EASYRSA_REQ_SERIAL="$val" ;;
 	--ns-cert)
 		export EASYRSA_NS_SUPPORT="$val" ;;
 	--ns-comment)

--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -49,8 +49,8 @@ localityName		= optional
 organizationName	= optional
 organizationalUnitName	= optional
 commonName		= supplied
-name			= optional
 emailAddress		= optional
+serialNumber	= optional
 
 ####################################################################
 # Easy-RSA request handling
@@ -100,6 +100,9 @@ commonName_default		= $ENV::EASYRSA_REQ_CN
 emailAddress			= Email Address
 emailAddress_default		= $ENV::EASYRSA_REQ_EMAIL
 emailAddress_max		= 64
+
+serialNumber		= Serial-number (eg, device serial-number)
+serialNumber_default	= $ENV::EASYRSA_REQ_SERIAL
 
 ####################################################################
 # Easy-RSA cert extension handling

--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -13,9 +13,9 @@ crl_dir		= $dir			# Where the issued crl are kept
 database	= $dir/index.txt	# database index file.
 new_certs_dir	= $dir/certs_by_serial	# default place for new certs.
 
-certificate	= $dir/ca.crt	 	# The CA certificate
-serial		= $dir/serial 		# The current serial number
-crl		= $dir/crl.pem 		# The current CRL
+certificate	= $dir/ca.crt		# The CA certificate
+serial		= $dir/serial		# The current serial number
+crl		= $dir/crl.pem		# The current CRL
 private_key	= $dir/private/ca.key	# The private key
 RANDFILE	= $dir/.rand		# private random number file
 
@@ -57,7 +57,7 @@ serialNumber	= optional
 # We key off $DN_MODE to determine how to format the DN
 [ req ]
 default_bits		= $ENV::EASYRSA_KEY_SIZE
-default_keyfile 	= privkey.pem
+default_keyfile	= privkey.pem
 default_md		= $ENV::EASYRSA_DIGEST
 distinguished_name	= $ENV::EASYRSA_DN
 x509_extensions		= easyrsa_ca	# The extensions to add to the self signed cert


### PR DESCRIPTION
Add a *final* layer of granularity to X509 Distinguished Name.
Only used if **--req-serial="\<PRINTABLE\>user data"** is specified.

To minimize the noise to the user by this new field, change the way
that OpenSSL is called to build a CA: Always use '-batch' mode.

User visible change when building a CA:
* Instead of being prompted for each individual DN field, now the
  user is presented with a read-out of how the fields are currently
  set. There is now only a single confirmation that all fields are
  correct.
* If '--req-serial' is not used then 'serialNumber' is not displayed.

PRINTABLE: a-z,A-Z,0-9, -+/=.,?:()

Closes: OpenVPN#462 - The original proposal and prototype code.
Closes: OpenVPN#598 - Supersedes: Introduce 1.organizationalUnitName
Closes: OpenVPN#600 - Bugfix: Remove unused 'name' definition from SSL conf.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>