### PR TITLE
Ensure 'pki/renewed/<folders>' exist for 'rewind-renew'

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2406,6 +2406,11 @@ Unexpected input in file: $req_in"
 	key_out="$out_dir/private/$crt_cn.key"
 	req_out="$out_dir/reqs/$crt_cn.req"
 
+	# Create out_dir
+	for newdir in issued private reqs; do
+		mkdir -p "$out_dir/$newdir" || die "Failed to create: $out_dir/$newdir"
+	done
+
 	# NEVER over-write a renewed cert, revoke it first
 	deny_msg="\
 Cannot renew this certificate because a conflicting file exists.


### PR DESCRIPTION
It is possible that only the 'foo_by_serial' folders will exist in
the 'pki/renewed' sub-folder when 'rewind-renew' is needed.

Create the required folders when using 'rewind-renew'.

Closes: #612

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>