### PR TITLE
verify_ca_init: Reorder names to improve error message

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -887,7 +887,7 @@ verify_ca_init() {
 
 	# Verify expected files are present. Allow files to be regular files
 	# (or symlinks), but also pipes, for flexibility with ca.key
-	for i in serial index.txt index.txt.attr ca.crt private/ca.key; do
+	for i in ca.crt private/ca.key index.txt index.txt.attr serial; do
 		if [ ! -f "$EASYRSA_PKI/$i" ] && [ ! -p "$EASYRSA_PKI/$i" ]; then
 			[ "$1" = "test" ] && return 1
 			die "\


### PR DESCRIPTION
If verify_ca_init fails then the error message states that: 'serial
is missing'.  While this is true, it is not 'user friendly'.

Reorder the checks so that if verify_ca_init fails then the error
message will "probably" state that: 'ca.crt is missing', which makes
more sense if the CA has not been initialised.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>