### PR TITLE
show: Reorder parameter checks to guard against empty input

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3000,13 +3000,12 @@ verify_file() {
 show() {
 	type="$1"
 	name="$2"
-	shift 2
-
 	in_file=""
 	format=""
 	[ "$name" ] || die "\
 Missing expected <file_name_base> argument.
 Run easyrsa without commands for usage help."
+	shift 2
 
 	# opts support
 	type_opts="-${type}opt"
@@ -3043,7 +3042,7 @@ Run easyrsa without commands for usage help."
 
 	# Verify file exists and is of the correct type
 	[ -e "$in_file" ] || die "\
-No such $type file with a basename of '$name' is present.
+No such '$type' type file with a <file_name_base> of '$name' is present.
 Expected to find this file at:
 $in_file"
 


### PR DESCRIPTION
'shift 2' was moved above the parameter check in previous commit:
1d227736e404b805e84b8949aa238a240c4ad5eb

Move it back to after the check and reword user output for clarity.

Relates-to: #632

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>