### PR TITLE
Re-enable the use of --vars=file for init-pki

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4786,10 +4786,6 @@ vars_setup
 # determine how we were called, then hand off to the function responsible
 case "$cmd" in
 	init-pki|clean-all)
-		if [ "$user_vars_true" ]; then
-			# Ref: https://github.com/OpenVPN/easy-rsa/issues/566
-			die "Use of '--vars=FILE init-pki' is prohibited, use '--pki-dir=DIR'"
-		fi
 		init_pki "$@"
 		;;
 	build-ca)


### PR DESCRIPTION
Since relaxing the rules concerning the location of vars file,
commit f4a604438d3ce5fe67a1f4db956dc42fc4ae5588, it is no longer
necessary to prohibit the use of --vars=file with 'init-pki'.

This initial prohibition was only a temporary measure and has
proven to be of no value.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>