### PR TITLE
Unsupported characters: Correct check and warning message

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3853,18 +3853,12 @@ recommended - please remove it from there before continuing."
 			fi
 
 			# Warning: Unsupported  characters
-			if  grep '^[[:blank:]]*set_var[[:blank:]][[:blank:]]*.*' "$vars" |
-					grep \
-						-e "EASYRSA_REQ_COUNTRY" \
-						-e "EASYRSA_REQ_PROVINCE" \
-						-e "EASYRSA_REQ_CITY" \
-						-e "EASYRSA_REQ_ORG" \
-						-e "EASYRSA_REQ_EMAIL" \
-						-e "EASYRSA_REQ_OU" |
-						grep -q -e '`' -e '{' -e '}'
+			if grep '^[[:blank:]]*set_var[[:blank:]]*.*$' "$vars" | \
+				grep -q -e '`'
 			then
-				warn 'Unsupported characters are present in the vars file.
-These characters are not supported: (`) "{" "}"
+				warn '\
+Unsupported characters are present in the vars file.
+These characters are not supported: ` backtick
 Sourcing the vars file and building certificates will probably fail ..'
 			fi
 

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -94,12 +94,7 @@ fi
 
 # NOTE: The following characters are not supported
 #       in these "Organizational fields" by Easy-RSA:
-#       single quote (')
 #       back-tick (`)
-#       hash (#)
-#       ampersand (&)
-#       dollar sign ($)
-# Use them at your own risk!
 
 #set_var EASYRSA_REQ_COUNTRY	"US"
 #set_var EASYRSA_REQ_PROVINCE	"California"


### PR DESCRIPTION
Since the introduction of 'escape_hazard()' function, all characters
except (`) backtick are supported.

This patch brings vars.example in line with the warning in easyrsa and
also only warns about backtick.

It is possible that curly brace '{}' may also cause OpenSSL to behave
strangely. However, the strange behaviour, which I previously observed,
may have been rectified by OpenSSL.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>