### PR TITLE
build-ca: Assign default sub-CA commonName and enable SSL interactive

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -472,7 +472,7 @@ Distinguished Name mode:
   --dn-mode=MODE    : Distinguished Name mode to use 'cn_only' or 'org'
                       (Default: 'cn_only')
 
-  --req-cn=NAME     : Set commonNama for CA/SubCA ONLY. Default 'Easy-RSA CA'
+  --req-cn=NAME     : Set commonName for CA/SubCA ONLY. Default 'Easy-RSA CA'
 
   Distinguished Name Organizational options: (only used with '--dn-mode=org')
   --req-c=CC           : country code (2-letters)
@@ -1249,13 +1249,20 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	printf '%s\n' "01" > "$EASYRSA_PKI/serial" || die "$err_file"
 
 	# Default CA commonName
-	[ "$EASYRSA_REQ_CN" = ChangeMe ] && export EASYRSA_REQ_CN="Easy-RSA CA"
-
-	# Do not use prompting from SSL config
-	ssl_batch=1
+	if [ "$EASYRSA_REQ_CN" = ChangeMe ]; then
+		if [ "$sub_ca" ]; then
+			export EASYRSA_REQ_CN="Easy-RSA Sub-CA"
+		else
+			export EASYRSA_REQ_CN="Easy-RSA CA"
+		fi
+		unsest -v ssl_batch
+	else
+		# Do not use prompting from SSL config
+		ssl_batch=1
+	fi
 
 	# Get user confirmation here, not while in SSL
-	if [ "$EASYRSA_BATCH" ]; then
+	if [ "$EASYRSA_BATCH" ] || [ -z "$ssl_batch" ]; then
 		: # ok
 	else
 		case "$EASYRSA_DN" in


### PR DESCRIPTION
When building a CA/SubCA, if a commonName has not been assigned by --req-cn
then assign a default commonName, of either:
* 'Easy-RSA CA' or 'Easy-RSA Sub-CA'.

If a default commonName has been assigned then use SSL interactive mode
to edit/confirm each of the subject fields individually. Otherwise, use
EasyRSA to confirm all of the subject fields with a single prompt.

Closes: #659

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>