### PR TITLE
Prevent overwriting EASYRSA_REQ_CN with default value

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1482,8 +1482,10 @@ Run easyrsa without commands for usage and commands."
 	key_out="$EASYRSA_PKI/private/$1.key"
 	req_out="$EASYRSA_PKI/reqs/$1.req"
 
-	# Set the request commonName
-	EASYRSA_REQ_CN="$1"
+	# Set the request commonName to the "file base" when no commonName override is provided
+	if [ -z ${EASYRSA_REQ_CN} ]; then
+		EASYRSA_REQ_CN="$1"
+	fi
 	shift
 
 	# Verify PKI has been initialised


### PR DESCRIPTION
There is no check in place to see if the EASYRSA_REQ_CN has already been configured through use of environment variables; the variable always gets set with the "file base". 

This PR fixes issue: https://github.com/OpenVPN/easy-rsa/issues/668

Signed-off-by: Tom de Vries <tomdev@users.noreply.github.com>