### PR TITLE
`--subca-len=X sign-req ca` honour user set critical flag in ca

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -13,8 +13,6 @@ Easy-RSA 3 ChangeLog
    * Introduce 'rewind-renew' (#579)
    * Expand status reports to include checking a single cert (#577)
    * update OpenSSL for Windows to 3.0.5
-   * Support user enabled critical flag in basicConstraints, if present,
-     for sub CA certificates (#692)
 
 3.1.0 (2022-05-18)
    * Introduce basic support for OpenSSL version 3 (#492)

--- a/ChangeLog
+++ b/ChangeLog
@@ -13,6 +13,8 @@ Easy-RSA 3 ChangeLog
    * Introduce 'rewind-renew' (#579)
    * Expand status reports to include checking a single cert (#577)
    * update OpenSSL for Windows to 3.0.5
+   * Support user enabled critical flag in basicConstraints, if present,
+     for sub CA certificates (#692)
 
 3.1.0 (2022-05-18)
    * Introduce basic support for OpenSSL version 3 (#492)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1691,10 +1691,6 @@ $(display_dn req "$req_in")
 
 	# Generate the extensions file for this cert:
 	ext_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
-	# shellcheck disable=SC2016 # vars don't expand in single quotes (is awk)
-	# only check for critical in last instance of basicConstraints
-	awkchkcrit='/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
-END { if (bC ~ /critical/) e=0; else e=1; exit e }'
 	{
 		# Append first any COMMON file (if present) then the cert-type extensions
 		cat "$EASYRSA_EXT_DIR/COMMON" || \
@@ -1704,12 +1700,11 @@ END { if (bC ~ /critical/) e=0; else e=1; exit e }'
 
 		# Support a dynamic CA path length when present:
 		if [ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ]; then
-			# check for user set critical flag
-			if awk "${awkchkcrit}" "$EASYRSA_EXT_DIR/$crt_type"; then
-				print "basicConstraints = critical, CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
-			else
-				print "basicConstraints = CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
-			fi
+			# extract last occurrence of basicConstraints and append pathlen
+			# shellcheck disable=SC2016 # vars don't expand in single quotes
+			awkchkcrit='/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
+END { if (length(bC) == 0 ) bC="basicConstraints = CA:TRUE"; print bC }'
+			print "$(awk "${awkchkcrit}" "$EASYRSA_EXT_DIR/$crt_type"), pathlen:$EASYRSA_SUBCA_LEN"
 		fi
 
 		# Deprecated Netscape extension support, if enabled

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1691,6 +1691,10 @@ $(display_dn req "$req_in")
 
 	# Generate the extensions file for this cert:
 	ext_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	# shellcheck disable=SC2016 # vars don't expand in single quotes (is awk)
+	# only check for critical in last instance of basicConstraints
+	awkchkcrit='/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
+END { if (bC ~ /critical/) e=0; else e=1; exit e }'
 	{
 		# Append first any COMMON file (if present) then the cert-type extensions
 		cat "$EASYRSA_EXT_DIR/COMMON" || \
@@ -1699,8 +1703,14 @@ $(display_dn req "$req_in")
 			die "Failed to read X509-type $crt_type"
 
 		# Support a dynamic CA path length when present:
-		[ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ] && \
-			print "basicConstraints = CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
+		if [ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ]; then
+			# check for user set critical flag
+			if awk "${awkchkcrit}" "$EASYRSA_EXT_DIR/$crt_type"; then
+				print "basicConstraints = critical, CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
+			else
+				print "basicConstraints = CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
+			fi
+		fi
 
 		# Deprecated Netscape extension support, if enabled
 		if print "$EASYRSA_NS_SUPPORT" | awk_yesno; then


### PR DESCRIPTION
During sign_req with crt_type = ca and $EASYRSA_SUBCA_LEN set, check for *critical* flag presence in existing *basicConstraints* within the *ca* file.

Note as the user may have something like:
```
basicConstraints = critical, CA:TRUE
basicConstraints = CA:TRUE
```
only check the last occurrence of *basicConstraints*

While I have used awk to solve this, a `grep |tail |grep` could also be used:
```
if grep '^[[:blank:]]*basicConstraints[[:blank:]]*=' "$EASYRSA_EXT_DIR/$crt_type"|tail -n 1|grep -q critical; then
```

Addresses #691 and partial solution for #448 (noting that `build-ca` now pulls in *COMMON* and *ca* this should be the last piece needed)