### PR TITLE
X509-types: Always check SSL config file for EasyRSA insert-markers

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1288,6 +1288,13 @@ $EASYRSA_PKI
 Refusing to create a new CA keypair as this operation would overwrite your
 current CA keypair. If you intended to start a new CA, run init-pki first."
 
+	# Check for insert-marker in ssl config file
+	if ! grep -q '^#%CA_X509_TYPES_EXTRA_EXTS%' "$EASYRSA_SSL_CONF"; then
+		die "\
+The copy of openssl-easyrsa.cnf in your PKI does not have full support
+for X509-type CA. Please update your copy to the official release."
+	fi
+
 	# create necessary files and dirs:
 	err_file="Unable to create necessary PKI files (permissions?)"
 	for i in issued certs_by_serial \
@@ -1525,6 +1532,13 @@ Continuing with key generation will replace this key."
 
 	# When EASYRSA_EXTRA_EXTS is defined, append it to openssl's [req] section:
 	if [ "$EASYRSA_EXTRA_EXTS" ]; then
+		# Check for insert-marker in ssl config file
+		if ! grep -q '^#%EXTRA_EXTS%' "$EASYRSA_SSL_CONF"; then
+			die "\
+The copy of openssl-easyrsa.cnf in your PKI does not have full support
+for request extensions. Please update your copy to the official release."
+		fi
+
 		# Setup & insert the extra ext data keyed by a magic line
 		extra_exts="
 req_extensions = req_extra
@@ -1672,6 +1686,13 @@ $(display_dn req "$req_in")
 
 	# When EASYRSA_CP_EXT is defined, adjust openssl's [default_ca] section:
 	if [ "$EASYRSA_CP_EXT" ]; then
+		# Check for insert-marker in ssl config file
+		if ! grep -q '^#%COPY_EXTS%' "$EASYRSA_SSL_CONF"; then
+			die "\
+The copy of openssl-easyrsa.cnf in your PKI does not have full support
+for X509-type $crt_type. Please update your copy to the official release."
+		fi
+
 		# Setup & insert the copy_extensions data keyed by a magic line
 		copy_exts="copy_extensions = copy"
 		# shellcheck disable=SC2016 # vars don't expand in single quote

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1291,8 +1291,9 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 	# Check for insert-marker in ssl config file
 	if ! grep -q '^#%CA_X509_TYPES_EXTRA_EXTS%' "$EASYRSA_SSL_CONF"; then
 		die "\
-The copy of openssl-easyrsa.cnf in your PKI does not have full support
-for X509-type CA. Please update your copy to the official release."
+The copy of openssl-easyrsa.cnf in use does not support X509-type 'ca'.
+* $EASYRSA_SSL_CONF
+Please update to the latest official release."
 	fi
 
 	# create necessary files and dirs:
@@ -1535,8 +1536,9 @@ Continuing with key generation will replace this key."
 		# Check for insert-marker in ssl config file
 		if ! grep -q '^#%EXTRA_EXTS%' "$EASYRSA_SSL_CONF"; then
 			die "\
-The copy of openssl-easyrsa.cnf in your PKI does not have full support
-for request extensions. Please update your copy to the official release."
+The copy of openssl-easyrsa.cnf in use does not support request extensions.
+^ $EASYRSA_SSL_CONF
+Please update to the latest official release."
 		fi
 
 		# Setup & insert the extra ext data keyed by a magic line
@@ -1689,8 +1691,9 @@ $(display_dn req "$req_in")
 		# Check for insert-marker in ssl config file
 		if ! grep -q '^#%COPY_EXTS%' "$EASYRSA_SSL_CONF"; then
 			die "\
-The copy of openssl-easyrsa.cnf in your PKI does not have full support
-for X509-type $crt_type. Please update your copy to the official release."
+The copy of openssl-easyrsa.cnf in use does not support --copy-ext.
+* $EASYRSA_SSL_CONF
+Please update to the latest official release."
 		fi
 
 		# Setup & insert the copy_extensions data keyed by a magic line

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1293,7 +1293,7 @@ current CA keypair. If you intended to start a new CA, run init-pki first."
 		die "\
 The copy of openssl-easyrsa.cnf in use does not support X509-type 'ca'.
 * $EASYRSA_SSL_CONF
-Please update to the latest official release."
+Please update openssl-easyrsa.cnf to the latest official release."
 	fi
 
 	# create necessary files and dirs:
@@ -1537,8 +1537,8 @@ Continuing with key generation will replace this key."
 		if ! grep -q '^#%EXTRA_EXTS%' "$EASYRSA_SSL_CONF"; then
 			die "\
 The copy of openssl-easyrsa.cnf in use does not support request extensions.
-^ $EASYRSA_SSL_CONF
-Please update to the latest official release."
+* $EASYRSA_SSL_CONF
+Please update openssl-easyrsa.cnf to the latest official release."
 		fi
 
 		# Setup & insert the extra ext data keyed by a magic line
@@ -1693,7 +1693,7 @@ $(display_dn req "$req_in")
 			die "\
 The copy of openssl-easyrsa.cnf in use does not support --copy-ext.
 * $EASYRSA_SSL_CONF
-Please update to the latest official release."
+Please update openssl-easyrsa.cnf to the latest official release."
 		fi
 
 		# Setup & insert the copy_extensions data keyed by a magic line


### PR DESCRIPTION
Since EasyRSA version 3.1 there is a NEW insert-marker for X509 type 'ca'.

* New insert-marker: '^#%CA_X509_TYPES_EXTRA_EXTS%' [BRE]

This is only required to build a new CA or Sub-CA. However, without this check, an old version of openssl-easyrsa.cnf will silently FAIL to include the X509 types for 'ca' and 'COMMON', when builing a new CA.

EasyRSA 'init-pki soft' does leave 'openssl-easyrsa.cnf' in place, which means that this is a known possible failure.

For consistency, check for All EasyRSA insert-markers, when used.

* Standard insert-markers: '^#%EXTRA_EXTS%' and '^#%COPY_EXTS%' [BRE]

Tested manually.

Closes: #693

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>