### PR TITLE
build_full: Remove sign_req() subshell and do full cleanup

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -667,6 +667,7 @@ easyrsa_mktemp() {
 
 # remove temp files and do terminal cleanups
 cleanup() {
+	verbose "* Cleanup!"
 	if [ "${EASYRSA_TEMP_DIR_session%/*}" ] && \
 		[ -d "$EASYRSA_TEMP_DIR_session" ]
 	then
@@ -687,6 +688,9 @@ cleanup() {
 	then
 		rm -rf "$EASYRSA_EC_DIR"
 	fi
+
+	# Remove files when build_full()->sign_req() is interrupted
+	[ "$on_error_build_full_cleanup" ] && rm -f "$crt_out" "$req_out" "$key_out"
 
 	# Restore files when renew is interrupted
 	[ "$on_error_undo_renew_move" ] && renew_restore_move; :
@@ -1851,10 +1855,12 @@ Option conflict: '$cmd' does not support setting an external commonName"
 	gen_req "$name" batch ${nopass+ nopass}
 
 	# Sign it
-	( sign_req "$crt_type" "$name" ) || {
-		rm -f "$crt_out" "$req_out" "$key_out"
+	on_error_build_full_cleanup=1
+	if sign_req "$crt_type" "$name"; then
+		unset -v on_error_build_full_cleanup
+	else
 		die "Failed to sign '$name' - See error messages above for details."
-	}
+	fi
 
 	# inline it
 	if [ "$EASYRSA_INLINE" ]; then


### PR DESCRIPTION
build-x-full uses a subshell to detect errors and cleanup the files if an error occurs.  This does not work if Ctrl-C is pressed during the confirmation yes/no dialog.

Replace the subshell with an indicator, $on_error_build_full_cleanup, to force cleanup() to remove the CSR, key and certificate files when an error occurs or user presses Ctrl-C.

Closes: #680

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>