### PR TITLE
Opt. --subca-len: basicConstraints CA extension, Append 'pathlen:N'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Easy-RSA 3 ChangeLog
 
 3.1.1 (TBD)
+   * Resolve long-standing issue with --subca-len=N (#691)
    * Expand 'show-renew', include 'renewed/certs_by_serial' (#700)
    * Introduce 'renew' (version 3). Only renew cert (#688)
    * Require 'openssl-easyrsa.cnf' is up to date (#695}

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -533,10 +533,9 @@ die() {
 	print "
 Easy-RSA error:
 
-$1" 1>&2
-
-	show_host
-
+$1
+" 1>&2
+	die_error_exit=1
 	exit "${2:-1}"
 } # => die()
 
@@ -667,7 +666,6 @@ easyrsa_mktemp() {
 
 # remove temp files and do terminal cleanups
 cleanup() {
-	verbose "* Cleanup!"
 	if [ "${EASYRSA_TEMP_DIR_session%/*}" ] && \
 		[ -d "$EASYRSA_TEMP_DIR_session" ]
 	then
@@ -677,8 +675,7 @@ cleanup() {
 			[ -d "$keep_tmp" ] && rm -rf "$keep_tmp"
 
 			mv -f "$EASYRSA_TEMP_DIR_session" "$keep_tmp"
-			information \
-				"Temp session preserved: $keep_tmp"
+			information "Temp session preserved: $keep_tmp"
 		else
 			rm -rf "$EASYRSA_TEMP_DIR_session"
 		fi
@@ -690,7 +687,8 @@ cleanup() {
 	fi
 
 	# Remove files when build_full()->sign_req() is interrupted
-	[ "$on_error_build_full_cleanup" ] && rm -f "$crt_out" "$req_out" "$key_out"
+	[ "$on_error_build_full_cleanup" ] && \
+		rm -f "$crt_out" "$req_out" "$key_out"
 
 	# Restore files when renew is interrupted
 	[ "$on_error_undo_renew_move" ] && renew_restore_move; :
@@ -727,6 +725,8 @@ cleanup() {
 		exit 0
 	else
 		# if 'cleanup' is called without 'ok' then an error occurred
+		# Do not show_host() for confirm() aborted exit
+		[ "$die_error_exit" ] && show_host
 		exit 1
 	fi
 } # => cleanup()
@@ -3989,7 +3989,6 @@ detect_host() {
 
 # Extra diagnostics
 show_host() {
-	print
 	print_version
 	print "$host_out | ${ssl_version:-ssl_version not currently set}"
 	[ "$EASYRSA_DEBUG" ] || return 0
@@ -4938,12 +4937,9 @@ trap "exit 3" 3
 trap "exit 6" 6
 trap "exit 14" 15
 
-# Get host details - does not require vars_setup
-detect_host
-
 # Initialisation requirements
-unset -v easyrsa_error_exit user_san_true user_vars_true \
-	alias_days
+unset -v die_error_exit easyrsa_error_exit \
+	user_san_true user_vars_true alias_days
 
 # Parse options
 while :; do
@@ -5099,6 +5095,9 @@ case "$cmd" in
 		pki_is_required=1
 		unset -v no_pki_required
 esac
+
+# Get host details - does not require vars_setup
+detect_host
 
 # Intelligent env-var detection and auto-loading:
 vars_setup

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1684,21 +1684,6 @@ at: $crt_out"
 The certificate request file is not in a valid X509 request format.
 File Path: $req_in"
 
-	# Display the request subject in an easy-to-read format
-	# Confirm the user wishes to sign this request
-	# Support batch by internal caller:
-	#[ "$3" = "batch" ] ||
-	confirm "Confirm request details: " "yes" "\
-You are about to sign the following certificate.
-Please check over the details shown below for accuracy. Note that this request
-has not been cryptographically verified. Please be sure it came from a trusted
-source or that you have verified the request checksum with the sender.
-
-Request subject, to be signed as a $crt_type certificate for $EASYRSA_CERT_EXPIRE days:
-
-$(display_dn req "$req_in")
-"	# => confirm end
-
 	# Get fixed dates by --fix-offset
 	if [ "$EASYRSA_FIX_OFFSET" ]; then
 		fixed_dates="$( # subshell for debug
@@ -1749,8 +1734,16 @@ Please update openssl-easyrsa.cnf to the latest official release."
 			die "Failed to read X509-type $crt_type"
 
 		# Support a dynamic CA path length when present:
-		[ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ] && \
-			print "basicConstraints = CA:TRUE, pathlen:$EASYRSA_SUBCA_LEN"
+		if [ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ]; then
+			# Print the last occurence of basicContraints in x509-types/ca
+			# If basicContraints not defined then bail
+			awkscript='/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
+				END { if (length(bC) == 0 ) exit 1;	print bC }'
+			basicConstraints="$(awk "$awkscript" "$ext_tmp")" || die "\
+basicConstraints is not defined, cannot use 'pathlen'"
+			print "$basicConstraints, pathlen:$EASYRSA_SUBCA_LEN"
+			unset -v basicConstraints
+		fi
 
 		# Deprecated Netscape extension support, if enabled
 		if print "$EASYRSA_NS_SUPPORT" | awk_yesno; then
@@ -1789,6 +1782,21 @@ Please update openssl-easyrsa.cnf to the latest official release."
 	} > "$ext_tmp" || die "\
 Failed to create temp extension file (bad permissions?) at:
 $ext_tmp"
+
+	# Display the request subject in an easy-to-read format
+	# Confirm the user wishes to sign this request
+	# Support batch by internal caller:
+	#[ "$3" = "batch" ] ||
+	confirm "Confirm request details: " "yes" "\
+You are about to sign the following certificate.
+Please check over the details shown below for accuracy. Note that this request
+has not been cryptographically verified. Please be sure it came from a trusted
+source or that you have verified the request checksum with the sender.
+
+Request subject, to be signed as a $crt_type certificate for $EASYRSA_CERT_EXPIRE days:
+
+$(display_dn req "$req_in")
+"	# => confirm end
 
 	# sign request
 	crt_out_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1737,9 +1737,12 @@ Please update openssl-easyrsa.cnf to the latest official release."
 		if [ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ]; then
 			# Print the last occurence of basicContraints in x509-types/ca
 			# If basicContraints not defined then bail
+			# shellcheck disable=SC2016 # vars don't expand in ''
 			awkscript='/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
 				END { if (length(bC) == 0 ) exit 1; print bC }'
-			basicConstraints="$(awk "$awkscript" "$ext_tmp")" || die "\
+			basicConstraints="$(
+				awk "$awkscript" "$EASYRSA_EXT_DIR/$crt_type"
+				)" || die "\
 basicConstraints is not defined, cannot use 'pathlen'"
 			print "$basicConstraints, pathlen:$EASYRSA_SUBCA_LEN"
 			unset -v basicConstraints

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1738,7 +1738,7 @@ Please update openssl-easyrsa.cnf to the latest official release."
 			# Print the last occurence of basicContraints in x509-types/ca
 			# If basicContraints not defined then bail
 			awkscript='/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
-				END { if (length(bC) == 0 ) exit 1;	print bC }'
+				END { if (length(bC) == 0 ) exit 1; print bC }'
 			basicConstraints="$(awk "$awkscript" "$ext_tmp")" || die "\
 basicConstraints is not defined, cannot use 'pathlen'"
 			print "$basicConstraints, pathlen:$EASYRSA_SUBCA_LEN"


### PR DESCRIPTION
When signing a request for an intermediate CA using --subca-len=N:

For a Sub-CA, the current method to apply 'pathlen:N' to CA basicConstraints over-writes all user set basicConstraints.

Replace that with an awk script which reads the current x509-types/ca file; selects the last occurence of 'basicConstraints' (As does OpenSSL) and then prints that line, with ", pathlen:$EASYRSA_SUBCA_LEN" appended, into the temporary x509-types/ca file.

If no CA basicConstraint is found then exit with an error. Reason:

Easy-RSA default CA basicConstrain will always be defined. If that is changed by the user, who then attempts to use Easy-RSA to append 'pathlen' then that is an error. Easy-RSA must not insert a default when the default has been deliberately removed.

Closes: #691 - Original bug report.
Closes: #692 - First use of awk as a solution. [Credit]

Additional: Move the confirmation dialogue to after all the configuration has
been completed.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>