### PR TITLE
Use POSIX [[:space:]] instead of \s for sed(1).

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3103,7 +3103,7 @@ display_san() {
 
 	if echo "$EASYRSA_EXTRA_EXTS" | grep -q subjectAltName; then
 		print "$(echo "$EASYRSA_EXTRA_EXTS" | grep subjectAltName |
-			sed 's/^\s*subjectAltName\s*=\s*//')"
+			sed 's/^[[:space:]]*subjectAltName[[:space:]]*=[[:space:]]*//')"
 	else
 		san="$(
 			x509v3san="X509v3 Subject Alternative Name:"


### PR DESCRIPTION
2nd half of fix for #714.

Obtained from:	topical@gmx.net