### PR TITLE
print_version(): Redirect stderr for "openssl" call

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4857,7 +4857,7 @@ return 0
 
 print_version()
 {
-	ssl_version="$("${EASYRSA_OPENSSL:-openssl}" version)"
+	ssl_version="$("${EASYRSA_OPENSSL:-openssl}" version 2>/dev/null)"
 		cat << VERSION_TEXT
 EasyRSA Version Information
 Version:     $EASYRSA_version


### PR DESCRIPTION
This redirects stderr message generated by missing config file, specifically for LibreSSL.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>