### PR TITLE
Option --subca-len - Allow value to be 0 (zero)

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4986,8 +4986,10 @@ unset -v die_error_exit easyrsa_error_exit \
 
 # Parse options
 while :; do
+	# Reset per pass flags
+	unset -v opt val is_empty empty_ok number_only zero_allowed
+
 	# Separate option from value:
-	unset -v opt val is_empty empty_ok number_only
 	opt="${1%%=*}"
 	val="${1#*=}"
 
@@ -5111,6 +5113,7 @@ while :; do
 		;;
 	--subca-len)
 		number_only=1
+		zero_allowed=1
 		export EASYRSA_SUBCA_LEN="$val"
 		;;
 	--vars)
@@ -5136,17 +5139,22 @@ subjectAltName = $val"
 		break
 	esac
 
-	# fatal error when a number is expected but not provided
-	if [ "$number_only" ]; then
-		case "$val" in
-			(*[!1234567890]*|0*)
-				die "$opt - Number expected: '$val'"
-		esac
-	fi
-
 	# fatal error when no value was provided
 	if [ "$is_empty" ]; then
 		[ "$empty_ok" ] || die "Missing value to option: $opt"
+	fi
+
+	# fatal error when a number is expected but not provided
+	if [ "$number_only" ]; then
+		case "$val" in
+			(0)
+				# Allow zero only
+				[ "$zero_allowed" ] || \
+					die "$opt - Number expected: '$val'"
+			;;
+			(*[!1234567890]*|0*)
+				die "$opt - Number expected: '$val'"
+		esac
 	fi
 
 	shift


### PR DESCRIPTION
For an intermediate CA certificate, Path length of zero (0) is valid. Therefore, allow the character '0' as a valid numeric input for EasyRSA option --subca-len=<N>

This method allows character zero (0) ONLY, as a numeric input for options which accept zero as a value.

Add comment: # Reset per pass flags

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>