### PR TITLE
Allow --fix-offset to create post-dated certificates

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3459,18 +3459,6 @@ fixed_cert_dates() {
 		this_year_n="$(busybox date -u +%y)"
 		today_n="$(busybox date -u +%j)"
 
-		# If the start day number is into the future then back-date by one year
-		if [ "$start_fix_day_n" -gt "$today_n" ]; then
-			not_valid_until_d="$(( start_fix_day_n - today_n ))"
-			this_year_n="$(( this_year_n - 1 ))"
-			# Get user confirmation
-			# This needs to be less rigid ;-)
-			confirm "  Create certificate with one year back-dated date ? " \
-				"yes" "\
-This certificate will not be valid for '${not_valid_until_d} days'.
-The fixed date will be rolled backward by one year."
-		fi
-
 		New_Year_day_s="$(
 			busybox date -u -d "${this_year_n}01010000.01" '+%s'
 			)"
@@ -3491,17 +3479,6 @@ The fixed date will be rolled backward by one year."
 
 		this_year_n="$(date -j +%y)"
 		today_n="$(date -u -j +%j)"
-
-		# If the start day number is into the future then back-date by one year
-		if [ "$start_fix_day_n" -gt "$today_n" ]; then
-			not_valid_until_d="$(( start_fix_day_n - today_n ))"
-			this_year_n="$(( this_year_n - 1 ))"
-			# Get user confirmation
-			confirm "  Create certificate with one year back-dated date ? " \
-				"yes" "\
-This certificate will not be valid for ${not_valid_until_d} days.
-The fixed date will be rolled backward by one year."
-		fi
 
 		New_Year_day_d="$(
 			date -u -j -f %y%m%d%H%M%S "${this_year_n}0101000001" \
@@ -3529,17 +3506,6 @@ The fixed date will be rolled backward by one year."
 
 		# Day of Year number today
 		today_n="$(date -u +%j)"
-
-		# If the start day number is into the future then back-date by one year
-		if [ "$start_fix_day_n" -gt "$today_n" ]; then
-			not_valid_until_d="$(( start_fix_day_n - today_n ))"
-			this_year_n="$(( this_year_n - 1 ))"
-			# Get user confirmation
-			confirm "  Create certificate with one year back-dated date ? " \
-				"yes" "\
-This certificate will not be valid for ${not_valid_until_d} days.
-The fixed date will be rolled backward by one year."
-		fi
 
 		# New Years day date
 		New_Year_day_d="$(


### PR DESCRIPTION
Currently, --fix-offset does not allow creating post-dated cerificates. Instead, it rolls the start date back by one year.

The reason for this behavior is that --fix-offest was only meant to fix a day of the year but not which year.

This patch simply removes the check for a post-dated certificate, which allows `not-before-date` to be set upto one year in the future.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>