### PR TITLE
Windows, build-ca: Add input password to re-open private key

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1370,23 +1370,34 @@ Please update openssl-easyrsa.cnf to the latest official release."
 		: # passphrase defined
 	else
 		# Assign passphrase vars and temp file
-		p=""
-		q=""
 		in_key_pass_tmp="$(easyrsa_mktemp)" || \
 			die "Failed to create temporary file"
 		out_key_pass_tmp="$(easyrsa_mktemp)" || \
 			die "Failed to create temporary file"
 
-		# Get passphrase
-		prompt="Enter New CA Key Passphrase: "
-		get_passphrase p
+		# Dirty way to unit-test default behavior
+		if [ "$ERSA_UTEST_VERSION" ]; then
+		# Prove this works by changing passwords
+		# use: ERSA_UTEST_VERSION=9 easyrsa build-ca
+			p="EasyRSA"
+			q="EasyRSA"
+			unset -v EASYRSA_PASSIN EASYRSA_PASSOUT
+			warn "SPECIAL unit-test CA password!"
 
-		# Confirm passphrase
-		prompt="Confirm New CA Key Passphrase: "
-		get_passphrase q
+		else
+			p=""
+			q=""
+			# Get passphrase p
+			prompt="Enter New CA Key Passphrase: "
+			get_passphrase p
+
+			# Confirm passphrase q
+			prompt="Confirm New CA Key Passphrase: "
+			get_passphrase q
+		fi
 
 		# Validate passphrase
-		if [ "$p" = "$q" ]; then
+		if [ "$p" ] && [ "$p" = "$q" ]; then
 			printf "%s" "$p" > "$in_key_pass_tmp"
 			printf "%s" "$p" > "$out_key_pass_tmp"
 			unset -v p q

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1474,7 +1474,7 @@ Please update openssl-easyrsa.cnf to the latest official release."
 			${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
 			${EASYRSA_PASSOUT:+ -passout "$EASYRSA_PASSOUT"} \
 			${in_key_pass_tmp:+ -passin file:"$in_key_pass_tmp"} \
-			${out_key_pass_tmp:+ -passin file:"$out_key_pass_tmp"} \
+			${out_key_pass_tmp:+ -passout file:"$out_key_pass_tmp"} \
 				|| die "Failed to build the CA"
 	;;
 	*)	die "build-ca ssl lib: $osslv_major"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1372,6 +1372,8 @@ Please update openssl-easyrsa.cnf to the latest official release."
 		# Assign passphrase vars and temp file
 		p=""
 		q=""
+		in_key_pass_tmp="$(easyrsa_mktemp)" || \
+			die "Failed to create temporary file"
 		out_key_pass_tmp="$(easyrsa_mktemp)" || \
 			die "Failed to create temporary file"
 
@@ -1385,6 +1387,7 @@ Please update openssl-easyrsa.cnf to the latest official release."
 
 		# Validate passphrase
 		if [ "$p" = "$q" ]; then
+			printf "%s" "$p" > "$in_key_pass_tmp"
 			printf "%s" "$p" > "$out_key_pass_tmp"
 			unset -v p q
 		else
@@ -1459,6 +1462,7 @@ Please update openssl-easyrsa.cnf to the latest official release."
 			${EASYRSA_NO_PASS+ "$no_password"} \
 			${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
 			${EASYRSA_PASSOUT:+ -passout "$EASYRSA_PASSOUT"} \
+			${in_key_pass_tmp:+ -passin file:"$in_key_pass_tmp"} \
 			${out_key_pass_tmp:+ -passin file:"$out_key_pass_tmp"} \
 				|| die "Failed to build the CA"
 	;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1371,9 +1371,9 @@ Please update openssl-easyrsa.cnf to the latest official release."
 	else
 		# Assign passphrase vars and temp file
 		in_key_pass_tmp="$(easyrsa_mktemp)" || \
-			die "Failed to create temporary file"
+			die "in_key_pass_tmp: create"
 		out_key_pass_tmp="$(easyrsa_mktemp)" || \
-			die "Failed to create temporary file"
+			die "out_key_pass_tmp: create"
 
 		# Dirty way to unit-test default behavior
 		if [ "$ERSA_UTEST_VERSION" ]; then
@@ -1398,8 +1398,10 @@ Please update openssl-easyrsa.cnf to the latest official release."
 
 		# Validate passphrase
 		if [ "$p" ] && [ "$p" = "$q" ]; then
-			printf "%s" "$p" > "$in_key_pass_tmp"
-			printf "%s" "$p" > "$out_key_pass_tmp"
+			printf "%s" "$p" > "$in_key_pass_tmp" || \
+				die "in_key_pass_tmp: write"
+			printf "%s" "$p" > "$out_key_pass_tmp" || \
+				die "out_key_pass_tmp: write"
 			unset -v p q
 		else
 			die "Passphrases do not match!"
@@ -1414,7 +1416,7 @@ Please update openssl-easyrsa.cnf to the latest official release."
  {print}
 }'
 
-	conf_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	conf_tmp="$(easyrsa_mktemp)" || die "conf_tmp: create"
 	{
 		cat "$EASYRSA_EXT_DIR/ca" "$EASYRSA_EXT_DIR/COMMON"
 		[ "$EASYRSA_EXTRA_EXTS" ] && print "$EASYRSA_EXTRA_EXTS"
@@ -1475,7 +1477,7 @@ Please update openssl-easyrsa.cnf to the latest official release."
 			${EASYRSA_PASSOUT:+ -passout "$EASYRSA_PASSOUT"} \
 			${in_key_pass_tmp:+ -passin file:"$in_key_pass_tmp"} \
 			${out_key_pass_tmp:+ -passout file:"$out_key_pass_tmp"} \
-				|| die "Failed to build the CA"
+				|| die "Failed to build the CA certificate"
 	;;
 	*)	die "build-ca ssl lib: $osslv_major"
 	esac


### PR DESCRIPTION
Using OpenSSL 3.0.7, packaged by OpenVPN Windows installer, causes EasyRSA command 'build-ca' to fail, because it does not have an imput password to re-open the private key, which is required to generate the CA certificate or subCA request file.

Provide the user specified CA passphrase as input password for build-ca.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>