### PR TITLE
cleanup(): General improvements - Create KNOWN error exit

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -585,9 +585,9 @@ Type the word '$value' to continue, or any other input to abort."
 	read input
 	printf '\n'
 	[ "$input" = "$value" ] && return
-	confirm_aborted=1
+	easyrsa_error_exit=1
 	notice "Aborting without confirmation."
-	exit 9
+	cleanup 9
 } # => confirm()
 
 # Generate random hex
@@ -698,15 +698,16 @@ Temporary session not preserved."
 	fi
 
 	# Remove files when build_full()->sign_req() is interrupted
-	[ "$on_error_build_full_cleanup" ] && \
+	[ "$error_build_full_cleanup" ] && \
 		rm -f "$crt_out" "$req_out" "$key_out"
 
 	# Restore files when renew is interrupted
-	[ "$on_error_undo_renew_move" ] && renew_restore_move; :
+	[ "$error_undo_renew_move" ] && renew_restore_move
 	# Restore files when rebuild is interrupted
-	[ "$on_error_undo_rebuild_move" ] && rebuild_restore_move; :
+	[ "$error_undo_rebuild_move" ] && rebuild_restore_move
 
-	# shellcheck disable=SC3040 # In POSIX sh, set option [name] is undefined
+	# shellcheck disable=SC3040
+	# In POSIX sh, set option [name] is undefined
 	case "$easyrsa_host_os" in
 		nix) [ -t 1 ] && stty echo ;;
 		win)
@@ -719,27 +720,34 @@ Temporary session not preserved."
 		*) warn "Host OS undefined."
 	esac
 
-	if [ "$EASYRSA_BATCH" ] || [ "$EASYRSA_SILENT" ]; then
+	if [ "$EASYRSA_BATCH" ] || [ "$EASYRSA_SILENT" ]
+	then
 		: # ok
 	else
-		print # To get a clean line after terminal echo is disabled
+		print # To get a clean line
 	fi
 
-	# Exit with error 1, if an error ocured...
+	# Clear traps
+	trap - 0 1 2 3 6 15
+
+	# Final exit
 	if [ "$easyrsa_error_exit" ]; then
-		# Set by verify_cert() for full error-out
-		exit 1
+		# Known errors:
+		# -> confirm(): aborted
+		# -> verify_cert(): verify failed
+		exit "${1:-1}"
 	elif [ "$1" = ok ]; then
-		# if there is no error then 'cleanup ok' is called
+		# if there is no error
+		# then 'cleanup ok' is called
 		exit 0
 	elif [ "$1" = 2 ]; then
 		# SIGINT
 		kill -2 "$$"
 	else
-		# if 'cleanup' is called without 'ok' then an error occurred
-		# Do not show_host() for confirm() aborted exit
-		[ "$confirm_aborted" ] || show_host
-		exit 1
+		# if 'cleanup' is called without 'ok'
+		# then an error occurred
+		show_host
+		exit "${1:-1}"
 	fi
 } # => cleanup()
 
@@ -1922,9 +1930,9 @@ Option conflict: '$cmd' does not support setting an external commonName"
 	gen_req "$name" batch
 
 	# Sign it
-	on_error_build_full_cleanup=1
+	error_build_full_cleanup=1
 	if sign_req "$crt_type" "$name"; then
-		unset -v on_error_build_full_cleanup
+		unset -v error_build_full_cleanup
 	else
 		die "Failed to sign '$name' - See error messages above for details."
 	fi
@@ -2270,11 +2278,11 @@ with the following subject:
 
 	# move renewed files so we can reissue certificate with the same name
 	renew_move
-	on_error_undo_renew_move=1
+	error_undo_renew_move=1
 
 	# renew certificate
 	if EASYRSA_BATCH=1 sign_req "$cert_type" "$file_name_base"; then
-		unset -v on_error_undo_renew_move
+		unset -v error_undo_renew_move
 	else
 		# If renew failed then restore cert. Otherwise, issue a warning
 		renew_restore_move
@@ -2297,7 +2305,7 @@ use: 'revoke-renewed $file_name_base reason' ('reason' is optional)"
 
 # Restore files on failure to renew
 renew_restore_move() {
-	unset -v rrm_err on_error_undo_renew_move
+	unset -v rrm_err error_undo_renew_move
 	# restore crt file to PKI folders
 	if mv "$restore_crt_out" "$restore_crt_in"; then
 		: # ok
@@ -2766,11 +2774,11 @@ with the following subject:
 
 	# move renewed files so we can reissue certificate with the same name
 	rebuild_move
-	on_error_undo_rebuild_move=1
+	error_undo_rebuild_move=1
 
 	# rebuild certificate
 	if EASYRSA_BATCH=1 build_full "$cert_type" "$file_name_base"; then
-		unset -v on_error_undo_rebuild_move
+		unset -v error_undo_rebuild_move
 	else
 		# If rebuild failed then restore cert, key and req. Otherwise,
 		# issue a warning. If *restore* fails then at least the file-names
@@ -2795,7 +2803,7 @@ use: 'revoke-renewed $file_name_base reason' ('reason' is optional)"
 
 # Restore files on failure to rebuild
 rebuild_restore_move() {
-	unset -v rrm_err on_error_undo_renew_move
+	unset -v rrm_err error_undo_renew_move
 	# restore crt, key and req file to PKI folders
 	if mv "$restore_crt_out" "$restore_crt_in"; then
 		: # ok
@@ -5092,7 +5100,7 @@ trap "exit 14" 15
 detect_host
 
 # Initialisation requirements
-unset -v confirm_aborted easyrsa_error_exit \
+unset -v easyrsa_error_exit \
 	user_san_true user_vars_true alias_days
 
 # Parse options
@@ -5424,8 +5432,7 @@ esac
 # shellcheck disable=SC2181
 [ $? = 0 ] || warn "Untrapped error detected!"
 
-# Clear traps and do 'cleanup ok' on successful completion
-trap - 0 1 2 3 6 15
+# Do 'cleanup ok' on successful completion
 cleanup ok
 
 # vim: ft=sh nu ai sw=8 ts=8 noet

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1923,7 +1923,8 @@ Matching file found at: "
 
 	# Set commonName
 	[ "$EASYRSA_REQ_CN" = ChangeMe ] || die "\
-Option conflict: '$cmd' does not support setting an external commonName"
+Option conflict:
+* '$cmd' does not support setting an external commonName"
 	EASYRSA_REQ_CN="$name"
 
 	# create request
@@ -1934,19 +1935,27 @@ Option conflict: '$cmd' does not support setting an external commonName"
 	if sign_req "$crt_type" "$name"; then
 		unset -v error_build_full_cleanup
 	else
-		die "Failed to sign '$name' - See error messages above for details."
+		die "\
+Failed to sign '$name' - \
+See error messages above for details."
 	fi
 
 	# inline it
 	if [ "$EASYRSA_INLINE" ]; then
 		inline_file="$EASYRSA_PKI/$name.creds"
 		if [ -e "$inline_file" ]; then
-			warn "Inline file exists not over-writing: $inline_file"
+			warn "\
+Inline file exists not over-writing:
+* $inline_file"
 		else
 			if inline_creds; then
-				notice "Inline file created: $inline_file"
+				notice "\
+Inline file created:
+* $inline_file"
 			else
-				warn "Failed to write inline file: $inline_file"
+				warn "\
+Failed to write inline file:
+* $inline_file"
 			fi
 		fi
 	fi
@@ -2287,7 +2296,7 @@ with the following subject:
 		# If renew failed then restore cert. Otherwise, issue a warning
 		renew_restore_move
 		die "\
-Renewal has failed to build a new certificate/key pair."
+Renewal has failed to build a new certificate."
 	fi
 
 	# Success messages


### PR DESCRIPTION
cleanup(): General improvements - Create KNOWN error exit

Where errors are known, exit via 'Known' branch.
Allow preset error number to propagate.

Long line wrapping. Shorten associated variable names.

Move clearing traps to within cleanup().


Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>