### PR TITLE
build-ca: Change FATAL error to warning for old openssl-easyrsa.cnf

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1333,9 +1333,13 @@ Missing X509-type 'ca'"
 Missing X509-type 'COMMON'"
 
 	# Check for insert-marker in ssl config file
-	if ! grep -q '^#%CA_X509_TYPES_EXTRA_EXTS%' "$EASYRSA_SSL_CONF"; then
-		die "\
-The copy of openssl-easyrsa.cnf in use does not support X509-type 'ca'.
+	if grep -q '^#%CA_X509_TYPES_EXTRA_EXTS%' \
+		"$EASYRSA_SSL_CONF"
+	then
+		[ "$EASYRSA_BATCH" ] || print
+	else
+		warn "\
+The openssl config file in use does not support X509-type 'ca'.
 * $EASYRSA_SSL_CONF
 Please update openssl-easyrsa.cnf to the latest official release."
 	fi


### PR DESCRIPTION
This will only effect a CA built with custom EASYRSA_EXTRA_EXTS; The solution being, to use the correct 'openssl-easyrsa.cnf'.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>