### PR TITLE
build-ca: Old openssl-easyrsa.cnf is a FATAL error

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1332,12 +1332,10 @@ Missing X509-type 'ca'"
 Missing X509-type 'COMMON'"
 
 	# Check for insert-marker in ssl config file
-	if grep -q '^#%CA_X509_TYPES_EXTRA_EXTS%' \
+	if ! grep -q '^#%CA_X509_TYPES_EXTRA_EXTS%' \
 		"$EASYRSA_SSL_CONF"
 	then
-		: # [ "$EASYRSA_BATCH" ] || print
-	else
-		warn "\
+		die "\
 This openssl config file does not support X509-type 'ca'.
 * $EASYRSA_SSL_CONF
 Please update openssl-easyrsa.cnf to the latest release."


### PR DESCRIPTION
Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>