### PR TITLE
Global option '--passout' always take priority ONLY

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1284,7 +1284,9 @@ build_ca() {
 	while [ "$1" ]; do
 		case "$1" in
 			intca|subca) sub_ca=1 ;;
-			nopass) EASYRSA_NO_PASS=1 ;;
+			nopass)
+				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
+			;;
 			*) warn "Ignoring unknown command option: '$1'"
 		esac
 		shift
@@ -1599,7 +1601,9 @@ Run easyrsa without commands for usage and commands."
 	while [ "$1" ]; do
 		case "$1" in
 			text) text=1 ;;
-			nopass) EASYRSA_NO_PASS=1 ;;
+			nopass)
+				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
+			;;
 			# batch flag supports internal callers needing silent operation
 			batch) ssl_batch=1 ;;
 			*) warn "Ignoring unknown command option: '$1'"
@@ -1917,7 +1921,10 @@ Run easyrsa without commands for usage and commands."
 	# function opts support
 	while [ "$1" ]; do
 		case "$1" in
-			nopass) EASYRSA_NO_PASS=1 ;;
+			nopass)
+				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
+			;;
+			inline) EASYRSA_INLINE=1 ;;
 			*) warn "Ignoring unknown command option: '$1'"
 		esac
 		shift
@@ -2749,11 +2756,15 @@ Run easyrsa without commands for usage and command help."
 	up23_upgrade_ca || die "Failed to upgrade CA to support renewal."
 
 	# Set 'nopass'
-	case "$1" in
-		nopass) EASYRSA_NO_PASS=1; shift ;;
-		'') : ;; # Empty ok
-		*) die "Unknown option: $1"
-	esac
+	while [ "$1" ]; do
+		case "$1" in
+			nopass)
+				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
+			;;
+			*) die "Unknown option: $1"
+		esac
+		shift
+	done
 
 	# referenced cert must exist:
 	[ -f "$crt_in" ] || die "\
@@ -3090,7 +3101,9 @@ Run easyrsa without commands for usage and command help."
 		case "$1" in
 			noca) want_ca="" ;;
 			nokey) want_key="" ;;
-			nopass) EASYRSA_NO_PASS=1 ;;
+			nopass)
+				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
+			;;
 			usefn) pkcs_friendly_name="$short_name" ;;
 			*) warn "Ignoring unknown command option: '$1'"
 		esac
@@ -3204,7 +3217,9 @@ See help output for usage details."
 	unset -v nopass
 	while [ "$1" ]; do
 		case "$1" in
-			nopass) EASYRSA_NO_PASS=1 ;;
+			nopass)
+				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
+			;;
 			file) file="$raw_file" ;;
 			*) warn "Ignoring unknown command option: '$1'"
 		esac
@@ -3261,7 +3276,9 @@ Missing argument: no name/file supplied."
 	cipher="-aes256"
 	while [ "$1" ]; do
 		case "$1" in
-			nopass) EASYRSA_NO_PASS=1 ;;
+			nopass)
+				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
+			;;
 			file) file="$raw_file" ;;
 			*) warn "Ignoring unknown command option: '$1'"
 		esac
@@ -5188,13 +5205,18 @@ trap "exit 14" 15
 detect_host
 
 # Initialisation requirements
-unset -v easyrsa_error_exit \
-	user_san_true user_vars_true alias_days
+unset -v \
+	easyrsa_error_exit \
+	prohibit_no_pass \
+	user_vars_true \
+	user_san_true \
+	alias_days
 
 # Parse options
 while :; do
 	# Reset per pass flags
-	unset -v opt val is_empty empty_ok number_only zero_allowed
+	unset -v opt val \
+		is_empty empty_ok number_only zero_allowed
 
 	# Separate option from value:
 	opt="${1%%=*}"
@@ -5209,7 +5231,8 @@ while :; do
 	case "$opt" in
 	--days)
 		number_only=1
-		# Set the appropriate date variable when called by command later
+		# Set the appropriate date variable
+		# when called by command later
 		alias_days="$val"
 		;;
 	--fix-offset)
@@ -5345,7 +5368,8 @@ subjectAltName = $val"
 
 	# fatal error when no value was provided
 	if [ "$is_empty" ]; then
-		[ "$empty_ok" ] || die "Missing value to option: $opt"
+		[ "$empty_ok" ] || \
+			die "Missing value to option: $opt"
 	fi
 
 	# fatal error when a number is expected but not provided
@@ -5364,7 +5388,8 @@ subjectAltName = $val"
 	shift
 done
 
-# Set cmd now because vars_setup needs to know if this is init-pki
+# Set cmd now
+# vars_setup needs to know if this is init-pki
 cmd="$1"
 [ "$1" ] && shift # scrape off command
 
@@ -5379,18 +5404,18 @@ case "$cmd" in
 		unset -v no_pki_required
 esac
 
-# Mutual exclusions
-# --nopass cannot be used with --passin and --passout
-if [ "$EASYRSA_NO_PASS" ] && \
-	{ [ "$EASYRSA_PASSIN" ] || [ "$EASYRSA_PASSOUT" ]; }
-then
-	die "* Cannot use --nopass with --passin or --passout"
-fi
-
 # Intelligent env-var detection and auto-loading:
 vars_setup
 
-# determine how we were called, then hand off to the function responsible
+# Mutual exclusions:
+# --nopass cannot be used with --passout
+if [ "$EASYRSA_PASSOUT" ]; then
+	# --passout MUST take priority over --nopass
+	unset -v EASYRSA_NO_PASS
+	prohibit_no_pass=1
+fi
+
+# Hand off to the function responsible
 case "$cmd" in
 	init-pki|clean-all)
 		init_pki "$@"


### PR DESCRIPTION
Option '--passout' MUST take priority over '--nopass' and 'nopass'. Otherwise, the private key is unintentionally created unencrypted.

Option '--passin' must NOT take priority.
Otherwise, it is not possible to automatically create an entity key without a password, if the CA key is created with a password.

Initialisation: Wrap long lines

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>