### PR TITLE
Option --fix-offset: Adjust off-by-one day

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3599,6 +3599,9 @@ fixed_cert_dates() {
 		die "Fixed off-set range [1-365 days]: $start_fix_day_n"
 	fi
 
+	# Final offset is off-by-one, adjust now
+	start_fix_day_n="$(( start_fix_day_n - 1 ))"
+
 	# Set the end fixed day-number of the Year
 	end_fix_day_n="$(( start_fix_day_n + EASYRSA_CERT_EXPIRE ))"
 


### PR DESCRIPTION
The current code calculates --fix-offset=1 as January 2nd.

This decreases the input value by one, which results in --fix-offset=1 being January 1st.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>