### PR TITLE
fixed_cert_dates(): Remove subshell

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3440,7 +3440,8 @@ No certificate found for the input: '$crt_in'"
 Input is not a valid certificate: $crt_in"
 
 	# Test SSL out
-	if easyrsa_openssl verify -CAfile "$ca_crt" "$crt_in" 1>/dev/null
+	if easyrsa_openssl verify -CAfile "$ca_crt" \
+		"$crt_in" 1>/dev/null
 	then
 		notice "\
   Certificate name:   $file_name_base
@@ -3451,9 +3452,12 @@ Input is not a valid certificate: $crt_in"
   Certificate name:   $file_name_base
   Verfication status: FAILED"
 		# Exit with error (batch mode), otherwise term msg only
-		[ "$exit_with_error" ] && easyrsa_error_exit=1
-		# Return error for internal callers (status reports)
-		return 1
+		if [ "$exit_with_error" ]; then
+			easyrsa_error_exit=1
+			# Return error for internal callers (status reports)
+			# or command line in --batch mode
+			return 1
+		fi
 	fi
 } # => verify_cert()
 
@@ -5523,7 +5527,8 @@ case "$cmd" in
 		init_pki "$@"
 		;;
 	build-ca)
-		[ "$alias_days" ] && export EASYRSA_CA_EXPIRE="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CA_EXPIRE="$alias_days"
 		build_ca "$@"
 		;;
 	gen-dh)
@@ -5533,23 +5538,28 @@ case "$cmd" in
 		gen_req "$@"
 		;;
 	sign|sign-req)
-		[ "$alias_days" ] && export EASYRSA_CERT_EXPIRE="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CERT_EXPIRE="$alias_days"
 		sign_req "$@"
 		;;
 	build-client-full)
-		[ "$alias_days" ] && export EASYRSA_CERT_EXPIRE="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CERT_EXPIRE="$alias_days"
 		build_full client "$@"
 		;;
 	build-server-full)
-		[ "$alias_days" ] && export EASYRSA_CERT_EXPIRE="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CERT_EXPIRE="$alias_days"
 		build_full server "$@"
 		;;
 	build-serverClient-full)
-		[ "$alias_days" ] && export EASYRSA_CERT_EXPIRE="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CERT_EXPIRE="$alias_days"
 		build_full serverClient "$@"
 		;;
 	gen-crl)
-		[ "$alias_days" ] && export EASYRSA_CRL_DAYS="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CRL_DAYS="$alias_days"
 		gen_crl
 		;;
 	revoke)
@@ -5559,14 +5569,16 @@ case "$cmd" in
 		revoke_renewed "$@"
 		;;
 	renew)
-		[ "$alias_days" ] && export EASYRSA_CERT_EXPIRE="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CERT_EXPIRE="$alias_days"
 		renew "$@"
 		;;
 	rewind-renew)
 		rewind_renew "$@"
 		;;
 	rebuild)
-		[ "$alias_days" ] && export EASYRSA_CERT_EXPIRE="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CERT_EXPIRE="$alias_days"
 		rebuild "$@"
 		;;
 	import-req)
@@ -5609,13 +5621,11 @@ case "$cmd" in
 		show_ca "$@"
 		;;
 	verify)
-		# using internal 'batch' mode, this can return an error
-		# Ignore the error here, catch the error if used internally
-		# eg. show-expire/expire_status
-		verify_cert "$@" || :
+		verify_cert "$@"
 		;;
 	show-expire)
-		[ "$alias_days" ] && export EASYRSA_CERT_RENEW="$alias_days"; :
+		[ -z "$alias_days" ] || \
+			export EASYRSA_CERT_RENEW="$alias_days"
 		status expire "$@"
 		;;
 	show-revoke)
@@ -5640,7 +5650,8 @@ case "$cmd" in
 		print_version
 		;;
 	*)
-		die "Unknown command '$cmd'. Run without commands for usage help."
+		die "\
+Unknown command '$cmd'. Run without commands for usage help."
 esac
 
 # Check for untrapped errors

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3830,35 +3830,41 @@ offset_days_to_cert_date \
 
 # Convert fixed format date to X509 certificate style date
 ff_date_to_cert_date() {
+	# check input
+	[ "$#" -eq 2 ] || die "\
+ff_date_to_cert_date - input error"
 
 	in_date="$1"
 
 	# busybox
 	if busybox date --help > /dev/null 2>&1
 	then
-		cert_type_date="$(
-			busybox date -u -D "%y-%m-%d %H:%M:%S%Z" \
-				-d "$in_date" \
-				"+%b %d %H:%M:%S %Y %Z" 2>/dev/null
-			)"
-		return
+		out_date="$(
+			busybox date -u \
+				-D "%y-%m-%d %H:%M:%S%Z" \
+				-d "$in_date" "+%b %d %H:%M:%S %Y %Z" \
+				2>/dev/null
+			)" || die "\
+ff_date_to_cert_date - out_date - busybox"
 
 	# Darwin, BSD
-	elif cert_type_date="$(
-			date -u -j -f '%y-%m-%d %TZ' "$in_date" \
-				"+%b %d %H:%M:%S %Y %Z" 2>/dev/null
+	elif out_date="$(
+			date -u -j -f '%y-%m-%d %TZ' \
+				"$in_date" "+%b %d %H:%M:%S %Y %Z" \
+				2>/dev/null
 			)"
-	then return
+	then : # ok
 
 	# OS dependencies
 	# Linux and Windows
 	# * date.exe does not support format +%s as input
 	# MacPorts GNU date
-	elif cert_type_date="$(
+	elif out_date="$(
 			date -u -d "$in_date" \
-				"+%b %d %H:%M:%S %Y %Z" 2>/dev/null
+				"+%b %d %H:%M:%S %Y %Z" \
+				2>/dev/null
 			)"
-	then return
+	then : # ok
 
 	# Something else
 	else
@@ -3866,6 +3872,13 @@ ff_date_to_cert_date() {
 ff_date_to_cert_date:
 'date' failed for 'in_date': $in_date"
 	fi
+
+	# Return offset_date
+	safe_set_var "$2" "$out_date" || die "\
+ff_date_to_cert_date \
+- safe_set_var - $2 - $out_date"
+
+	unset -v in_date out_date
 } # => ff_date_to_cert_date()
 
 # Fixed format date
@@ -4070,7 +4083,8 @@ serial mismatch:
 		# Translate db date to usable date
 		#cert_source=database
 		db_date_to_ff_date "$db_notAfter" # Assigns ff_date
-		ff_date_to_cert_date "$ff_date" # Assigns cert_type_date
+		cert_type_date=
+		ff_date_to_cert_date "$ff_date" cert_type_date
 		# Use db translated date
 		cert_not_after_date="$cert_type_date"
 	fi
@@ -4115,7 +4129,8 @@ revoke_status() {
 	# Translate db date to usable date
 	#source_date=database
 	db_date_to_ff_date "$db_revoke_date" # Assigns ff_date
-	ff_date_to_cert_date "$ff_date" # Assigns cert_type_date
+	cert_type_date=
+	ff_date_to_cert_date "$ff_date" cert_type_date
 	# Use db translated date
 	cert_revoke_date="$cert_type_date"
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3919,7 +3919,7 @@ safe_set_var() {
 	# check for simple errors
 	case "$1" in
 		[1234567890]*|*[-.\ ]*)
-			die "safe_set_var - var"
+			die "safe_set_var - $1"
 	esac
 	eval "$1"=1 || die "safe_set_var - eval"
 	unset -v "$1" || die "safe_set_var - unset"
@@ -3938,8 +3938,7 @@ ssl_cert_serial() {
 	# remove the serial= part -> we only need the XXXX part
 	fn_ssl_out="${fn_ssl_out##*=}"
 
-	shift
-	safe_set_var "$*" "$fn_ssl_out" || \
+	safe_set_var "$2" "$fn_ssl_out" || \
 		die "ssl_cert_serial - failed to set var '$*'"
 
 	unset -v fn_ssl_out
@@ -3947,38 +3946,42 @@ ssl_cert_serial() {
 
 # Get certificate start date
 ssl_cert_not_before_date() {
-	[ "$#" = 2 ] || die "ssl_cert_not_before_date - invalid input"
-	[ -f "$1" ] || die "ssl_cert_not_before_date - missing cert"
+	[ "$#" = 2 ] || die "\
+ssl_cert_not_before_date - invalid input"
+	[ -f "$1" ] || die "\
+ssl_cert_not_before_date - missing cert"
 
 	fn_ssl_out="$(
 		unset -v EASYRSA_DEBUG
 		easyrsa_openssl x509 -in "$1" -noout -startdate
-		)" || die "ssl_cert_not_before_date - failed: -startdate"
+		)" || die "\
+ssl_cert_not_before_date - failed: -startdate"
 
 	fn_ssl_out="${fn_ssl_out#*=}"
 
-	shift
-	safe_set_var "$*" "$fn_ssl_out" || \
-		die "ssl_cert_not_before_date - failed to set var '$*'"
+	safe_set_var "$2" "$fn_ssl_out" || die "\
+ssl_cert_not_before_date - failed to set var '$*'"
 
 	unset -v fn_ssl_out
 } # => ssl_cert_not_before_date()
 
 # Get certificate end date
 ssl_cert_not_after_date() {
-	[ "$#" = 2 ] || die "ssl_cert_not_after_date - invalid input"
-	[ -f "$1" ] || die "ssl_cert_not_after_date - missing cert"
+	[ "$#" = 2 ] || die "\
+ssl_cert_not_after_date - invalid input"
+	[ -f "$1" ] || die "\
+ssl_cert_not_after_date - missing cert"
 
 	fn_ssl_out="$(
 		unset -v EASYRSA_DEBUG
 		easyrsa_openssl x509 -in "$1" -noout -enddate
-		)" || die "ssl_cert_not_after_date - failed: -enddate"
+		)" || die "\
+ssl_cert_not_after_date - failed: -enddate"
 
 	fn_ssl_out="${fn_ssl_out#*=}"
 
-	shift
-	safe_set_var "$*" "$fn_ssl_out" || \
-		die "ssl_cert_not_after_date - failed to set var '$*'"
+	safe_set_var "$2" "$fn_ssl_out" || die "\
+ssl_cert_not_after_date - failed to set var '$*'"
 
 	unset -v fn_ssl_out
 } # => ssl_cert_not_after_date()

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3727,6 +3727,9 @@ fixed_cert_dates - safe_set_var - $3 - $end_fix_day_d"
 
 # Convert certificate date to timestamp seconds since epoch
 cert_date_to_timestamp_s() {
+	# check input
+	[ "$#" -eq 2 ] || die "\
+cert_date_to_timestamp_s - input error"
 
 	in_date="$1"
 
@@ -3734,26 +3737,27 @@ cert_date_to_timestamp_s() {
 	if busybox date --help > /dev/null 2>&1
 	then
 		timestamp_s="$(
-			busybox date -D "%b %e %H:%M:%S %Y" -d "$in_date" +%s \
-				2>/dev/null
-			)"
-		return
+			busybox date -D "%b %e %H:%M:%S %Y" \
+				-d "$in_date" +%s 2>/dev/null
+			)" || die "\
+cert_date_to_timestamp_s - out_date_s - busybox"
 
 	# Darwin, BSD
 	elif timestamp_s="$(
-		date -j -f '%b %d %T %Y %Z' "$in_date" +%s \
-			2>/dev/null
-		)"
-	then return
+			date -j -f '%b %d %T %Y %Z' \
+				"$in_date" +%s 2>/dev/null
+			)"
+	then : # ok
 
 	# OS dependencies
-	# Linux and Windows: date.exe does not allow +%s as input
+	# Linux and Windows
+	# date.exe does not allow +%s as input
 	# MacPorts GNU date
 	elif timestamp_s="$(
-		date -d "$in_date" +%s \
-			2>/dev/null
-		)"
-	then return
+			date -d "$in_date" +%s \
+				2>/dev/null
+			)"
+	then : # ok
 
 	# Something else
 	else
@@ -3761,6 +3765,12 @@ cert_date_to_timestamp_s() {
 cert_date_to_timestamp_s:
 'date' failed for 'in_date': $in_date"
 	fi
+
+	# Return timestamp_s
+	safe_set_var "$2" "$timestamp_s" || die "\
+cert_date_to_timestamp_s - safe_set_var - $2 - $timestamp_s"
+
+	unset -v in_date timestamp_s
 } # => cert_date_to_timestamp_s()
 
 # Convert system date to X509 certificate style date (+)offset
@@ -4038,7 +4048,8 @@ serial mismatch:
 		fi
 
 		#cert_source=issued
-		ssl_cert_not_after_date "$cert_issued" cert_not_after_date
+		ssl_cert_not_after_date \
+			"$cert_issued" cert_not_after_date
 
 	else
 		# Translate db date to usable date
@@ -4050,18 +4061,21 @@ serial mismatch:
 	fi
 
 	# Get timestamp seconds for certificate expiry date
-	cert_date_to_timestamp_s "$cert_not_after_date" # Assigns timestamp_s
-	cert_expire_date_s="$timestamp_s"
+	cert_expire_date_s=
+	cert_date_to_timestamp_s \
+		"$cert_not_after_date" cert_expire_date_s
 
 	# Set the cutoff date for expiry comparison
 	offset_days_to_cert_date "$EASYRSA_CERT_RENEW" # Assigns cert_type_date
-	cert_date_to_timestamp_s "$cert_type_date" # Assigns timestamp_s
-	cutoff_date_s="$timestamp_s"
+	cutoff_date_s=
+	cert_date_to_timestamp_s \
+		"$cert_type_date" cutoff_date_s
 
 	# Set NOW date for expiry comparison
 	offset_days_to_cert_date 0 # Assigns cert_type_date
-	cert_date_to_timestamp_s "$cert_type_date" # Assigns timestamp_s
-	now_date_s="$timestamp_s"
+	now_date_s=
+	cert_date_to_timestamp_s \
+		"$cert_type_date" now_date_s
 
 	if [ "$cert_expire_date_s" -lt "$cutoff_date_s" ]; then
 		# Cert expires in less than grace period

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3773,44 +3773,59 @@ cert_date_to_timestamp_s - safe_set_var - $2 - $timestamp_s"
 	unset -v in_date timestamp_s
 } # => cert_date_to_timestamp_s()
 
-# Convert system date to X509 certificate style date (+)offset
-# TODO minus (-)offset
+# Convert system date plus offset days
+# to X509 certificate style date (+)offset
 offset_days_to_cert_date() {
+	# check input
+	[ "$#" -eq 2 ] || die "\
+offset_days_to_cert_date - input error"
 
-	offset="$1"
+	in_offset="$1"
 
 	# busybox (Alpine)
 	if busybox date --help > /dev/null 2>&1
 	then
-		cert_type_date="$(
+		offset_date="$(
 			busybox date -u -d \
-				"@$(( $(busybox date +%s) + offset * 86400 ))" \
-				"+%b %d %H:%M:%S %Y %Z" 2>/dev/null
-			)"
-		return
+				"@$(( $(busybox date +%s) \
+					+ in_offset * 86400 ))" \
+				"+%b %d %H:%M:%S %Y %Z" \
+				2>/dev/null
+			)" || die "\
+offset_days_to_cert_date - offset_date - busybox"
 
 	# Darwin, BSD
-	elif cert_type_date="$(
-		date -u -j -v "+${offset}d" "+%b %d %H:%M:%S %Y %Z" \
-			2>/dev/null
-		)"
-	then return
+	elif offset_date="$(
+			date -u -j -v "+${in_offset}d" \
+				"+%b %d %H:%M:%S %Y %Z" \
+				2>/dev/null
+			)"
+	then : # ok
 
 	# OS dependencies
-	# Linux and Windows: date.exe does not allow +%s as input
+	# Linux and Windows
+	# date.exe does not allow +%s as input
 	# MacPorts GNU date
-	elif cert_type_date="$(
-		date -u -d "+${offset}days" "+%b %d %H:%M:%S %Y %Z" \
-			2>/dev/null
-		)"
-	then return
+	elif offset_date="$(
+			date -u -d "+${in_offset}days" \
+				"+%b %d %H:%M:%S %Y %Z" \
+				2>/dev/null
+			)"
+	then : # ok
 
 	# Something else
 	else
 		die "\
 offset_days_to_cert_date:
-'date' failed for 'offset': $offset"
+'date' failed for 'in_offset': $in_offset"
 	fi
+
+	# Return offset_date
+	safe_set_var "$2" "$offset_date" || die "\
+offset_days_to_cert_date \
+- safe_set_var - $2 - $offset_date"
+
+	unset -v in_offset offset_date
 } # => offset_days_to_cert_date()
 
 # Convert fixed format date to X509 certificate style date
@@ -4066,13 +4081,17 @@ serial mismatch:
 		"$cert_not_after_date" cert_expire_date_s
 
 	# Set the cutoff date for expiry comparison
-	offset_days_to_cert_date "$EASYRSA_CERT_RENEW" # Assigns cert_type_date
+	cert_type_date=
+	offset_days_to_cert_date \
+		"$EASYRSA_CERT_RENEW" cert_type_date
 	cutoff_date_s=
 	cert_date_to_timestamp_s \
 		"$cert_type_date" cutoff_date_s
 
 	# Set NOW date for expiry comparison
-	offset_days_to_cert_date 0 # Assigns cert_type_date
+	cert_type_date=
+	offset_days_to_cert_date \
+		0 cert_type_date
 	now_date_s=
 	cert_date_to_timestamp_s \
 		"$cert_type_date" now_date_s

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3873,7 +3873,7 @@ ff_date_to_cert_date:
 'date' failed for 'in_date': $in_date"
 	fi
 
-	# Return offset_date
+	# Return out_date
 	safe_set_var "$2" "$out_date" || die "\
 ff_date_to_cert_date \
 - safe_set_var - $2 - $out_date"
@@ -3884,24 +3884,34 @@ ff_date_to_cert_date \
 # Fixed format date
 # Build a Windows date.exe compatible input field
 db_date_to_ff_date() {
-	unset -v ff_date
-	ff_date="$1"
-	[ "$ff_date" ] || die "ff_date: '$ff_date'"
-	yy="${ff_date%???????????}"
-	ff_date="${ff_date#"$yy"}"
-	mm="${ff_date%?????????}"
-	ff_date="${ff_date#"$mm"}"
-	dd="${ff_date%???????}"
-	ff_date="${ff_date#"$dd"}"
-	HH="${ff_date%?????}"
-	ff_date="${ff_date#"$HH"}"
-	MM="${ff_date%???}"
-	ff_date="${ff_date#"$MM"}"
-	SS="${ff_date%?}"
-	ff_date="${ff_date#"$SS"}"
-	TZ="$ff_date"
-	ff_date="${yy}-${mm}-${dd} ${HH}:${MM}:${SS}${TZ}"
-} # => build_ff_date_string()
+	# check input
+	[ "$#" -eq 2 ] || die "\
+db_date_to_ff_date - input error"
+
+	in_date="$1"
+
+	yy="${in_date%???????????}"
+	in_date="${in_date#"$yy"}"
+	mm="${in_date%?????????}"
+	in_date="${in_date#"$mm"}"
+	dd="${in_date%???????}"
+	in_date="${in_date#"$dd"}"
+	HH="${in_date%?????}"
+	in_date="${in_date#"$HH"}"
+	MM="${in_date%???}"
+	in_date="${in_date#"$MM"}"
+	SS="${in_date%?}"
+	in_date="${in_date#"$SS"}"
+	TZ="$in_date"
+	out_date="${yy}-${mm}-${dd} ${HH}:${MM}:${SS}${TZ}"
+
+	# Return out_date
+	safe_set_var "$2" "$out_date" || die "\
+db_date_to_ff_date \
+- safe_set_var - $2 - $out_date"
+
+	unset -v in_date out_date yy mm dd HH MM SS TZ
+} # => db_date_to_ff_date()
 
 # sanatize and set var
 safe_set_var() {
@@ -4082,7 +4092,8 @@ serial mismatch:
 	else
 		# Translate db date to usable date
 		#cert_source=database
-		db_date_to_ff_date "$db_notAfter" # Assigns ff_date
+		ff_date=
+		db_date_to_ff_date "$db_notAfter" ff_date
 		cert_type_date=
 		ff_date_to_cert_date "$ff_date" cert_type_date
 		# Use db translated date
@@ -4128,7 +4139,8 @@ serial mismatch:
 revoke_status() {
 	# Translate db date to usable date
 	#source_date=database
-	db_date_to_ff_date "$db_revoke_date" # Assigns ff_date
+	ff_date=
+	db_date_to_ff_date "$db_revoke_date" ff_date
 	cert_type_date=
 	ff_date_to_cert_date "$ff_date" cert_type_date
 	# Use db translated date

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1756,15 +1756,8 @@ File Path: $req_in"
 
 	# Get fixed dates by --fix-offset
 	if [ "$EASYRSA_FIX_OFFSET" ]; then
-		fixed_dates="$( # subshell for debug
-			[ "$EASYRSA_DEBUG" ] && set -x
-			fixed_cert_dates "$EASYRSA_FIX_OFFSET"
-		)" # Close subshell
-		start_fixdate="${fixed_dates% *}"
-		end_fixdate="${fixed_dates#* }"
-		unset -v fixed_dates
-	else
-		unset -v start_fixdate end_fixdate
+		fixed_cert_dates "$EASYRSA_FIX_OFFSET" \
+			start_fixdate end_fixdate
 	fi
 
 	# When EASYRSA_CP_EXT is defined, adjust openssl's [default_ca] section:
@@ -3584,54 +3577,62 @@ OpenSSL failure to process the input"
 
 # Set fixed offset dates
 fixed_cert_dates() {
+	# check input
+	[ "$#" -eq 3 ] || die "fixed_cert_dates - input error"
+
 	# Set the start fixed day-number of the Year
 	start_fix_day_n="$1"
 
-	# Check offset is numeric
-	case "$start_fix_day_n" in
-	(''|*[!1234567890]*|0*)
-		die "fixed_cert_dates - Number expected: $start_fix_day_n"
-	esac
-
 	# Check offset range
-	if [ 1 -gt "$start_fix_day_n" ] || [ 365 -lt "$start_fix_day_n" ]
+	if [ "$start_fix_day_n" -lt 1 ] || \
+		[ "$start_fix_day_n" -gt 365 ]
 	then
-		die "Fixed off-set range [1-365 days]: $start_fix_day_n"
+		die "\
+Fixed off-set range [1-365 days]: $start_fix_day_n"
 	fi
 
 	# Final offset is off-by-one, adjust now
 	start_fix_day_n="$(( start_fix_day_n - 1 ))"
 
 	# Set the end fixed day-number of the Year
-	end_fix_day_n="$(( start_fix_day_n + EASYRSA_CERT_EXPIRE ))"
+	end_fix_day_n="$((
+		start_fix_day_n + EASYRSA_CERT_EXPIRE
+		))"
 
 	# OS dependencies
 
-	# busybox - Works best with seconds since epoch
-	# busybox can probably do this better, this was writen for 'date'
+	# busybox
 	if busybox date --help > /dev/null 2>&1; then
 
 		this_year_n="$(busybox date -u +%y)"
 		#today_n="$(busybox date -u +%j)"
 
 		New_Year_day_s="$(
-			busybox date -u -d "${this_year_n}01010000.01" '+%s'
-			)"
+			busybox date -u -d \
+				"${this_year_n}01010000.01" '+%s'
+			)" || die "\
+fixed_cert_dates - New_Year_day_s - busybox"
 
 		start_fix_day_s="$((
 			New_Year_day_s + start_fix_day_n * 86400
 			))"
+
 		end_fix_day_s="$((
 			start_fix_day_s + EASYRSA_CERT_EXPIRE * 86400
 			))"
 
 		# Convert to date-stamps for SSL input
 		start_fix_day_d="$(
-			busybox date -u -d @"${start_fix_day_s}" +%Y%m%d%H%M%SZ
-			)"
+			busybox date -u -d @"${start_fix_day_s}" \
+				+%Y%m%d%H%M%SZ
+			)" || die "\
+fixed_cert_dates - start_fix_day_d - busybox"
+
 		end_fix_day_d="$(
-			busybox date -u -d @"${end_fix_day_s}" +%Y%m%d%H%M%SZ
-			)"
+			busybox date -u -d @"${end_fix_day_s}" \
+				+%Y%m%d%H%M%SZ
+			)" || die "\
+fixed_cert_dates - end_fix_day_d - busybox"
 
 	# Darwin, BSD
 	elif date -j > /dev/null 2>&1; then
@@ -3640,25 +3641,36 @@ fixed_cert_dates() {
 		#today_n="$(date -u -j +%j)"
 
 		New_Year_day_d="$(
-			date -u -j -f %y%m%d%H%M%S "${this_year_n}0101000001" \
+			date -u -j -f %y%m%d%H%M%S \
+				"${this_year_n}0101000001" \
 				+%Y%m%d%H%M.%SZ
-			)"
+			)" || die "\
+fixed_cert_dates - New_Year_day_d - Darwin"
 
 		# Convert to date-stamps for SSL input
 		start_fix_day_d="$(
-			date -u -j -f %Y%m%d%H%M.%SZ -v "+${start_fix_day_n}d" \
+			date -u -j -f %Y%m%d%H%M.%SZ -v \
+				"+${start_fix_day_n}d" \
 				"$New_Year_day_d" +%Y%m%d%H%M%SZ
-			)"
-		end_fix_day_d="$(
-			date -u -j -f %Y%m%d%H%M.%SZ -v "+${end_fix_day_n}d" \
-				"$New_Year_day_d" +%Y%m%d%H%M%SZ
-			)"
-		end_fix_day_s="$(
-			date -u -j -f %Y%m%d%H%M.%SZ -v "+${end_fix_day_n}d" \
-				"$New_Year_day_d" +%s
-			)"
+			)" || die "\
+fixed_cert_dates - start_fix_day_d - Darwin"
 
-	# Linux and Windows: date.exe does not allow +%s as input
+		end_fix_day_d="$(
+			date -u -j -f %Y%m%d%H%M.%SZ -v \
+				"+${end_fix_day_n}d" \
+				"$New_Year_day_d" +%Y%m%d%H%M%SZ
+			)" || die "\
+fixed_cert_dates - end_fix_day_d - Darwin"
+
+		end_fix_day_s="$(
+			date -u -j -f %Y%m%d%H%M.%SZ -v \
+				"+${end_fix_day_n}d" \
+				"$New_Year_day_d" +%s
+			)" || die "\
+fixed_cert_dates - end_fix_day_s - Darwin"
+
+	# Linux and Windows
+	# date.exe does not allow +%s as input
 	# MacPorts GNU date
 	elif this_year_n="$(date -u +%y)"; then
 
@@ -3667,29 +3679,50 @@ fixed_cert_dates() {
 
 		# New Years day date
 		New_Year_day_d="$(
-			date -u -d "${this_year_n}-01-01 00:00:01Z" \
+			date -u -d \
+				"${this_year_n}-01-01 00:00:01Z" \
 				'+%Y-%m-%d %H:%M:%SZ'
-			)"
+			)" || die "\
+fixed_cert_dates - New_Year_day_d - Linux"
 
 		# Convert to date-stamps for SSL input
 		start_fix_day_d="$(
-			date -u -d "$New_Year_day_d +${start_fix_day_n}days" \
+			date -u -d "$New_Year_day_d \
+				+${start_fix_day_n}days" \
 				+%Y%m%d%H%M%SZ
-			)"
+			)" || die "\
+fixed_cert_dates - start_fix_day_d - Linux"
+
 		end_fix_day_d="$(
-			date -u -d "$New_Year_day_d +${end_fix_day_n}days" \
+			date -u -d "$New_Year_day_d \
+				+${end_fix_day_n}days" \
 				+%Y%m%d%H%M%SZ
-			)"
+			)" || die "\
+fixed_cert_dates - end_fix_day_d - Linux"
+
 		end_fix_day_s="$(
-			date -u -d "$New_Year_day_d +${end_fix_day_n}days" +%s
-			)"
+			date -u -d "$New_Year_day_d \
+				+${end_fix_day_n}days" +%s
+			)" || die "\
+fixed_cert_dates - end_fix_day_s - Linux"
 
 	else
-		die "Unsupported 'date' program, upgrade your Matrix."
+		die "\
+Unsupported 'date' program, upgrade your Matrix."
 	fi
 
 	# Return FINAL dates for use in the certificate
-	print "$start_fix_day_d $end_fix_day_d"
+	safe_set_var "$2" "$start_fix_day_d" || die "\
+fixed_cert_dates - safe_set_var - $2 - $start_fix_day_d"
+
+	safe_set_var "$3" "$end_fix_day_d" || die "\
+fixed_cert_dates - safe_set_var - $3 - $end_fix_day_d"
+
+	# cleanup
+	unset -v start_fix_day_n start_fix_day_d \
+			end_fix_day_d end_fix_day_s \
+			this_year_n New_Year_day_d
+
 } # => fixed_cert_dates()
 
 # Convert certificate date to timestamp seconds since epoch


### PR DESCRIPTION
fixed_cert_dates(): Replace capturing subshell-output by setting variables via safe_set_var()

Wrap long lines.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>