### PR TITLE
Rename safe_set_var() to force_set_var()

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1262,7 +1262,7 @@ get_passphrase() {
 			printf '\n%s\n' \
 				"Passphrase must be at least 4 characters!"
 		else
-			safe_set_var "$t" "$r" || die "Passphrase error!"
+			force_set_var "$t" "$r" || die "Passphrase error!"
 			unset -v r t
 			print
 			return 0
@@ -3751,11 +3751,11 @@ Unsupported 'date' program, upgrade your Matrix."
 	fi
 
 	# Return FINAL dates for use in the certificate
-	safe_set_var "$2" "$start_fix_day_d" || die "\
-fixed_cert_dates - safe_set_var - $2 - $start_fix_day_d"
+	force_set_var "$2" "$start_fix_day_d" || die "\
+fixed_cert_dates - force_set_var - $2 - $start_fix_day_d"
 
-	safe_set_var "$3" "$end_fix_day_d" || die "\
-fixed_cert_dates - safe_set_var - $3 - $end_fix_day_d"
+	force_set_var "$3" "$end_fix_day_d" || die "\
+fixed_cert_dates - force_set_var - $3 - $end_fix_day_d"
 
 	# cleanup
 	unset -v start_fix_day_n start_fix_day_d \
@@ -3806,8 +3806,8 @@ cert_date_to_timestamp_s:
 	fi
 
 	# Return timestamp_s
-	safe_set_var "$2" "$timestamp_s" || die "\
-cert_date_to_timestamp_s - safe_set_var - $2 - $timestamp_s"
+	force_set_var "$2" "$timestamp_s" || die "\
+cert_date_to_timestamp_s - force_set_var - $2 - $timestamp_s"
 
 	unset -v in_date timestamp_s
 } # => cert_date_to_timestamp_s()
@@ -3860,9 +3860,9 @@ offset_days_to_cert_date:
 	fi
 
 	# Return offset_date
-	safe_set_var "$2" "$offset_date" || die "\
+	force_set_var "$2" "$offset_date" || die "\
 offset_days_to_cert_date \
-- safe_set_var - $2 - $offset_date"
+- force_set_var - $2 - $offset_date"
 
 	unset -v in_offset offset_date
 } # => offset_days_to_cert_date()
@@ -3913,9 +3913,9 @@ ff_date_to_cert_date:
 	fi
 
 	# Return out_date
-	safe_set_var "$2" "$out_date" || die "\
+	force_set_var "$2" "$out_date" || die "\
 ff_date_to_cert_date \
-- safe_set_var - $2 - $out_date"
+- force_set_var - $2 - $out_date"
 
 	unset -v in_date out_date
 } # => ff_date_to_cert_date()
@@ -3945,25 +3945,19 @@ db_date_to_ff_date - input error"
 	out_date="${yy}-${mm}-${dd} ${HH}:${MM}:${SS}${TZ}"
 
 	# Return out_date
-	safe_set_var "$2" "$out_date" || die "\
+	force_set_var "$2" "$out_date" || die "\
 db_date_to_ff_date \
-- safe_set_var - $2 - $out_date"
+- force_set_var - $2 - $out_date"
 
 	unset -v in_date out_date yy mm dd HH MM SS TZ
 } # => db_date_to_ff_date()
 
 # sanatize and set var
-safe_set_var() {
-	[ "$#" -eq 2 ] || die "safe_set_var - input"
-	# check for simple errors
-	case "$1" in
-		[1234567890]*|*[-.\ ]*)
-			die "safe_set_var - $1"
-	esac
-	eval "$1"=1 || die "safe_set_var - eval"
-	unset -v "$1" || die "safe_set_var - unset"
-	set_var "$1" "$2" || die "safe_set_var - set_var"
-} # => safe_set_var()
+force_set_var() {
+	[ "$#" -eq 2 ] || die "force_set_var - input"
+	unset -v "$1" || die "force_set_var - unset"
+	set_var "$1" "$2" || die "force_set_var - set_var"
+} # => force_set_var()
 
 # get the serial number of the certificate -> serial=XXXX
 ssl_cert_serial() {
@@ -3977,7 +3971,7 @@ ssl_cert_serial() {
 	# remove the serial= part -> we only need the XXXX part
 	fn_ssl_out="${fn_ssl_out##*=}"
 
-	safe_set_var "$2" "$fn_ssl_out" || \
+	force_set_var "$2" "$fn_ssl_out" || \
 		die "ssl_cert_serial - failed to set var '$*'"
 
 	unset -v fn_ssl_out
@@ -3998,7 +3992,7 @@ ssl_cert_not_before_date - failed: -startdate"
 
 	fn_ssl_out="${fn_ssl_out#*=}"
 
-	safe_set_var "$2" "$fn_ssl_out" || die "\
+	force_set_var "$2" "$fn_ssl_out" || die "\
 ssl_cert_not_before_date - failed to set var '$*'"
 
 	unset -v fn_ssl_out
@@ -4019,7 +4013,7 @@ ssl_cert_not_after_date - failed: -enddate"
 
 	fn_ssl_out="${fn_ssl_out#*=}"
 
-	safe_set_var "$2" "$fn_ssl_out" || die "\
+	force_set_var "$2" "$fn_ssl_out" || die "\
 ssl_cert_not_after_date - failed to set var '$*'"
 
 	unset -v fn_ssl_out


### PR DESCRIPTION
force_set_var() is intended to deliberately over-write all prior values.

This also drops an unnecessary 'eval'.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>