### PR TITLE
Wrap long lines: easyrsa_openssl(), sed command

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -785,6 +785,60 @@ escape_hazard - Failed to write temp-file"
 escape_hazard - Failed to source temp-file"
 } # => escape_hazard()
 
+# Replace environment variable names with current value
+# and write to temp-file or return error from sed
+easyrsa_rewrite_ssl_config () {
+	# shellcheck disable=SC2016 # No expansion inside ''
+	sed \
+\
+-e s\`'$dir'\`\
+\""$EASYRSA_PKI"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_PKI'\`\
+\""$EASYRSA_PKI"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_CERT_EXPIRE'\`\
+\""$EASYRSA_CERT_EXPIRE"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_CRL_DAYS'\`\
+\""$EASYRSA_CRL_DAYS"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_DIGEST'\`\
+\""$EASYRSA_DIGEST"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_KEY_SIZE'\`\
+\""$EASYRSA_KEY_SIZE"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_DN'\`\
+\""$EASYRSA_DN"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_CN'\`\
+\""$EASYRSA_REQ_CN"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_COUNTRY'\`\
+\""$EASYRSA_REQ_COUNTRY"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_PROVINCE'\`\
+\""$EASYRSA_REQ_PROVINCE"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_CITY'\`\
+\""$EASYRSA_REQ_CITY"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_ORG'\`\
+\""$EASYRSA_REQ_ORG"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_OU'\`\
+\""$EASYRSA_REQ_OU"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_EMAIL'\`\
+\""$EASYRSA_REQ_EMAIL"\"\`g \
+\
+-e s\`'$ENV::EASYRSA_REQ_SERIAL'\`\
+\""$EASYRSA_REQ_SERIAL"\"\`g \
+\
+	"$EASYRSA_SSL_CONF" > "$easyrsa_safe_ssl_conf"
+} # => easyrsa_rewrite_ssl_config()
+
 # Easy-RSA meta-wrapper for SSL
 easyrsa_openssl() {
 	openssl_command="$1"; shift
@@ -821,32 +875,11 @@ easyrsa_openssl() {
 	# $require_safe_ssl_conf is ALWAYS set by verify_ssl_lib()
 	# Can be over-ruled for OpenSSL by option --no-safe-ssl
 	if [ "$require_safe_ssl_conf" ]; then
-
-	# Break indentation for long lines
-	# Make a safe SSL config file
-	# shellcheck disable=SC2016 # No expansion inside ' single quote
-	sed \
-	-e s\`'$dir'\`\""$EASYRSA_PKI"\"\`g \
-	-e s\`'$ENV::EASYRSA_PKI'\`\""$EASYRSA_PKI"\"\`g \
-	-e s\`'$ENV::EASYRSA_CERT_EXPIRE'\`\""$EASYRSA_CERT_EXPIRE"\"\`g \
-	-e s\`'$ENV::EASYRSA_CRL_DAYS'\`\""$EASYRSA_CRL_DAYS"\"\`g \
-	-e s\`'$ENV::EASYRSA_DIGEST'\`\""$EASYRSA_DIGEST"\"\`g \
-	-e s\`'$ENV::EASYRSA_KEY_SIZE'\`\""$EASYRSA_KEY_SIZE"\"\`g \
-	-e s\`'$ENV::EASYRSA_DN'\`\""$EASYRSA_DN"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_CN'\`\""$EASYRSA_REQ_CN"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_COUNTRY'\`\""$EASYRSA_REQ_COUNTRY"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_PROVINCE'\`\""$EASYRSA_REQ_PROVINCE"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_CITY'\`\""$EASYRSA_REQ_CITY"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_ORG'\`\""$EASYRSA_REQ_ORG"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_OU'\`\""$EASYRSA_REQ_OU"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_EMAIL'\`\""$EASYRSA_REQ_EMAIL"\"\`g \
-	-e s\`'$ENV::EASYRSA_REQ_SERIAL'\`\""$EASYRSA_REQ_SERIAL"\"\`g \
-		"$EASYRSA_SSL_CONF" > "$easyrsa_safe_ssl_conf" || \
-			die "easyrsa_openssl - sed failed"
-
-	# Restore standard indentation
+		# Write a safe SSL config temp-file
+		easyrsa_rewrite_ssl_config || die \
+			"easyrsa_openssl - easyrsa_rewrite_ssl_config"
 	else
-		# Assign safe temp file as: Use original EasyRSA-OpenSSL conf
+		# Assign safe temp file as Original openssl-easyrsa.conf
 		easyrsa_safe_ssl_conf="$EASYRSA_SSL_CONF"
 	fi
 


### PR DESCRIPTION
Move the sed command to a function and wrap long lines. New function: easyrsa_rewrite_ssl_config()

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>