### PR TITLE
Option -S|--silent-ssl: Silence ALL SSL error messages ONLY

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 Easy-RSA 3 ChangeLog
 
+3.1.3 (ETA: 2023-10-13)
+   * Option -S|--silent-ssl: Silence ALL SSL error messages (#871)
+
 3.1.2 (2023-01-13)
    * build-full: Always enable inline file creation (#834)
    * Make default Edwards curve ED25519 (#828)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -462,11 +462,11 @@ General options:
 
 --version       : Prints EasyRSA version and build information
 --batch         : Set automatic (no-prompts when possible) mode
---silent|-s     : Disable all warnings, notices and information
+-s|--silent     : Disable all warnings, notices and information
 --sbatch        : Combined --silent and --batch operating mode
+-S|--silent-ssl : Silence ALL SSL library error messages
 
---no-pass       : Do not use passwords
-                  Can not be used with --passin or --passout
+--no-pass       : Do not use passwords. Over-ruled by --passout
 --passin=ARG    : Set -passin ARG for openssl (eg: pass:xEasyRSAy)
 --passout=ARG   : Set -passout ARG for openssl (eg: pass:xEasyRSAy)
 
@@ -891,28 +891,61 @@ easyrsa_openssl() {
 		# move temp file to safessl-easyrsa.cnf
 		mv -f "$easyrsa_safe_ssl_conf" "$EASYRSA_SAFE_CONF" || \
 			die "easyrsa_openssl - makesafeconf failed"
+		return
 
 	elif [ "$has_config" ]; then
 		# debug log on
 		if [ "$EASYRSA_DEBUG" ]; then print "<< DEBUG-ON >>"; set -x; fi
 
-		# Exec SSL with -config temp-file
-		"$EASYRSA_OPENSSL" "$openssl_command" \
-			-config "$easyrsa_safe_ssl_conf" "$@" || return
+		# Silent SSL mode
+		if [ "$EASYRSA_SILENT_SSL" ]; then
+			# Exec SSL WITH -config temp-file
+			err_silent="OpenSSL $openssl_command (Silent)"
+			if "$EASYRSA_OPENSSL" "$openssl_command" \
+				-config "$easyrsa_safe_ssl_conf" "$@" \
+				2>/dev/null
+			then
+				unset -v err_silent
+			fi
+		else
+			# Exec SSL WITH -config temp-file
+			err_normal="OpenSSL $openssl_command (Normal)"
+			if "$EASYRSA_OPENSSL" "$openssl_command" \
+				-config "$easyrsa_safe_ssl_conf" "$@"
+			then
+				unset -v err_normal
+			fi
+		fi
 
 		# debug log off
 		if [ "$EASYRSA_DEBUG" ]; then set +x; print ">> DEBUG-OFF <<"; fi
+
+		# Catch errors
+		if [ "$err_silent" ]; then
+			die "easyrsa_openssl - $err_silent"
+		elif [ "$err_normal" ]; then
+			die "easyrsa_openssl - $err_normal"
+		else
+			unset -v err_silent err_normal
+			return 0
+		fi
 
 	else
 		# debug log on
 		if [ "$EASYRSA_DEBUG" ]; then print "<< DEBUG-ON >>"; set -x; fi
 
-		# Exec SSL without -config temp-file
-		"$EASYRSA_OPENSSL" "$openssl_command" "$@" || return
+		# Exec SSL WITHOUT -config temp-file
+		if "$EASYRSA_OPENSSL" "$openssl_command" "$@"
+		then
+			return
+		else
+			return 1
+		fi
 
 		# debug log off
 		if [ "$EASYRSA_DEBUG" ]; then set +x; print ">> DEBUG-OFF <<"; fi
 	fi
+	die "easyrsa_openssl - undefined error"
 } # => easyrsa_openssl()
 
 # Verify the SSL library is functional and establish version dependencies
@@ -4427,7 +4460,6 @@ ${host_out}${easyrsa_win_git_bash+ | "$easyrsa_win_git_bash"}"
 
 # Extra diagnostics
 show_host() {
-	[ "$EASYRSA_SILENT" ] && return
 	print_version
 	print "$host_out"
 	[ "$EASYRSA_DEBUG" ] || return 0
@@ -5493,6 +5525,9 @@ while :; do
 		empty_ok=1
 		export EASYRSA_SILENT=1
 		export EASYRSA_BATCH=1
+		;;
+	-S|--silent-ssl)
+		export EASYRSA_SILENT_SSL=1
 		;;
 	--no-safe-ssl)
 		empty_ok=1


### PR DESCRIPTION
easyrsa_openssl():
This new option allows redirecting SSL file descriptor 2 to /dev/null

Having a seprate option allows the original --silent mode to ONLY silence EasyRSA output, as intended.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>