### PR TITLE
easyrsa_mktemp(): Use sequential numbered temp files

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -609,7 +609,7 @@ easyrsa_random() {
 # Create session directory atomically or fail
 secure_session() {
 	# Session is already defined
-	[ "$EASYRSA_TEMP_DIR_session" ] && \
+	[ "$secured_session" ] && \
 		die "session overload"
 
 	# temporary directory must exist
@@ -627,9 +627,9 @@ secure_session() {
 			easyrsa_random 4
 			)" || die "secure_session - session"
 
-		EASYRSA_TEMP_DIR_session="${EASYRSA_TEMP_DIR}/${session}"
+		secured_session="${EASYRSA_TEMP_DIR}/${session}"
 		# atomic:
-		mkdir "$EASYRSA_TEMP_DIR_session" && return
+		mkdir "$secured_session" && return
 	done
 	die "secure_session failed"
 } # => secure_session()
@@ -639,14 +639,14 @@ easyrsa_mktemp() {
 	[ "$#" = 1 ] || die "easyrsa_mktemp - invalid input"
 
 	# session directory must exist
-	[ "$EASYRSA_TEMP_DIR_session" ] || die "\
+	[ "$secured_session" ] || die "\
 easyrsa_mktemp - Temporary session undefined"
 
 	# Update counter
 	mktemp_counter="$(( mktemp_counter + 1 ))"
 
 	# Assign internal temp-file name
-	t="${EASYRSA_TEMP_DIR_session}/temp.${mktemp_counter}"
+	t="${secured_session}/temp.${mktemp_counter}"
 
 	# Create temp-file or die
 	for i in x y z; do
@@ -668,8 +668,8 @@ easyrsa_mktemp - Temporary session undefined"
 
 # remove temp files and do terminal cleanups
 cleanup() {
-	if [ "${EASYRSA_TEMP_DIR_session%/*}" ] && \
-		[ -d "$EASYRSA_TEMP_DIR_session" ]
+	if [ "${secured_session%/*}" ] && \
+		[ -d "$secured_session" ]
 	then
 		# Remove temp-session or create temp-snapshot
 		if [ "$EASYRSA_KEEP_TEMP" ]
@@ -685,13 +685,13 @@ Temporary session not preserved."
 				keep_tmp="$EASYRSA_TEMP_DIR/tmp/$EASYRSA_KEEP_TEMP"
 				mkdir -p "$keep_tmp"
 				rm -rf "$keep_tmp"
-				mv -f "$EASYRSA_TEMP_DIR_session" "$keep_tmp"
+				mv -f "$secured_session" "$keep_tmp"
 				print "Temp session preserved: $keep_tmp"
 			fi
 		fi
 
 		# Always remove temp-session
-		rm -rf "$EASYRSA_TEMP_DIR_session"
+		rm -rf "$secured_session"
 	fi
 
 	if [ "${EASYRSA_EC_DIR%/*}" ] && [ -d "$EASYRSA_EC_DIR" ]
@@ -5019,12 +5019,12 @@ up23_create_openssl_cnf ()
 
 	# Create secure session
 	# Because the upgrade runs twice, once as a test and then for real
-	# EASYRSA_TEMP_DIR_session must be cleared to avoid overload error
-	[ "$EASYRSA_TEMP_DIR_session" ] && unset -v EASYRSA_TEMP_DIR_session
+	# secured_session must be cleared to avoid overload error
+	[ "$secured_session" ] && unset -v secured_session
 	up23_verbose "> Create secure session"
 	secure_session || die "up23_create_openssl_cnf - secure_session failed."
 	up23_verbose "> OK"
-	up23_verbose "  secure session: $EASYRSA_TEMP_DIR_session"
+	up23_verbose "  secure session: $secured_session"
 
 	# Create $EASYRSA_PKI/safessl-easyrsa.cnf
 	easyrsa_openssl makesafeconf
@@ -5397,6 +5397,7 @@ detect_host
 unset -v \
 	easyrsa_error_exit \
 	prohibit_no_pass \
+	secured_session \
 	user_vars_true \
 	user_san_true \
 	alias_days

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -635,15 +635,8 @@ easyrsa_mktemp() {
 	[ "$#" = 1 ] || die "easyrsa_mktemp - invalid input"
 
 	# session directory must exist
-	if [ "$EASYRSA_TEMP_DIR_session" ] && \
-		[ -d "$EASYRSA_TEMP_DIR_session" ]
-	then
-		: # ok
-	else
-		die "\
-easyrsa_mktemp - Non-existant temporary session:
-* $EASYRSA_TEMP_DIR_session"
-	fi
+	[ "$EASYRSA_TEMP_DIR_session" ] || die "\
+easyrsa_mktemp - Temporary session undefined"
 
 	# Update counter
 	mktemp_counter="$(( mktemp_counter + 1 ))"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -630,10 +630,13 @@ secure_session() {
 	die "secure_session failed"
 } # => secure_session()
 
-# Create tempfile atomically or fail
+# Create temp-file atomically or fail
 easyrsa_mktemp() {
+	[ "$#" = 1 ] || die "easyrsa_mktemp - invalid input"
+
 	# session directory must exist
-	if [ "$EASYRSA_TEMP_DIR_session" ] && [ -d "$EASYRSA_TEMP_DIR_session" ]
+	if [ "$EASYRSA_TEMP_DIR_session" ] && \
+		[ -d "$EASYRSA_TEMP_DIR_session" ]
 	then
 		: # ok
 	else
@@ -642,24 +645,26 @@ easyrsa_mktemp - Non-existant temporary session:
 * $EASYRSA_TEMP_DIR_session"
 	fi
 
-	for i in 1 2 3; do
-		# Always use openssl directly for rand
-		random_file="$(
-			easyrsa_random 4
-			)" || die "easyrsa_mktemp - random_file '$random_file'"
+	# Update counter
+	mktemp_counter="$(( mktemp_counter + 1 ))"
 
-		shotfile="${EASYRSA_TEMP_DIR_session}/shot.$random_file"
+	# Assign internal temp-file name
+	t="${EASYRSA_TEMP_DIR_session}/temp.${mktemp_counter}"
+
+	# Must not exist
+	for i in x y z; do
+
+		shotfile="${t}.${i}"
 		if [ -e "$shotfile" ]; then
 			continue
 		else
 			printf "" > "$shotfile" || continue
 		fi
 
-		tempfile="${EASYRSA_TEMP_DIR_session}/temp.$random_file"
 		# atomic:
-		if mv "$shotfile" "$tempfile"; then
-			# Print the new temporary file-name for the caller
-			printf '%s\n' "$tempfile" && return
+		if mv "$shotfile" "$t"; then
+			# Assign external temp-file name
+			force_set_var "$1" "$t" && return
 		fi
 	done
 	die "easyrsa_mktemp failed"
@@ -763,8 +768,8 @@ Generated safe SSL config file:
 # Escape hazardous characters
 escape_hazard() {
 	# Assign temp file
-	easyrsa_vars_org="$(easyrsa_mktemp)" || \
-		die "escape_hazard - easyrsa_mktemp failed"
+	easyrsa_mktemp easyrsa_vars_org || \
+		die "escape_hazard - easyrsa_mktemp"
 
 	# write org fields to org temp-file and escape '&' and '$'
 	print "\
@@ -861,8 +866,8 @@ easyrsa_openssl() {
 	fi
 
 	# Assign safe temp file to create, may not be used
-	easyrsa_safe_ssl_conf="$(easyrsa_mktemp)" || \
-		die "easyrsa_openssl - easyrsa_mktemp failed"
+	easyrsa_mktemp easyrsa_safe_ssl_conf || \
+		die "easyrsa_openssl - easyrsa_mktemp"
 
 	# Auto-escape hazardous characters:
 	# '&' - Workaround 'sed' behavior
@@ -1402,10 +1407,11 @@ Unable to create necessary PKI files (permissions?)"
 	fi
 
 	# Assign cert and key temp files
-	out_key_tmp="$(easyrsa_mktemp)" || \
-		die "Failed to create temp-key file"
-	out_file_tmp="$(easyrsa_mktemp)" || \
-		die "Failed to create temp-cert file"
+	easyrsa_mktemp out_key_tmp || \
+		die "build_ca - easyrsa_mktemp out_key_tmp"
+	easyrsa_mktemp out_file_tmp || \
+		die "build_ca - easyrsa_mktemp out_file_tmp"
+
 
 	# Get passphrase from user if necessary
 	if [ "$EASYRSA_NO_PASS" ]
@@ -1418,10 +1424,10 @@ Unable to create necessary PKI files (permissions?)"
 
 	else
 		# Assign passphrase vars and temp file
-		in_key_pass_tmp="$(easyrsa_mktemp)" || \
-			die "in_key_pass_tmp: create"
-		out_key_pass_tmp="$(easyrsa_mktemp)" || \
-			die "out_key_pass_tmp: create"
+		easyrsa_mktemp in_key_pass_tmp || \
+			die "build_ca - in_key_pass_tmp"
+		easyrsa_mktemp out_key_pass_tmp || \
+			die "build_ca - out_key_pass_tmp"
 
 		p=""
 		q=""
@@ -1453,7 +1459,9 @@ Unable to create necessary PKI files (permissions?)"
  {print}
 }'
 
-	conf_tmp="$(easyrsa_mktemp)" || die "conf_tmp: create"
+	# Assign tmp-file for config
+	easyrsa_mktemp conf_tmp || \
+		die "build_ca - easyrsa_mktemp conf_tmp"
 	{
 		cat "$EASYRSA_EXT_DIR/ca" "$EASYRSA_EXT_DIR/COMMON"
 		[ "$EASYRSA_EXTRA_EXTS" ] && print "$EASYRSA_EXTRA_EXTS"
@@ -1562,8 +1570,8 @@ at: $out_file"
 
 	# Create a temp file
 	# otherwise user abort leaves an incomplete dh.pem
-	tmp_dh_file="$(easyrsa_mktemp)" || \
-		die "Failed to create temp DH file"
+	easyrsa_mktemp tmp_dh_file || \
+		die "gen_dh - easyrsa_mktemp tmp_dh_file"
 
 	# Generate dh.pem
 	"$EASYRSA_OPENSSL" dhparam -out "$tmp_dh_file" \
@@ -1665,8 +1673,10 @@ $EASYRSA_EXTRA_EXTS"
 	{ while ( getline<"/dev/stdin" ) {print} next }
  {print}
 }'
-		conf_tmp="$(easyrsa_mktemp)" || die "\
-gen_req - easyrsa_mktemp - conf_tmp"
+		# Assign temp-file for confg
+		easyrsa_mktemp conf_tmp || \
+			die "gen_req - easyrsa_mktemp conf_tmp"
+
 		print "$extra_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
 			> "$conf_tmp" \
@@ -1676,10 +1686,10 @@ gen_req - easyrsa_mktemp - conf_tmp"
 	fi
 
 	# Name temp files
-	key_out_tmp="$(easyrsa_mktemp)" || die "\
-gen_req - easyrsa_mktemp - key_out_tmp"
-	req_out_tmp="$(easyrsa_mktemp)" || die "\
-gen_req - easyrsa_mktemp - req_out_tmp"
+	easyrsa_mktemp key_out_tmp || \
+		die "gen_req - easyrsa_mktemp key_out_tmp"
+	easyrsa_mktemp req_out_tmp || \
+		die "gen_req - easyrsa_mktemp req_out_tmp"
 
 	# Set Edwards curve name or elliptic curve parameters file
 	algo_opts=""
@@ -1728,15 +1738,12 @@ sign_req() {
 				easyrsa_random 16
 				)" || die "sign_req - easyrsa_random"
 
-			# Print random $serial to pki/serial file
-			# for use by SSL config
-			print "$serial" > "$EASYRSA_PKI/serial" || \
-				die "sign_req - serial"
-
 			# Check for duplicate serial in CA db
 			# Always errors out - Do not capture error
+			# unset EASYRSA_SILENT_SSL to capure all output
 			check_serial="$(
-				easyrsa_openssl ca -status "$serial" 2>&1
+				EASYRSA_SILENT_SSL='' \
+					easyrsa_openssl ca -status "$serial" 2>&1
 				)" || :
 
 			case "$check_serial" in
@@ -1752,6 +1759,11 @@ sign_req - Randomize Serial number failed:
 
 $check_serial"
 	fi
+
+	# Print random $serial to pki/serial file
+	# for use by SSL config
+	print "$serial" > "$EASYRSA_PKI/serial" || \
+		die "sign_req - write serial to file"
 
 	verify_ca_init
 
@@ -1815,8 +1827,10 @@ to the latest official release."
 	{ while ( getline<"/dev/stdin" ) {print} next }
  {print}
 }'
-		conf_tmp="$(easyrsa_mktemp)" || \
-			die "sign_req - easyrsa_mktemp - conf_tmp"
+		# Assign temp-file for confg
+		easyrsa_mktemp conf_tmp || \
+			die "sign_req - easyrsa_mktemp conf_tmp"
+
 		print "$copy_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
 			> "$conf_tmp" \
@@ -1826,8 +1840,8 @@ to the latest official release."
 	fi
 
 	# Generate the extensions file for this cert:
-	ext_tmp="$(easyrsa_mktemp)" || \
-		die "sign_req - easyrsa_mktemp - ext_tmp"
+	easyrsa_mktemp ext_tmp || \
+		die "sign_req - easyrsa_mktemp ext_tmp"
 	{
 		# Append COMMON and cert-type extensions
 		cat "$EASYRSA_EXT_DIR/COMMON" || \
@@ -1925,8 +1939,8 @@ $(display_dn req "$req_in")
 "	# => confirm end
 
 	# Assign temp cert file
-	crt_out_tmp="$(easyrsa_mktemp)" || \
-		die "sign_req - easyrsa_mktemp - crt_out_tmp"
+	easyrsa_mktemp crt_out_tmp || \
+		die "sign_req - easyrsa_mktemp crt_out_tmp"
 
 	# sign request
 	easyrsa_openssl ca -utf8 -in "$req_in" \
@@ -3074,7 +3088,9 @@ gen_crl() {
 	verify_ca_init
 
 	out_file="$EASYRSA_PKI/crl.pem"
-	out_file_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+
+	easyrsa_mktemp out_file_tmp || \
+		die "gen_crl - easyrsa_mktemp out_file_tmp"
 
 	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" \
 		${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || die "\
@@ -3083,8 +3099,8 @@ CRL Generation failed."
 	mv "$out_file_tmp" "$out_file"
 
 	notice "\
-An updated CRL has been created.
-CRL file: $out_file"
+An updated CRL has been created:
+* $out_file"
 
 	return 0
 } # => gen_crl()
@@ -3290,7 +3306,9 @@ If the key is currently encrypted you must supply the decryption passphrase.
 ${cipher:+You will then enter a new PEM passphrase for this key.$NL}"
 
 	# Set password
-	out_key_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	easyrsa_mktemp out_key_tmp || \
+		die "set_pass_legacy - easyrsa_mktemp out_key_tmp"
+
 	easyrsa_openssl "$key_type" -in "$file" -out "$out_key_tmp" \
 		${cipher:+ "$cipher"} \
 		${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
@@ -3349,7 +3367,8 @@ If the key is encrypted then you must supply the decryption pass phrase.
 ${cipher:+You will then enter and verify a new PEM pass phrase for this key.}"
 
 	# Set password
-	out_key_tmp="$(easyrsa_mktemp)" || die "Failed to create temporary file"
+	easyrsa_mktemp out_key_tmp || \
+		die "set_pass - easyrsa_mktemp out_key_tmp"
 
 	easyrsa_openssl pkey -in "$file" -out "$out_key_tmp" \
 		${cipher:+ "$cipher"} \
@@ -3798,7 +3817,7 @@ cert_date_to_timestamp_s - input error"
 			busybox date -D "%b %e %H:%M:%S %Y" \
 				-d "$in_date" +%s 2>/dev/null
 			)" || die "\
-cert_date_to_timestamp_s - out_date_s - busybox"
+cert_date_to_timestamp_s - timestamp_s - busybox $in_date"
 
 	# Darwin, BSD
 	elif timestamp_s="$(
@@ -4430,7 +4449,8 @@ verify_algo_params() {
 	;;
 	ec)
 		# Verify Elliptic curve
-		EASYRSA_ALGO_PARAMS="$(easyrsa_mktemp)"
+		easyrsa_mktemp EASYRSA_ALGO_PARAMS || die \
+		"verify_algo_params - easyrsa_mktemp EASYRSA_ALGO_PARAMS"
 
 		# Create the required ecparams file
 		easyrsa_openssl ecparam -name "$EASYRSA_CURVE" \
@@ -5367,6 +5387,8 @@ unset -v \
 	user_san_true \
 	alias_days
 
+	mktemp_counter=0
+
 # Parse options
 while :; do
 	# Reset per pass flags
@@ -5708,6 +5730,7 @@ esac
 [ $? = 0 ] || warn "Untrapped error detected!"
 
 # Do 'cleanup ok' on successful completion
+#print "mktemp_counter: $mktemp_counter uses"
 cleanup ok
 
 # vim: ft=sh nu ai sw=8 ts=8 noet

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -593,8 +593,9 @@ Type the word '$value' to continue, or any other input to abort."
 
 # Generate random hex
 # Cannot use easyrsa-openssl() due to chicken vs egg,
-# easyrsa_openssl() creates temp-files, which needs `openssl rand`.
-# Redirect error-out, because LibreSSL complains of missing conf.
+# easyrsa_openssl() creates temp-files,
+# which needs `openssl rand`.
+# Redirect error-out, ignore complaints of missing config
 easyrsa_random() {
 	case "$1" in
 	(*[!1234567890]*|0*|"") : ;; # invalid input
@@ -608,22 +609,25 @@ easyrsa_random() {
 # Create session directory atomically or fail
 secure_session() {
 	# Session is already defined
-	[ "$EASYRSA_TEMP_DIR_session" ] && die "session overload"
+	[ "$EASYRSA_TEMP_DIR_session" ] && \
+		die "session overload"
 
 	# temporary directory must exist
-	if [ "$EASYRSA_TEMP_DIR" ] && [ -d "$EASYRSA_TEMP_DIR" ]
+	if [ "$EASYRSA_TEMP_DIR" ] && \
+		[ -d "$EASYRSA_TEMP_DIR" ]
 	then
 		: # ok
 	else
-		die "Non-existant temporary directory: $EASYRSA_TEMP_DIR"
+		die "Non-existant temporary directory:
+* $EASYRSA_TEMP_DIR"
 	fi
 
 	for i in 1 2 3; do
-		random_session="$(
+		session="$(
 			easyrsa_random 4
-			)" || die "secure_session - random_session '$random_session'"
+			)" || die "secure_session - session"
 
-		EASYRSA_TEMP_DIR_session="${EASYRSA_TEMP_DIR}/${random_session}"
+		EASYRSA_TEMP_DIR_session="${EASYRSA_TEMP_DIR}/${session}"
 		# atomic:
 		mkdir "$EASYRSA_TEMP_DIR_session" && return
 	done

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -768,8 +768,9 @@ Generated safe SSL config file:
 # Escape hazardous characters
 escape_hazard() {
 	# Assign temp file
-	easyrsa_mktemp easyrsa_vars_org || \
-		die "escape_hazard - easyrsa_mktemp"
+	easyrsa_vars_org=""
+	easyrsa_mktemp easyrsa_vars_org || die \
+		"escape_hazard - easyrsa_mktemp easyrsa_vars_org"
 
 	# write org fields to org temp-file and escape '&' and '$'
 	print "\
@@ -866,8 +867,9 @@ easyrsa_openssl() {
 	fi
 
 	# Assign safe temp file to create, may not be used
-	easyrsa_mktemp easyrsa_safe_ssl_conf || \
-		die "easyrsa_openssl - easyrsa_mktemp"
+	easyrsa_safe_ssl_conf=""
+	easyrsa_mktemp easyrsa_safe_ssl_conf || die \
+		"easyrsa_openssl - easyrsa_mktemp easyrsa_safe_ssl_conf"
 
 	# Auto-escape hazardous characters:
 	# '&' - Workaround 'sed' behavior
@@ -1407,8 +1409,10 @@ Unable to create necessary PKI files (permissions?)"
 	fi
 
 	# Assign cert and key temp files
+	out_key_tmp=""
 	easyrsa_mktemp out_key_tmp || \
 		die "build_ca - easyrsa_mktemp out_key_tmp"
+	out_file_tmp=""
 	easyrsa_mktemp out_file_tmp || \
 		die "build_ca - easyrsa_mktemp out_file_tmp"
 
@@ -1424,8 +1428,10 @@ Unable to create necessary PKI files (permissions?)"
 
 	else
 		# Assign passphrase vars and temp file
+		in_key_pass_tmp=""
 		easyrsa_mktemp in_key_pass_tmp || \
 			die "build_ca - in_key_pass_tmp"
+		out_key_pass_tmp=""
 		easyrsa_mktemp out_key_pass_tmp || \
 			die "build_ca - out_key_pass_tmp"
 
@@ -1460,6 +1466,7 @@ Unable to create necessary PKI files (permissions?)"
 }'
 
 	# Assign tmp-file for config
+	conf_tmp=""
 	easyrsa_mktemp conf_tmp || \
 		die "build_ca - easyrsa_mktemp conf_tmp"
 	{
@@ -1570,6 +1577,7 @@ at: $out_file"
 
 	# Create a temp file
 	# otherwise user abort leaves an incomplete dh.pem
+	tmp_dh_file=""
 	easyrsa_mktemp tmp_dh_file || \
 		die "gen_dh - easyrsa_mktemp tmp_dh_file"
 
@@ -1674,6 +1682,7 @@ $EASYRSA_EXTRA_EXTS"
  {print}
 }'
 		# Assign temp-file for confg
+		conf_tmp=""
 		easyrsa_mktemp conf_tmp || \
 			die "gen_req - easyrsa_mktemp conf_tmp"
 
@@ -1686,8 +1695,10 @@ $EASYRSA_EXTRA_EXTS"
 	fi
 
 	# Name temp files
+	key_out_tmp=""
 	easyrsa_mktemp key_out_tmp || \
 		die "gen_req - easyrsa_mktemp key_out_tmp"
+	req_out_tmp=""
 	easyrsa_mktemp req_out_tmp || \
 		die "gen_req - easyrsa_mktemp req_out_tmp"
 
@@ -1828,6 +1839,7 @@ to the latest official release."
  {print}
 }'
 		# Assign temp-file for confg
+		conf_tmp=""
 		easyrsa_mktemp conf_tmp || \
 			die "sign_req - easyrsa_mktemp conf_tmp"
 
@@ -1840,6 +1852,7 @@ to the latest official release."
 	fi
 
 	# Generate the extensions file for this cert:
+	ext_tmp=""
 	easyrsa_mktemp ext_tmp || \
 		die "sign_req - easyrsa_mktemp ext_tmp"
 	{
@@ -1939,6 +1952,7 @@ $(display_dn req "$req_in")
 "	# => confirm end
 
 	# Assign temp cert file
+	crt_out_tmp=""
 	easyrsa_mktemp crt_out_tmp || \
 		die "sign_req - easyrsa_mktemp crt_out_tmp"
 
@@ -3089,6 +3103,7 @@ gen_crl() {
 
 	out_file="$EASYRSA_PKI/crl.pem"
 
+	out_file_tmp=""
 	easyrsa_mktemp out_file_tmp || \
 		die "gen_crl - easyrsa_mktemp out_file_tmp"
 
@@ -3306,6 +3321,7 @@ If the key is currently encrypted you must supply the decryption passphrase.
 ${cipher:+You will then enter a new PEM passphrase for this key.$NL}"
 
 	# Set password
+	out_key_tmp=""
 	easyrsa_mktemp out_key_tmp || \
 		die "set_pass_legacy - easyrsa_mktemp out_key_tmp"
 
@@ -3367,6 +3383,7 @@ If the key is encrypted then you must supply the decryption pass phrase.
 ${cipher:+You will then enter and verify a new PEM pass phrase for this key.}"
 
 	# Set password
+	out_key_tmp=""
 	easyrsa_mktemp out_key_tmp || \
 		die "set_pass - easyrsa_mktemp out_key_tmp"
 
@@ -4449,6 +4466,7 @@ verify_algo_params() {
 	;;
 	ec)
 		# Verify Elliptic curve
+		EASYRSA_ALGO_PARAMS=""
 		easyrsa_mktemp EASYRSA_ALGO_PARAMS || die \
 		"verify_algo_params - easyrsa_mktemp EASYRSA_ALGO_PARAMS"
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -651,20 +651,19 @@ easyrsa_mktemp - Non-existant temporary session:
 	# Assign internal temp-file name
 	t="${EASYRSA_TEMP_DIR_session}/temp.${mktemp_counter}"
 
-	# Must not exist
+	# Create temp-file or die
 	for i in x y z; do
-
-		shotfile="${t}.${i}"
+		shotfile="${t}.0"
+		target="$t.$i"
 		if [ -e "$shotfile" ]; then
-			continue
+			break
 		else
-			printf "" > "$shotfile" || continue
-		fi
-
-		# atomic:
-		if mv "$shotfile" "$t"; then
-			# Assign external temp-file name
-			force_set_var "$1" "$t" && return
+			printf "" > "$shotfile" || break
+			# atomic:
+			if mv "$shotfile" "$target"; then
+				# Assign external temp-file name
+				force_set_var "$1" "$target" && return
+			fi
 		fi
 	done
 	die "easyrsa_mktemp failed"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -694,11 +694,6 @@ Temporary session not preserved."
 		rm -rf "$secured_session"
 	fi
 
-	if [ "${EASYRSA_EC_DIR%/*}" ] && [ -d "$EASYRSA_EC_DIR" ]
-	then
-		rm -rf "$EASYRSA_EC_DIR"
-	fi
-
 	# Remove files when build_full()->sign_req() is interrupted
 	[ "$error_build_full_cleanup" ] && \
 		rm -f "$crt_out" "$req_out" "$key_out"
@@ -4367,7 +4362,6 @@ satisfy_shellcheck() {
 	EASYRSA_ALGO=
 	EASYRSA_KEY_SIZE=
 	EASYRSA_CURVE=
-	EASYRSA_EC_DIR=
 	EASYRSA_CA_EXPIRE=
 	EASYRSA_CERT_EXPIRE=
 	EASYRSA_CERT_RENEW=
@@ -4666,7 +4660,6 @@ Sourcing the vars file and building certificates will probably fail ..'
 	;;
 	ec)
 		set_var EASYRSA_CURVE		secp384r1
-		set_var EASYRSA_EC_DIR		"$EASYRSA_PKI/ecparams"
 	;;
 	ed)
 		set_var EASYRSA_CURVE		ed25519


### PR DESCRIPTION
This drops use of SSL to generate random numbered files. The temp-session is still randomly named.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>