### PR TITLE
set-var(): Check input, die on errors

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4345,10 +4345,10 @@ Sourcing the vars file and building certificates will probably fail ..'
 # the variable when it is already defined (even if currently null)
 # Sets $1 as the value contained in $2 and exports (may be blank)
 set_var() {
-	var=$1
-	shift
-	value="$*"
-	eval "export $var=\"\${$var-$value}\""
+	[ "$1" ] || die "set_var - missing input"
+	[ "$1" = "${1% *}" ] || die "set_var - input error"
+	[ "$#" -lt 3 ] || die "set_var - excess input"
+	eval "export \"$1\"=\"\${$1-$2}\""
 } #=> set_var()
 
 


### PR DESCRIPTION
Previously, set_var() had no input checking, combined with the point that, via vars, set_var() is user facing, this can lead to easy user errors.

Now, input is checked:
- Parameter 1 is required.
- Parameter 1 cannot contain a space.
- Less-than 3 input parameters are expected.
- Quote the expansion of the first occurence of parameter 1 in the evaluated expression.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>