### PR TITLE
sign-req: Do not specify SSL option -enddate

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1959,7 +1959,6 @@ $(display_dn req "$req_in")
 		${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} \
 		${EASYRSA_NO_TEXT:+-notext} \
 		${EASYRSA_FIX_OFFSET+ -startdate "$start_fixdate"} \
-		${EASYRSA_FIX_OFFSET+ -enddate "$end_fixdate"} \
 			|| die "\
 Signing failed (openssl output above may have more detail)"
 


### PR DESCRIPTION
Use of --fix-offset=N causes command sign-req to specify both SSL options -days and -enddate.  This is an incorrect use of SSL.

This patch removes specifying SSL option -enddate from EasyRSA sign-req.