### PR TITLE
sign-req: Only create a random serial number file when expected

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Easy-RSA 3 ChangeLog
 
 3.1.3 (ETA: 2023-10-13)
+   * Only create a random serial number file when expected (#896)
    * Option --fix-offset: Adjust off-by-one day (#847)
 
 3.1.2 (2023-01-13)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1765,12 +1765,12 @@ sign_req() {
 sign_req - Randomize Serial number failed:
 
 $check_serial"
-	fi
 
-	# Print random $serial to pki/serial file
-	# for use by SSL config
-	print "$serial" > "$EASYRSA_PKI/serial" || \
-		die "sign_req - write serial to file"
+		# Print random $serial to pki/serial file
+		# for use by SSL config
+		print "$serial" > "$EASYRSA_PKI/serial" || \
+			die "sign_req - write serial to file"
+	fi
 
 	verify_ca_init
 


### PR DESCRIPTION
When EASYRSA_RAND_SN="no", the file pki/serial file is not meant to be updated by easyrsa. OpenSSL manages the file itself.

Move the code to write the file pki/serial with a random number, inside the if condition for EASYRSA_RAND_SN, so the file is only written to by easyrsa, when a random serial number is expected.