### PR TITLE
Use set_var to correctly assign EASYRSA_REQ_SERIAL

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -767,6 +767,7 @@ export EASYRSA_REQ_CITY=\"$EASYRSA_REQ_CITY\"
 export EASYRSA_REQ_ORG=\"$EASYRSA_REQ_ORG\"
 export EASYRSA_REQ_OU=\"$EASYRSA_REQ_OU\"
 export EASYRSA_REQ_EMAIL=\"$EASYRSA_REQ_EMAIL\"
+export EASYRSA_REQ_SERIAL=\"$EASYRSA_REQ_SERIAL\"
 " | sed -e s\`'\&'\`'\\\&'\`g \
 		-e s\`'\$'\`'\\\$'\`g \
 			> "$easyrsa_vars_org" || die "\
@@ -4660,6 +4661,7 @@ Sourcing the vars file and building certificates will probably fail ..'
 	set_var EASYRSA_REQ_ORG			"Copyleft Certificate Co"
 	set_var EASYRSA_REQ_EMAIL		me@example.net
 	set_var EASYRSA_REQ_OU			"My Organizational Unit"
+	set_var EASYRSA_REQ_SERIAL		""
 	set_var EASYRSA_ALGO			rsa
 
 	case "$EASYRSA_ALGO" in


### PR DESCRIPTION
This configures EASYRSA_REQ_SERIAL for use in the SSL config file.

Signed-off-by: Richard T Bonhomme <tincantech@protonmail.com>