### PR TITLE
gen-crl: Minor improvements

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3108,10 +3108,11 @@ gen_crl() {
 		die "gen_crl - easyrsa_mktemp out_file_tmp"
 
 	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" \
-		${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || die "\
-CRL Generation failed."
+		${EASYRSA_CRL_DAYS:+-days "$EASYRSA_CRL_DAYS"} \
+		${EASYRSA_PASSIN:+-passin "$EASYRSA_PASSIN"} || \
+			die "CRL Generation failed."
 
-	mv "$out_file_tmp" "$out_file"
+	mv ${EASYRSA_BATCH:+-f} "$out_file_tmp" "$out_file"
 
 	notice "\
 An updated CRL has been created:


### PR DESCRIPTION
Add EASYRSA_CRL_DAYS to command to generate a new CRL. Although this is taken care of in the SSL config file, it is easier to understand by having the code incuded in the script.

Honor batch mode and over write an existing CRL, with out confirmation.  An out dated CRL is of little value and the user has specified batch mode, so honor it.