### PR TITLE
Build Safe SSL config at correct stage

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4901,7 +4901,7 @@ verify_algo_params() {
 		"verify_algo_params - easyrsa_mktemp EASYRSA_ALGO_PARAMS"
 
 		# Create the required ecparams file
-		easyrsa_openssl ecparam -name "$EASYRSA_CURVE" \
+		"$EASYRSA_OPENSSL" ecparam -name "$EASYRSA_CURVE" \
 			-out "$EASYRSA_ALGO_PARAMS" \
 			1>/dev/null || die "\
 Failed to generate ecparam file (permissions?) at:

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5195,10 +5195,14 @@ One or more of these problems has been found in your 'vars' file:
 	set_var EASYRSA_REQ_OU			"My Organizational Unit"
 	set_var EASYRSA_REQ_SERIAL		""
 	set_var EASYRSA_ALGO			rsa
+	set_var EASYRSA_KEY_SIZE		2048
 
 	case "$EASYRSA_ALGO" in
 	rsa)
-		set_var EASYRSA_KEY_SIZE	2048
+		: # ok
+		# default EASYRSA_KEY_SIZE must always be set
+		# it must NOT be set selectively because it is
+		# present in the SSL config file
 	;;
 	ec)
 		set_var EASYRSA_CURVE		secp384r1

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -937,25 +937,6 @@ easyrsa_openssl() {
 		has_config=1
 	fi
 
-	# Auto-escape hazardous characters:
-	# '&' - Workaround 'sed' behavior
-	# '$' - Workaround 'easyrsa' based limitation
-	# This is required for all SSL libs, otherwise,
-	# there are unacceptable differences in behavior
-	# EASYRSA_FORCE_SAFE_SSL will always over-ride
-	if [ -z "$EASYRSA_FORCE_SAFE_SSL" ] && \
-		[ "$working_safe_ssl_conf" ]
-	then
-		: # ok - This has been done before
-		verbose "\
-easyrsa_openssl: escape_hazard SKIPPED"
-	else
-		escape_hazard || \
-			die "easyrsa_openssl - escape_hazard failed"
-		verbose "\
-easyrsa_openssl: escape_hazard COMPLETED"
-	fi
-
 	# Make LibreSSL safe config file from OpenSSL config file
 	# $require_safe_ssl_conf is ALWAYS set by verify_ssl_lib()
 	# Can be over-ruled for OpenSSL by option --no-safe-ssl
@@ -970,10 +951,23 @@ easyrsa_openssl: escape_hazard COMPLETED"
 			[ "$working_safe_ssl_conf" ]
 		then
 			# ok - This has been done before
+			# Set SAFE SSL conf to working SAFE SSL conf
 			easyrsa_safe_ssl_conf="$working_safe_ssl_conf"
+			verbose "\
+easyrsa_openssl: escape_hazard SKIPPED"
 			verbose "\
 easyrsa_openssl: easyrsa_rewrite_ssl_config SKIPPED"
 		else
+			# Auto-escape hazardous characters:
+			# '&' - Workaround 'sed' behavior
+			# '$' - Workaround 'easyrsa' based limitation
+			# This is required for all SSL libs, otherwise,
+			# there are unacceptable differences in behavior
+			escape_hazard || \
+				die "easyrsa_openssl - escape_hazard failed"
+			verbose "\
+easyrsa_openssl: escape_hazard COMPLETED"
+
 			# Assign easyrsa_safe_ssl_conf temp-file
 			easyrsa_safe_ssl_conf=""
 			easyrsa_mktemp easyrsa_safe_ssl_conf || die "\

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -689,8 +689,6 @@ easyrsa_mktemp - Temporary session undefined"
 	t="${secured_session}/temp.${mktemp_counter}"
 
 	# Create shotfile
-	verbose "\
-easyrsa_mktemp: Create temp-file for: $1"
 	for h in x y x; do
 		shotfile="${t}.${h}"
 		if [ -e "$shotfile" ]; then
@@ -700,8 +698,6 @@ easyrsa_mktemp: shot-file EXISTS: $shotfile"
 		else
 			printf "" > "$shotfile" || die "\
 easyrsa_mktemp: create shotfile failed (1) $1"
-			verbose "\
-easyrsa_mktemp: shot-file created: $shotfile"
 
 			# Create temp-file or die
 			# subshells do not update mktemp_counter,
@@ -715,17 +711,19 @@ easyrsa_mktemp: temp-file EXISTS: $want_tmp_file"
 					continue
 				else
 					# atomic:
-					[ "$easyrsa_host_os" = win ] && \
+					[ "$easyrsa_host_os" = win ] && {
 						set -o noclobber
+					}
 
 					if mv "$shotfile" "$want_tmp_file"; then
-						verbose "\
-easyrsa_mktemp: atomic: Create temp-file OK: $want_tmp_file"
 						# Assign external temp-file name
 						if force_set_var "$1" "$want_tmp_file"
 						then
-							[ "$easyrsa_host_os" = win ] && \
+							verbose "\
+easyrsa_mktemp: $1 temp-file OK: $want_tmp_file"
+							[ "$easyrsa_host_os" = win ] && {
 								set +o noclobber
+							}
 							unset -v want_tmp_file shotfile
 							return 0
 						else
@@ -954,6 +952,8 @@ easyrsa_openssl: escape_hazard SKIPPED"
 	else
 		escape_hazard || \
 			die "easyrsa_openssl - escape_hazard failed"
+		verbose "\
+easyrsa_openssl: escape_hazard COMPLETED"
 	fi
 
 	# Make LibreSSL safe config file from OpenSSL config file
@@ -983,20 +983,20 @@ easyrsa_openssl - easyrsa_mktemp easyrsa_safe_ssl_conf"
 			if easyrsa_rewrite_ssl_config; then
 				verbose "\
 easyrsa_openssl: easyrsa_rewrite_ssl_config COMPLETED"
+				# Save the the safe conf file-name
+				working_safe_ssl_conf="$easyrsa_safe_ssl_conf"
+				verbose "\
+easyrsa_openssl: NEW SAFE SSL config: $easyrsa_safe_ssl_conf"
 			else
 				die "\
 easyrsa_openssl - easyrsa_rewrite_ssl_config"
 			fi
-
-			# Save the the safe conf file-name
-			working_safe_ssl_conf="$easyrsa_safe_ssl_conf"
-			verbose "\
-easyrsa_openssl: NEW SSL cnf file: $easyrsa_safe_ssl_conf"
 		fi
 
 	else
 		# Assign safe temp file as Original openssl-easyrsa.conf
 		easyrsa_safe_ssl_conf="$EASYRSA_SSL_CONF"
+		verbose "easyrsa_openssl: No SAFE SSL config"
 	fi
 
 	# VERIFY safe temp-file exists
@@ -4901,6 +4901,7 @@ verify_algo_params() {
 		"verify_algo_params - easyrsa_mktemp EASYRSA_ALGO_PARAMS"
 
 		# Create the required ecparams file
+		# call openssl directly because error is expected
 		"$EASYRSA_OPENSSL" ecparam -name "$EASYRSA_CURVE" \
 			-out "$EASYRSA_ALGO_PARAMS" \
 			1>/dev/null || die "\
@@ -4909,6 +4910,7 @@ Failed to generate ecparam file (permissions?) at:
 	;;
 	ed)
 		# Verify Edwards curve
+		# call openssl directly because error is expected
 		"$EASYRSA_OPENSSL" genpkey \
 			-algorithm "$EASYRSA_CURVE" \
 			1>/dev/null || die "\
@@ -4917,6 +4919,8 @@ Edwards Curve $EASYRSA_CURVE not found."
 	*) die "\
 Alg '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 	esac
+	verbose "\
+verify_algo_params: Params verified for algo '$EASYRSA_ALGO'"
 } # => verify_algo_params()
 
 # Check for conflicting input options
@@ -5272,6 +5276,13 @@ verify_working_env - install_data_to_pki vars-setup failed"
 
 			# Verify selected algorithm and parameters
 			verify_algo_params
+
+			# Check $working_safe_ssl_conf, to build
+			# a fully configured safe ssl conf, on the
+			# next invocation of easyrsa_openssl()
+			[ -z "$working_safe_ssl_conf" ] || {
+				die "working_safe_ssl_conf must not be set!"
+			}
 
 			# Last setup msg
 			information "\
@@ -5949,6 +5960,7 @@ unset -v \
 	easyrsa_error_exit \
 	prohibit_no_pass \
 	secured_session \
+	working_safe_ssl_conf \
 	user_vars_true \
 	user_san_true \
 	alias_days


### PR DESCRIPTION
This patch set fixes three inter-linked problems.

**Problem-1:**

When using EC algorithms, it was found that `EASYRSA_REQ_CN` was ignored by `easyrsa` because the value in the config took priority.

The config built was built too soon, before `EASYRSA_REQ_CN` had been assigned, which meant that building a CA would result in a CA CommonName of `ChangeMe`, instead of `Easy-RSA CA`.

This is partially resolved by not using `easyrsa_openssl()` meta-wrapper when calling `verify_algo_params()` but calling `EASYRSA_OPENSSL` directly.

This also, resolves an issue that if incorrect algorithm settings were chosen then `easyrsa_openssl()` would die with a misleading error, instead of `verify_algo_params()` exiting with the correct error message.

**Problem-2:**

Diagnosing Problem-1 exposed an issue with the SSL config file. When `EASYRSA_ALGO` was not set to `rsa` then `EASYRSA_KEY_SIZE` was also not set. This resulted in an error in the config file for empty vaue for `default_bits`.

This is resolved by ALWAYS assigning a value to `EASYRSA_KEY_SIZE`, regardless of algorithm.

**Problem-3:**

The first time the Safe SSL config is created then `working_safe_ssl_conf` is set and further invocations of `easyrsa_openssl()` will use the same SSL config file.  A new Safe SSL config file is not required once it has been built.

The assignment of `working_safe_ssl_conf` was set too late and resulted in it being set even if the Safe SSL config file had not been built.

This is resolved by moving the assignment to the correct place.

A secondary check is also now in place, at the end of `verify_working_env()`, to ensure that `working_safe_ssl_conf` remains unset until the issued command is executed. eg. build_ca()`.

**Additional**:

Move the use of `escape_hazard()`, use the same controlling code as `easyrsa_rewrite_ssl_config()`.