### PR TITLE
build-ca: Use OpenSSL password I/O argument 'stdin' 

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,12 @@
 Easy-RSA 3 ChangeLog
 
-3.1.3 (ETA: 2023-05-19)
+3.1.4 (ETA: 2023-06-02)
+   * build-ca: Revert manual CA password method to temp-files (#959)
+     Supersedes #955
+
+3.1.3 (2023-05-19)
    * build-ca: Replace password temp-files with file-descriptors (#955)
+     Superseded by #959
    * Replace --fix-offset with --startdate, --enddate (#918)
    * Introduce option -S|--silent-ssl: Silence SSL output (#913)
    * Only create a random serial number file when expected (#896)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -470,7 +470,7 @@ General options:
                   Can not be used with --passin or --passout
 --passin=ARG    : Set -passin ARG for openssl (eg: pass:xEasyRSAy)
 --passout=ARG   : Set -passout ARG for openssl (eg: pass:xEasyRSAy)
---ca-via-tf     : Build CA with password via temp-files (Old method)
+--ca-via-stdin  : Build CA with password via 'stdin' (New method)
 
 --vars=FILE     : Define a specific 'vars' file to use for Easy-RSA config
                   (Default vars file is in the EasyRSA PKI directory)
@@ -542,6 +542,10 @@ Easy-RSA error:
 
 $1
 "
+	if [ "$error_info" ]; then
+		print "${error_info}${NL}"
+	fi
+
 	show_host
 	exit "${2:-1}"
 } # => die()
@@ -1450,7 +1454,7 @@ get_passphrase() {
 # build-ca backend:
 build_ca() {
 	cipher="-aes256"
-	unset -v sub_ca ssl_batch date_stamp x509
+	unset -v sub_ca ssl_batch date_stamp x509 error_info
 	while [ "$1" ]; do
 		case "$1" in
 			intca|subca) sub_ca=1 ;;
@@ -1606,7 +1610,20 @@ to the latest Easy-RSA release."
 
 		# Validate passphrase
 		if [ "$p" ] && [ "$p" = "$q" ]; then
-			if [ "$EASYRSA_CA_PASS_OLD" ]; then
+			if [ "$EASYRSA_CA_PASS_NEW" ]; then
+				# CA password via stdin
+				CA_key_pass="$p"
+
+				# To use stdin for -passin and -passout
+				# MUST use -batch
+				ssl_batch=1
+
+				# Helpful info, in case of failure
+				error_info="\
+  EasyRSA 'build-ca' has failed due to use of OpenSSL password
+  argument 'stdin'.  Please report this error to EasyRSA."
+
+			else
 				# CA password via temp-files
 				in_key_pass_tmp=""
 				easyrsa_mktemp in_key_pass_tmp || \
@@ -1618,13 +1635,6 @@ to the latest Easy-RSA release."
 					die "in_key_pass_tmp: write"
 				printf "%s" "$p" > "$out_key_pass_tmp" || \
 					die "out_key_pass_tmp: write"
-			else
-				# CA password via file-descriptors
-				CA_key_pass="$p"
-
-				# To use stdin for -passin and -passout
-				# MUST use -batch
-				ssl_batch=1
 			fi
 			unset -v p q
 		else
@@ -1658,7 +1668,7 @@ to the latest Easy-RSA release."
 	EASYRSA_SSL_CONF="$conf_tmp"
 
 	# Generate CA Key
-	if [ "$CA_key_pass" ]; then
+	if [ "$EASYRSA_CA_PASS_NEW" ]; then
 		case "$EASYRSA_ALGO" in
 		rsa)
 			if easyrsa_openssl genpkey \
@@ -1755,7 +1765,7 @@ build_ca: CA key password created via temp-files"
 	fi
 
 	# Generate the CA keypair:
-	if [ "$CA_key_pass" ]; then
+	if [ "$EASYRSA_CA_PASS_NEW" ]; then
 		if easyrsa_openssl req -utf8 -new \
 			-key "$out_key_tmp" \
 			-out "$out_file_tmp" \
@@ -1769,6 +1779,7 @@ build_ca: CA key password created via temp-files"
 				EOF
 		then
 			: # ok
+			unset -v error_info
 		else
 			die "Failed to build the CA keypair."
 		fi
@@ -5091,8 +5102,8 @@ Your Easy-RSA PKI CA Private Key is WORLD readable.
 To correct this problem, it is recommended that you either:
 * Copy Easy-RSA to your User folders and run it from there, OR
 * Define your PKI to be in your User folders. EG:
-  'easyrsa --pki-dir=C:/Users/<your-user-name>/easy-rsa/pki\"'\
- <command>"
+  'easyrsa --pki-dir=\"C:/Users/<your-user-name>/easy-rsa/pki\"\
+ <command>'"
 		fi
 	fi
 
@@ -6228,9 +6239,9 @@ while :; do
 	--passout)
 		export EASYRSA_PASSOUT="$val"
 		;;
-	--ca-via-textfile|--ca-via-tf)
+	--ca-via-stdin)
 		empty_ok=1
-		export EASYRSA_CA_PASS_OLD=1
+		export EASYRSA_CA_PASS_NEW=1
 		;;
 	--notext|--no-text)
 		empty_ok=1

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1575,6 +1575,15 @@ to the latest Easy-RSA release."
 	then
 		: # No passphrase required
 
+	# Strictly for use only by easyrsa-unit-tests.sh
+	elif [ "$ERSA_UTEST_VERSION" ] && [ "$EASYRSA_USE_PASS" ]
+	then
+		# Set a test password and use file-descriptor method
+		CA_key_pass='EasyRSA'
+		# To use stdin for -passin and -passout
+		# MUST use -batch
+		ssl_batch=1
+
 	elif [ "$EASYRSA_PASSOUT" ] && [ "$EASYRSA_PASSIN" ]
 	then
 		: # passphrase defined
@@ -1700,8 +1709,14 @@ to the latest Easy-RSA release."
 		;;
 		*)	die "Unknown algorithm: $EASYRSA_ALGO"
 		esac
+
 		verbose "\
-build_ca: CA key password created via FD"
+build_ca: CA key password created via stdin"
+		if [ "$ERSA_UTEST_VERSION" ] && \
+			[ "$EASYRSA_USE_PASS" ]
+		then
+			print "CA key via stdin"
+		fi
 
 	else
 		case "$EASYRSA_ALGO" in
@@ -1753,10 +1768,17 @@ build_ca: CA key password created via temp-files"
 					${CA_key_pass}
 				EOF
 		then
-			verbose "\
-build_ca: CA certificate password created via FD"
+			: # ok
 		else
 			die "Failed to build the CA keypair."
+		fi
+
+		verbose "\
+build_ca: CA certificate password created via stdin"
+		if [ "$ERSA_UTEST_VERSION" ] && \
+			[ "$EASYRSA_USE_PASS" ]
+		then
+			print "CA Cert via stdin"
 		fi
 
 	else

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1612,6 +1612,10 @@ to the latest Easy-RSA release."
 			else
 				# CA password via file-descriptors
 				CA_key_pass="$p"
+
+				# To use stdin for -passin and -passout
+				# MUST use -batch
+				ssl_batch=1
 			fi
 			unset -v p q
 		else
@@ -1654,8 +1658,8 @@ to the latest Easy-RSA release."
 					rsa_keygen_bits:"$EASYRSA_ALGO_PARAMS" \
 				-out "$out_key_tmp" \
 				${cipher:+ "$cipher"} \
-				-pass fd:3 \
-					3<<-EOF
+				-pass stdin \
+					<<-EOF
 						${CA_key_pass}
 					EOF
 			then
@@ -1669,8 +1673,8 @@ to the latest Easy-RSA release."
 				-paramfile "$EASYRSA_ALGO_PARAMS" \
 				-out "$out_key_tmp" \
 				${cipher:+ "$cipher"} \
-				-pass fd:3 \
-					3<<-EOF
+				-pass stdin \
+					<<-EOF
 						${CA_key_pass}
 					EOF
 			then
@@ -1684,8 +1688,8 @@ to the latest Easy-RSA release."
 				-algorithm "$EASYRSA_CURVE" \
 				-out "$out_key_tmp" \
 				${cipher:+ "$cipher"} \
-				-pass fd:3 \
-					3<<-EOF
+				-pass stdin \
+					<<-EOF
 						${CA_key_pass}
 					EOF
 			then
@@ -1738,21 +1742,21 @@ build_ca: CA key password created via temp-files"
 	# Generate the CA keypair:
 	if [ "$CA_key_pass" ]; then
 		if easyrsa_openssl req -utf8 -new \
-			-key "$out_key_tmp" -keyout "$out_key_tmp" \
+			-key "$out_key_tmp" \
 			-out "$out_file_tmp" \
 			${ssl_batch:+ -batch} \
 			${x509:+ -x509} \
 			${date_stamp:+ -days "$EASYRSA_CA_EXPIRE"} \
 			${EASYRSA_DIGEST:+ -"$EASYRSA_DIGEST"} \
-			-passin fd:3 \
-				3<<-EOF
+			-passin stdin \
+				<<-EOF
 					${CA_key_pass}
 				EOF
 		then
 			verbose "\
 build_ca: CA certificate password created via FD"
 		else
-			die "Failed to build the CA keypair"
+			die "Failed to build the CA keypair."
 		fi
 
 	else
@@ -6202,7 +6206,7 @@ while :; do
 	--passout)
 		export EASYRSA_PASSOUT="$val"
 		;;
-	--ca-via-tf)
+	--ca-via-textfile|--ca-via-tf)
 		empty_ok=1
 		export EASYRSA_CA_PASS_OLD=1
 		;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1579,15 +1579,6 @@ to the latest Easy-RSA release."
 	then
 		: # No passphrase required
 
-	# Strictly for use only by easyrsa-unit-tests.sh
-	elif [ "$ERSA_UTEST_VERSION" ] && [ "$EASYRSA_USE_PASS" ]
-	then
-		# Set a test password and use file-descriptor method
-		CA_key_pass='EasyRSA'
-		# To use stdin for -passin and -passout
-		# MUST use -batch
-		ssl_batch=1
-
 	elif [ "$EASYRSA_PASSOUT" ] && [ "$EASYRSA_PASSIN" ]
 	then
 		: # passphrase defined
@@ -1722,11 +1713,6 @@ to the latest Easy-RSA release."
 
 		verbose "\
 build_ca: CA key password created via stdin"
-		if [ "$ERSA_UTEST_VERSION" ] && \
-			[ "$EASYRSA_USE_PASS" ]
-		then
-			print "CA key via stdin"
-		fi
 
 	else
 		case "$EASYRSA_ALGO" in
@@ -1786,11 +1772,6 @@ build_ca: CA key password created via temp-files"
 
 		verbose "\
 build_ca: CA certificate password created via stdin"
-		if [ "$ERSA_UTEST_VERSION" ] && \
-			[ "$EASYRSA_USE_PASS" ]
-		then
-			print "CA Cert via stdin"
-		fi
 
 	else
 		easyrsa_openssl req -utf8 -new \


### PR DESCRIPTION
When OpenSSL is built "for Windows", it does not support
password input/output via argument 'fd:N', file-descriptors.

However, OpenSSL built "for Windows" does allow use of 'stdin'.
eg: -pass:stdin (-passin/-passout)

There is one drawback; When using 'stdin' openssl cannot allow
further user input to customise the 'commonName', or any other
organisational fields used by '--dn-mode=org'. OpenSSL enforces
'-batch' when 'stdin' is used. Therefore, EasyRSA must set batch
mode, to correctly use 'stdin' to pass the CA password.

Creating CA key pair this way also requires that SSL option
'-keyout' be dropped from the create CA request command.
