### PR TITLE
sign-req: Allow the CSR DN-field order to be preserved

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 Easy-RSA 3 ChangeLog
 
+3.1.6 (2023-10-13)
+   * sign-req: Allow the CSR DN-field order to be preserved (#970)
+
 3.1.5 (2023-06-10)
    * Build Update: script now supports signing and verifying
    * Automate support-file creation (Free packaging) (#964)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -128,7 +128,7 @@ cmd_help() {
 	;;
 	sign|sign-req)
 		text="
-* sign-req <type> <file_name_base>
+* sign-req <type> <file_name_base> [ cmd-opts ]
 
       Sign a certificate request of the defined type. <type> must be a known type,
       such as: 'client', 'server', 'serverClient', or 'ca' (or a user-added type).
@@ -136,6 +136,8 @@ cmd_help() {
 
       This request file must exist in the reqs/ dir and have a .req file
       extension. See import-req below for importing reqs from other sources."
+		opts="
+      * preserve - When signing a request, 'preserve' the DN-field order of the CSR."
 	;;
 	build|build-client-full|build-server-full|build-serverClient-full)
 		text="
@@ -2243,6 +2245,15 @@ sign_req() {
 Incorrect number of arguments provided to sign-req:
 expected 2, got $# (see command help for usage)"
 
+	# Check for preserve-dn
+	if [ "$3" ]; then
+		case "$3" in
+			preserve*) export EASYRSA_PRESERVE_DN=1 ;;
+			*)
+				warn "Ignoring unknown option '$3'"
+		esac
+	fi
+
 	# Cert type must exist under the EASYRSA_EXT_DIR
 	[ -e "$EASYRSA_EXT_DIR/$crt_type" ] || warn "\
 Missing X509-type '$crt_type'"
@@ -2512,6 +2523,7 @@ $(display_dn req "$req_in")
 	easyrsa_openssl ca -utf8 -batch \
 		-in "$req_in" -out "$crt_out_tmp" \
 		-extfile "$ext_tmp" \
+		${EASYRSA_PRESERVE_DN:+ -preserveDN} \
 		${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
 		${EASYRSA_NO_TEXT:+ -notext} \
 		${EASYRSA_CERT_EXPIRE:+ -days "$EASYRSA_CERT_EXPIRE"} \

--- a/easyrsa3/openssl-easyrsa.cnf
+++ b/easyrsa3/openssl-easyrsa.cnf
@@ -31,6 +31,9 @@ crl_extensions	= crl_ext
 default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
 default_crl_days	= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
 default_md	= $ENV::EASYRSA_DIGEST		# use public key default MD
+
+# Note: preserve=no|yes, does nothing for EasyRSA.
+# Use sign-req command option 'preserve' instead.
 preserve	= no			# keep passed DN ordering
 
 # This allows to renew certificates which have not been revoked

--- a/easyrsa3/vars.example
+++ b/easyrsa3/vars.example
@@ -105,6 +105,12 @@ fi
 #set_var EASYRSA_REQ_EMAIL	"me@example.net"
 #set_var EASYRSA_REQ_OU		"My Organizational Unit"
 
+# Preserve the Distinguished Name field order
+# of the certificate signing request
+# *Only* effective in --dn-mode=org
+#
+#set_var EASYRSA_PRESERVE_DN	1
+
 # Set no password mode - This will create the entire PKI without passwords.
 # This can be better managed by choosing which entity private keys should be
 # encrypted with the following command line options:


### PR DESCRIPTION
When signing a request, EasyRSA ALWAYS defaults to the CA defined Distinguished Name field order, as defined by openssl-easyrsa.cnf configuration file.

In the unlikely event that a CSR is received with a different DN-field order, that order can be preserved for the signed certificate.

Command 'sign-req', now has a command option 'preserve' for this.

Additional:

Use of 'preserve = yes' in openssl-easyrsa.cnf has no effect for EasyRSA.

Testing OpenSSL directly indicates that this option may have no effect when used in OpenSSL default configuration file openssl.cnf

Also, OpenSSL documentation for command 'ca', option '-preserveDN' does NOT infer that this option can be used in the configuration file.

None of which is important to EasyRSA because only foreign CSRs can have a different DN-field order, so default behavior can remain.