### PR TITLE
Expose 'sign-req' unique, random serial number check to command line

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,8 @@
 Easy-RSA 3 ChangeLog
 
 3.1.6 (2023-10-13)
+   * Expose serial-check, display-dn, display-san and default-san to
+     command line. (#980) (Debugging functions, which remain undocumented)
    * Expand default status to include vars-file and CA status (#973)
    * sign-req: Allow the CSR DN-field order to be preserved (#970)
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2395,32 +2395,21 @@ The certificate request file is not in a valid X509 format:
 	if [ "$EASYRSA_RAND_SN" != "no" ]; then
 		serial=""
 		check_serial=""
-		unset -v unique_serial
+		unset -v serial_is_unique
 		for i in 1 2 3 4 5; do
 			serial="$(
 				easyrsa_random 16
 				)" || die "sign_req - easyrsa_random"
 
 			# Check for duplicate serial in CA db
-			# Always errors out - Do not capture error
-			# unset EASYRSA_SILENT_SSL to capure all output
-			check_serial="$(
-				unset -v EASYRSA_SILENT_SSL
-				easyrsa_openssl ca -status "$serial" 2>&1
-				)" || :
-
-			case "$check_serial" in
-				*"not present in db"*)
-					unique_serial=1
-					break
-				;;
-				*)
-					verbose "check_serial: $check_serial"
-			esac
+			if check_serial_status "$serial" batch; then
+				serial_is_unique=1
+				break
+			fi
 		done
 
 		# Check for unique_serial
-		[ "$unique_serial" ] || die "\
+		[ "$serial_is_unique" ] || die "\
 sign_req - Randomize Serial number failed:
 
 $check_serial"
@@ -2658,6 +2647,56 @@ Certificate created at:
 
 	return 0
 } # => sign_req()
+
+# Check serial in db
+check_serial_status() {
+	serial="$1"
+	[ "$serial" ] || user_error "Serial number required!"
+
+	[ "$2" = batch ] && internal_batch=1
+
+	unset -v unique_serial
+
+	# Check for openssl -status of serial number
+	# Always errors out - Do not capture error
+	# unset EASYRSA_SILENT_SSL to capure all output
+	check_serial="$(
+		unset -v EASYRSA_SILENT_SSL
+		easyrsa_openssl ca -status "$serial" 2>&1
+		)" || :
+
+	# Check for duplicate serial in CA db
+	case "$check_serial" in
+		(*"not present in db"*)
+			unique_serial=1
+			verbose "check_serial_status: unique_serial=true"
+		;;
+		*)
+			: # Some other response
+	esac
+
+	# In batch return result only
+	if [ "$internal_batch" ] || [ "$EASYRSA_BATCH" ]
+	then
+		[ "$unique_serial" ] && return
+		return 1
+	fi
+
+	# Otherwise, show result to user
+	print "
+check_serial_status() RESULT:
+========================================
+
+$check_serial
+
+========================================
+Complete"
+
+	# Force cleanup() to exit with error,
+	# if the serial number is not unique.
+	# OpenSSL always exits with error, regardless..
+	[ "$unique_serial" ] || easyrsa_exit_with_error=1
+} # => check_serial_status()
 
 # common build backend
 # used to generate+sign in 1 step
@@ -6812,6 +6851,9 @@ case "$cmd" in
 		;;
 	gen-req)
 		gen_req "$@"
+		;;
+	serial|check-serial)
+		check_serial_status "$@"
 		;;
 	sign|sign-req)
 		[ -z "$alias_days" ] || \

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -6852,9 +6852,6 @@ case "$cmd" in
 	gen-req)
 		gen_req "$@"
 		;;
-	serial|check-serial)
-		check_serial_status "$@"
-		;;
 	sign|sign-req)
 		[ -z "$alias_days" ] || \
 			export EASYRSA_CERT_EXPIRE="$alias_days"
@@ -6960,6 +6957,18 @@ case "$cmd" in
 		;;
 	make-safe-ssl)
 		make_safe_ssl "$@"
+		;;
+	serial|check-serial)
+		check_serial_status "$@"
+		;;
+	display-dn)
+		display_dn "$@"
+		;;
+	display-san)
+		display_san "$@"
+		;;
+	default-san)
+		default_server_san "$@"
 		;;
 	upgrade)
 		up23_manage_upgrade_23 "$@"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -868,6 +868,7 @@ Temporary session not preserved."
 	# Exit: Known errors
 	# -> confirm(): aborted
 	# -> verify_cert(): verify failed --batch mode
+	# -> check_serial_unique(): not unique --batch mode
 	if [ "$easyrsa_exit_with_error" ]; then
 		verbose "Exit: Known errors = true"
 		exit 1
@@ -2402,7 +2403,7 @@ The certificate request file is not in a valid X509 format:
 				)" || die "sign_req - easyrsa_random"
 
 			# Check for duplicate serial in CA db
-			if check_serial_status "$serial" batch; then
+			if check_serial_unique "$serial" batch; then
 				serial_is_unique=1
 				break
 			fi
@@ -2649,7 +2650,7 @@ Certificate created at:
 } # => sign_req()
 
 # Check serial in db
-check_serial_status() {
+check_serial_unique() {
 	serial="$1"
 	[ "$serial" ] || user_error "Serial number required!"
 
@@ -2669,34 +2670,34 @@ check_serial_status() {
 	case "$check_serial" in
 		(*"not present in db"*)
 			unique_serial=1
-			verbose "check_serial_status: unique_serial=true"
+			verbose "check_serial_unique: unique_serial=true"
 		;;
 		*)
 			: # Some other response
+			verbose "check_serial_unique: unique_serial=false"
 	esac
 
-	# In batch return result only
+	# In batch mode return result only
 	if [ "$internal_batch" ] || [ "$EASYRSA_BATCH" ]
 	then
-		[ "$unique_serial" ] && return
-		return 1
+		if [ "$unique_serial" ]; then
+			return 0
+		else
+			return 1
+		fi
 	fi
 
 	# Otherwise, show result to user
+	# and do not return any error code
 	print "
-check_serial_status() RESULT:
+check_serial_status RESULT:
 ========================================
 
 $check_serial
 
 ========================================
-Complete"
-
-	# Force cleanup() to exit with error,
-	# if the serial number is not unique.
-	# OpenSSL always exits with error, regardless..
-	[ "$unique_serial" ] || easyrsa_exit_with_error=1
-} # => check_serial_status()
+COMPLETE"
+} # => check_serial_unique()
 
 # common build backend
 # used to generate+sign in 1 step
@@ -6584,7 +6585,7 @@ unset -v \
 	working_safe_ssl_conf \
 	user_san_true \
 	alias_days \
-	do_build_full \
+	do_build_full internal_batch \
 	found_vars no_new_vars user_vars_true
 
 	# Used by build-ca->cleanup to restore prompt
@@ -6935,12 +6936,6 @@ case "$cmd" in
 	show-ca)
 		show_ca "$@"
 		;;
-	verify|verify-cert)
-		# Called with --batch, this will return error
-		# when the certificate fails verification.
-		# Therefore, on error, go directly to cleanup.
-		verify_cert "$@" || cleanup
-		;;
 	show-expire)
 		[ -z "$alias_days" ] || \
 			export EASYRSA_PRE_EXPIRY_WINDOW="$alias_days"
@@ -6958,8 +6953,19 @@ case "$cmd" in
 	make-safe-ssl)
 		make_safe_ssl "$@"
 		;;
+	verify|verify-cert)
+		# Called with --batch, this will return error
+		# when the certificate fails verification.
+		# Therefore, on error, exit with error.
+		verify_cert "$@" || \
+			easyrsa_exit_with_error=1
+		;;
 	serial|check-serial)
-		check_serial_status "$@"
+		# Called with --batch, this will return error
+		# when the serial number is not unique.
+		# Therefore, on error, exit with error.
+		check_serial_unique "$@" || \
+			easyrsa_exit_with_error=1
 		;;
 	display-dn)
 		display_dn "$@"


### PR DESCRIPTION
Problem:

EasyRSA uses SSL CA command parameter '-serial $serial_number', to check if a serial-number exists within the database.

The primary function of the SSL CA command parameter '-serial' is to check if a certificate is Valid or has been Revoked.

EasyRSA abuses the SSL output to infer that a serial-number must be unique because that output contains the text 'not present in db'.

SSL CA command parameter '-serial' ALWAYS returns an error, reagrdless of what-ever check it does. Likely, an SSL bug.

As a step-in-the-right direction:

To ease this needless-headache, expose the unique, random serial-number check to the command line.

This helps to understand what is going on under-the-hood.

The command 'sign-req' remains the same; except the unique, random serial-number check is moved to a separate, stand-alone function, which is also exposed to the command line for validation.