### PR TITLE
sign-req: Major refactor

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2263,7 +2263,9 @@ Writing 'copy_exts' to SSL config temp-file failed"
 		easyrsa_mktemp x509_type_tmp || \
 			die "sign_req - easyrsa_mktemp x509_type_tmp"
 
-		create_x509_type "$crt_type" > "$x509_type_tmp"
+		create_x509_type "$crt_type" > "$x509_type_tmp" || \
+			die "sign_req - create_x509_type $crt_type"
+
 		x509_type_file="$x509_type_tmp"
 	fi
 
@@ -2277,7 +2279,9 @@ Writing 'copy_exts' to SSL config temp-file failed"
 		easyrsa_mktemp x509_COMMON_tmp || \
 			die "sign_req - easyrsa_mktemp x509_COMMON_tmp"
 
-		create_x509_type COMMON > "$x509_COMMON_tmp"
+		create_x509_type COMMON > "$x509_COMMON_tmp" || \
+			die "sign_req - create_x509_type COMMON"
+
 		x509_COMMON_file="$x509_type_tmp"
 	fi
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -6823,7 +6823,7 @@ case "$cmd" in
 	*)
 		require_pki=1
 		case "$cmd" in
-			gen-req|gen-dh|build-ca)
+			gen-req|gen-dh|build-ca|show-req)
 				unset -v require_ca
 			;;
 			*)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2338,8 +2338,7 @@ basicConstraints is not defined, cannot use 'pathlen'"
 	# Begin output redirect
 	{
 		# Append $cert-type extensions
-		cat "$x509_COMMON_file"
-		cat "$x509_type_file"
+		cat "$x509_COMMON_file" "$x509_type_file"
 
 		# Support a dynamic CA path length when present:
 		if [ "$basicConstraints" ]; then

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2424,6 +2424,7 @@ $check_serial"
 		# for use by SSL config
 		print "$serial" > "$EASYRSA_PKI/serial" || \
 			die "sign_req - write serial to file"
+		unset -v serial check_serial serial_is_unique
 	fi
 
 	# When EASYRSA_CP_EXT is defined,
@@ -2457,12 +2458,12 @@ to the latest Easy-RSA release."
 
 		print "$copy_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
-			> "$conf_tmp" \
-			|| die "Writing SSL config to temp file failed"
+				> "$conf_tmp" || die "\
+Writing 'copy_exts' to SSL config temp-file failed"
 
 		# Use this SSL config for the rest of this function
 		EASYRSA_SSL_CONF="$conf_tmp"
-		verbose "sign_req: copy_extensions = copy"
+		verbose "sign_req: Using '$copy_exts'"
 	fi
 
 	# Find or create x509-type file
@@ -2665,6 +2666,7 @@ check_serial_unique() {
 	# Check for openssl -status of serial number
 	# Always errors out - Do not capture error
 	# unset EASYRSA_SILENT_SSL to capure all output
+	# Do NOT unset check_serial for sign-req error msg
 	check_serial="$(
 		unset -v EASYRSA_SILENT_SSL
 		easyrsa_openssl ca -status "$1" 2>&1
@@ -2685,8 +2687,10 @@ check_serial_unique() {
 	if [ "$internal_batch" ] || [ "$EASYRSA_BATCH" ]
 	then
 		if [ "$unique_serial_true" ]; then
+			unset -v unique_serial_true internal_batch
 			return 0
 		else
+			unset -v unique_serial_true internal_batch
 			return 1
 		fi
 	fi

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -6583,14 +6583,14 @@ detect_host
 # Initialisation requirements
 unset -v \
 	verify_ssl_lib_ok \
-	easyrsa_exit_with_error error_info \
-	prohibit_no_pass \
 	secured_session \
 	working_safe_ssl_conf \
-	user_san_true \
 	alias_days \
-	do_build_full internal_batch \
-	found_vars no_new_vars user_vars_true
+	prohibit_no_pass \
+	found_vars no_new_vars user_vars_true \
+	do_build_full error_build_full_cleanup \
+	internal_batch \
+	easyrsa_exit_with_error error_info
 
 	# Used by build-ca->cleanup to restore prompt
 	# after user interrupt when using manual password

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -921,7 +921,7 @@ export EASYRSA_REQ_CITY=\"$EASYRSA_REQ_CITY\"
 export EASYRSA_REQ_ORG=\"$EASYRSA_REQ_ORG\"
 export EASYRSA_REQ_OU=\"$EASYRSA_REQ_OU\"
 export EASYRSA_REQ_EMAIL=\"$EASYRSA_REQ_EMAIL\"
-export EASYRSA_REQ_SERIAL=\"$EASYRSA_REQ_SERIAL\"
+export EASYRSA_REQ_SERIAL=\"$EASYRSA_REQ_SERIAL\"\
 " | sed -e s\`'\&'\`'\\\&'\`g \
 		-e s\`'\$'\`'\\\$'\`g \
 			> "$easyrsa_vars_org" || die "\
@@ -1772,14 +1772,14 @@ Raw CA mode
 		if [ -f "$EASYRSA_EXT_DIR/ca" ]; then
 			cat "$EASYRSA_EXT_DIR/ca"
 		else
-			create_x509_type_ca
+			create_x509_type ca
 		fi
 
 		# COMMON file
 		if [ -f "$EASYRSA_EXT_DIR/COMMON" ]; then
 			cat "$EASYRSA_EXT_DIR/COMMON"
 		else
-			create_x509_type_COMMON
+			create_x509_type COMMON
 		fi
 
 		# User extentions
@@ -6100,7 +6100,7 @@ keyUsage = cRLSign, keyCertSign
 # Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
 
 # issuerAltName=issuer:copy
-authorityKeyIdentifier=keyid:always,issuer:always'
+authorityKeyIdentifier=keyid:always,issuer:always
 SSL_CONFIG
 } # => create_openssl_easyrsa_cnf()
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2307,6 +2307,9 @@ basicConstraints is not defined, cannot use 'pathlen'"
 	case "$EASYRSA_NS_SUPPORT" in
 		[yY][eE][sS])
 
+		confirm "Confirm use of Netscape extensions: " yes \
+			"WARNING: Netscape extensions are DEPRECATED!"
+
 		# Netscape extension
 		case "$crt_type" in
 			serverClient)
@@ -2406,15 +2409,6 @@ ${foriegn_request}Request subject, to be signed as a \
 $crt_type certificate ${valid_period}:
 
 $(display_dn req "$req_in")" # => confirm end
-
-	# Confirm deprecated use of NS extensions
-	case "$EASYRSA_NS_SUPPORT" in
-		[yY][eE][sS])
-		confirm "Confirm use of Netscape extensions: " yes \
-		"WARNING: Netscape extensions are DEPRECATED!"
-	;;
-	*) : #ok
-	esac
 
 	# Assign temp cert file
 	crt_out_tmp=""

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1522,58 +1522,62 @@ install_data_to_pki - Missing: '$x509_types_dir'"
 	verbose "install_data_to_pki: $context - COMPLETED"
 } # => install_data_to_pki ()
 
-# Create x509-type/ca
-create_x509_type_ca() {
-	cat << "CAFILECOMPLETE"
-basicConstraints = CA:TRUE
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer:always
-keyUsage = cRLSign, keyCertSign
-CAFILECOMPLETE
-} # => create_x509_type_ca()
+# Create X509-type files
+create_x509_type() {
+	x509_type="$1"
+	[ "$x509_type" ] || \
+		die "create_x509_type - type undefined"
 
-# Create x509-type/COMMON
-create_x509_type_COMMON() {
-	cat << "COMMONFILECOMPLETE"
-COMMONFILECOMPLETE
-} # => create_x509_type_COMMON()
+	case "$x509_type" in
+	COMMON)
+		cat <<- "X509_TYPE_COMMON"
+		X509_TYPE_COMMON
+	;;
+	serverClient)
+		create_x509_type_easyrsa
+		cat <<- "X509_TYPE_SERV_CLI"
+		extendedKeyUsage = serverAuth,clientAuth
+		X509_TYPE_SERV_CLI
+	;;
+	server)
+		create_x509_type_easyrsa
+		cat <<- "X509_TYPE_SERV"
+		extendedKeyUsage = serverAuth
+		X509_TYPE_SERV
+	;;
+	client)
+		create_x509_type_easyrsa
+		cat <<- "X509_TYPE_CLI"
+		extendedKeyUsage = clientAuth
+		X509_TYPE_CLI
+	;;
+	ca)
+		cat <<- "X509_TYPE_CA"
+		basicConstraints = CA:TRUE
+		subjectKeyIdentifier = hash
+		authorityKeyIdentifier = keyid:always,issuer:always
+		keyUsage = cRLSign, keyCertSign
+		X509_TYPE_CA
+	;;
+	*)
+		# Unknown type: User MUST supply the X509 file
+		die "Unknown X509 type: $x509_type"
+	esac
+} # => create_x509_type()
 
-# Create x509-type/unlisted: easyrsa
-# This could be COMMON but not for a CA
+# Create x509-type/easyrsa
+# This could be COMMON but not is not suitable for a CA
 create_x509_type_easyrsa() {
-	cat << "EASYRSAFILECOMPLETE"
-basicConstraints = CA:FALSE
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer:always
-keyUsage = digitalSignature,keyEncipherment
-EASYRSAFILECOMPLETE
+	cat <<- "X509_TYPE_EASYRSA"
+		basicConstraints = CA:FALSE
+		subjectKeyIdentifier = hash
+		authorityKeyIdentifier = keyid,issuer:always
+		keyUsage = digitalSignature,keyEncipherment
+		X509_TYPE_EASYRSA
 } # => create_x509_type_easyrsa()
 
-# Create x509-type/serverClient
-create_x509_type_serverClient() {
-	create_x509_type_easyrsa
-	cat << "SRVCLIFILECOMPLETE"
-extendedKeyUsage = serverAuth,clientAuth
-SRVCLIFILECOMPLETE
-} # => create_x509_type_serverClient()
-
-# Create x509-type/server
-create_x509_type_server() {
-	create_x509_type_easyrsa
-	cat << "SRVFILECOMPLETE"
-extendedKeyUsage = serverAuth
-SRVFILECOMPLETE
-} # => create_x509_type_server()
-
-# Create x509-type/client
-create_x509_type_client() {
-	create_x509_type_easyrsa
-	cat << "CLIFILECOMPLETE"
-extendedKeyUsage = clientAuth
-CLIFILECOMPLETE
-} # => create_x509_type_client()
-
 # Create vars.example - Not used
+# TODO
 create_vars_example() {
 	cat << "VARSEXFILECOMPLETE"
 VARSEXFILECOMPLETE
@@ -2349,42 +2353,43 @@ Your files are:
 # common signing backend
 sign_req() {
 	crt_type="$1"
-	req_in="$EASYRSA_PKI/reqs/$2.req"
-	crt_out="$EASYRSA_PKI/issued/$2.crt"
+	file_name_base="$2"
 
 	# Check argument sanity:
-	[ "$2" ] || user_error "\
+	[ "$file_name_base" ] || user_error "\
 Incorrect number of arguments provided to sign-req:
 expected 2, got $# (see command help for usage)"
 
-	# Check for preserve-dn
-	if [ "$3" ]; then
-		case "$3" in
-			preserve*) export EASYRSA_PRESERVE_DN=1 ;;
-			*)
-				warn "Ignoring unknown option '$3'"
-		esac
-	fi
+	req_in="$EASYRSA_PKI/reqs/$file_name_base.req"
+	crt_out="$EASYRSA_PKI/issued/$file_name_base.crt"
+	shift 2
 
-	# Cert type must exist under the EASYRSA_EXT_DIR
-	[ -e "$EASYRSA_EXT_DIR/$crt_type" ] || warn "\
-Missing X509-type '$crt_type'"
-	[ -e "$EASYRSA_EXT_DIR/COMMON" ] || warn "\
-Missing X509-type 'COMMON'"
+	# Check for preserve-dn
+	while [ "$1" ]; do
+		case "$1" in
+			preserve*)
+				export EASYRSA_PRESERVE_DN=1
+			;;
+			*)
+				warn "Ignoring unknown option '$1'"
+		esac
+		shift
+	done
 
 	# Cert type must NOT be COMMON
-	[ "$crt_type" != COMMON ] || user_error "\
+	[ "$crt_type" = COMMON ] && user_error "\
 Invalid certificate type: '$crt_type'"
 
 	# Request file must exist
 	[ -e "$req_in" ] || user_error "\
-No request found for the input: '$2'
-Expected to find the request at: $req_in"
+No request found for the input: '$file_name_base'
+Expected to find the request at:
+* $req_in"
 
 	# Certificate file must NOT exist
 	[ ! -e "$crt_out" ] || user_error "\
-Cannot sign this request for '$2'.
-Conflicting certificate already exists at:
+Cannot sign this request for '$file_name_base'.
+Conflicting certificate exists at:
 * $crt_out"
 
 	# Confirm input is a cert req
@@ -2393,7 +2398,7 @@ The certificate request file is not in a valid X509 format:
 * $req_in"
 
 	# Randomize Serial number
-	if [ "$EASYRSA_RAND_SN" != "no" ]; then
+	if [ "$EASYRSA_RAND_SN" != no ]; then
 		serial=""
 		check_serial=""
 		unset -v serial_is_unique
@@ -2454,9 +2459,81 @@ to the latest Easy-RSA release."
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
 			> "$conf_tmp" \
 			|| die "Writing SSL config to temp file failed"
+
 		# Use this SSL config for the rest of this function
 		EASYRSA_SSL_CONF="$conf_tmp"
+		verbose "sign_req: copy_extensions = copy"
 	fi
+
+	# Find or create x509-type file
+	if [ -f "$EASYRSA_EXT_DIR/$crt_type" ]; then
+		# Use the x509-types/$crt_type file
+		x509_type_file="$EASYRSA_EXT_DIR/$crt_type"
+	else
+		# Use a temp file
+		x509_type_tmp=""
+		easyrsa_mktemp x509_type_tmp || \
+			die "sign_req - easyrsa_mktemp x509_type_tmp"
+
+		create_x509_type "$crt_type" > "$x509_type_tmp"
+		x509_type_file="$x509_type_tmp"
+	fi
+
+	# Find or create x509 COMMON file
+	if [ -f "$EASYRSA_EXT_DIR/COMMON" ]; then
+		# Use the x509-types/COMMON file
+		x509_COMMON_file="$EASYRSA_EXT_DIR/COMMON"
+	else
+		# Use a temp file
+		x509_COMMON_tmp=""
+		easyrsa_mktemp x509_COMMON_tmp || \
+			die "sign_req - easyrsa_mktemp x509_COMMON_tmp"
+
+		create_x509_type COMMON > "$x509_COMMON_tmp"
+		x509_COMMON_file="$x509_type_tmp"
+	fi
+
+	# Support a dynamic CA path length when present:
+	unset -v basicConstraints
+	if [ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ]
+	then
+		# Print the last occurence of basicContraints in
+		# x509-types/ca
+		# If basicContraints is not defined then bail
+		# shellcheck disable=SC2016 # vars don't expand ''
+		awkscript='\
+/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
+END { if (length(bC) == 0 ) exit 1; print bC }'
+		basicConstraints="$(
+			awk "$awkscript" "$x509_type_file"
+			)" || die "\
+basicConstraints is not defined, cannot use 'pathlen'"
+		verbose "sign_req: Using basicConstraints pathlen"
+	fi
+
+	# Deprecated Netscape extension support
+	case "$EASYRSA_NS_SUPPORT" in
+		[yY][eE][sS])
+
+		# Netscape extension
+		case "$crt_type" in
+			serverClient)
+				ns_cert_type="nsCertType = serverClient" ;;
+			server)
+				ns_cert_type="nsCertType = server" ;;
+			client)
+				ns_cert_type="nsCertType = client" ;;
+			ca)
+				ns_cert_type="nsCertType = sslCA" ;;
+			*)
+				ns_cert_type="nsCertType = $crt_type"
+		esac
+		verbose "sign_req: Using $ns_cert_type"
+	;;
+	*)
+		# ok No NS support required
+		unset -v ns_cert_type
+	esac
 
 	# Generate the extensions file for this cert:
 	ext_tmp=""
@@ -2466,92 +2543,22 @@ to the latest Easy-RSA release."
 	# Begin output redirect
 	{
 		# Append $cert-type extensions
-		if [ -f "$EASYRSA_EXT_DIR/$crt_type" ]; then
-			cat "$EASYRSA_EXT_DIR/$crt_type"
-		else
-			# Create Easy-RSA base x509 type
-			case "$crt_type" in
-			ca)
-				create_x509_type_ca
-			;;
-			serverClient)
-				create_x509_type_serverClient
-			;;
-			server)
-				create_x509_type_server
-			;;
-			client)
-				create_x509_type_client
-			;;
-			*)
-				: # ok
-			esac
-		fi
-
-		# Append COMMON extensions
-		if [ -f "$EASYRSA_EXT_DIR/COMMON" ]; then
-			cat "$EASYRSA_EXT_DIR/COMMON"
-		else
-			create_x509_type_COMMON
-		fi
+		cat "$x509_COMMON_file"
+		cat "$x509_type_file"
 
 		# Support a dynamic CA path length when present:
-		if [ "$crt_type" = "ca" ] && [ "$EASYRSA_SUBCA_LEN" ]
-		then
-			# x509-types/ca is required
-			[ -f "$EASYRSA_EXT_DIR/$crt_type" ] || {
-				error_msg="Missing file: $EASYRSA_EXT_DIR/$crt_type"
-				return 1
-			}
-
-			# Print the last occurence of basicContraints in
-			# x509-types/ca
-			# If basicContraints is not defined then bail
-			# shellcheck disable=SC2016 # vars don't expand ''
-			awkscript='\
-/^[[:blank:]]*basicConstraints[[:blank:]]*=/ { bC=$0 }
-END { if (length(bC) == 0 ) exit 1; print bC }'
-			basicConstraints="$(
-				awk "$awkscript" "$EASYRSA_EXT_DIR/$crt_type"
-				)" || {
-					error_msg="\
-basicConstraints is not defined, cannot use 'pathlen'"
-					return 1
-					}
-
+		if [ "$basicConstraints" ]; then
 			print "$basicConstraints, pathlen:$EASYRSA_SUBCA_LEN"
-			unset -v basicConstraints
 		fi
 
 		# Deprecated Netscape extension support
-		case "$EASYRSA_NS_SUPPORT" in
-			[yY][eE][sS])
-
-			# Netscape extension
-			case "$crt_type" in
-				serverClient)
-					print "nsCertType = serverClient" ;;
-				server)
-					print "nsCertType = server" ;;
-				client)
-					print "nsCertType = client" ;;
-				ca)
-					print "nsCertType = sslCA" ;;
-				*)
-					error_msg="Unknown Netscape type: $crt_type"
-					return 1
-			esac
-
-			# Netscape comment
-			[ "$EASYRSA_NS_COMMENT" ] && \
-				print "nsComment = \"$EASYRSA_NS_COMMENT\""
-		;;
-		*)
-			: # ok No NS support required
-		esac
+		if [ "$ns_cert_type" ]; then
+			print "$ns_cert_type"
+			print "nsComment = \"$EASYRSA_NS_COMMENT\""
+		fi
 
 		# Add user SAN from --subject-alt-name
-		if [ "$user_san_true" ]; then
+		if [ "$EASYRSA_EXTRA_EXTS" ]; then
 			print "$EASYRSA_EXTRA_EXTS"
 		else
 			# or default server SAN
@@ -2568,16 +2575,13 @@ basicConstraints is not defined, cannot use 'pathlen'"
 					default_server_san "$req_in"
 				fi
 			fi
-
-			# Add user set EASYRSA_EXTRA_EXTS
-			[ -z "$EASYRSA_EXTRA_EXTS" ] || \
-				print "$EASYRSA_EXTRA_EXTS"
 		fi
 	} > "$ext_tmp" || die "\
 Error message: $error_msg
 
 Failed to create temp extension file (bad permissions?) at:
 * $ext_tmp"
+	verbose "sign_req: Generated extensions file OK"
 
 	# Set valid_period message
 	if [ "$EASYRSA_END_DATE" ]; then
@@ -2637,6 +2641,7 @@ $(display_dn req "$req_in")" # => confirm end
 		${EASYRSA_END_DATE:+ -enddate "$EASYRSA_END_DATE"} \
 			|| die "\
 Signing failed (openssl output above may have more detail)"
+	verbose "sign_req: signed cert '$file_name_base' OK"
 
 	mv "$crt_out_tmp" "$crt_out" || \
 		die "Failed to move temp-file to certificate."
@@ -2651,25 +2656,24 @@ Certificate created at:
 
 # Check serial in db
 check_serial_unique() {
-	serial="$1"
-	[ "$serial" ] || user_error "Serial number required!"
+	[ "$1" ] || user_error "Serial number required!"
 
 	[ "$2" = batch ] && internal_batch=1
 
-	unset -v unique_serial
+	unset -v unique_serial_true
 
 	# Check for openssl -status of serial number
 	# Always errors out - Do not capture error
 	# unset EASYRSA_SILENT_SSL to capure all output
 	check_serial="$(
 		unset -v EASYRSA_SILENT_SSL
-		easyrsa_openssl ca -status "$serial" 2>&1
+		easyrsa_openssl ca -status "$1" 2>&1
 		)" || :
 
 	# Check for duplicate serial in CA db
 	case "$check_serial" in
 		(*"not present in db"*)
-			unique_serial=1
+			unique_serial_true=1
 			verbose "check_serial_unique: unique_serial=true"
 		;;
 		*)
@@ -2680,7 +2684,7 @@ check_serial_unique() {
 	# In batch mode return result only
 	if [ "$internal_batch" ] || [ "$EASYRSA_BATCH" ]
 	then
-		if [ "$unique_serial" ]; then
+		if [ "$unique_serial_true" ]; then
 			return 0
 		else
 			return 1
@@ -6757,7 +6761,6 @@ while :; do
 		export EASYRSA_CP_EXT=1
 		;;
 	--subject-alt-name|--san)
-		user_san_true=1
 		export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS
 subjectAltName = $val"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2457,8 +2457,6 @@ check_serial_unique() {
 		: # ok
 	esac
 
-	[ "$2" = batch ] && internal_batch=1
-
 	unset -v unique_serial_true
 
 	# Check for openssl -status of serial number
@@ -2482,13 +2480,12 @@ check_serial_unique() {
 	esac
 
 	# In batch mode return result only
-	if [ "$internal_batch" ] || [ "$EASYRSA_BATCH" ]
-	then
+	if [ "$2" = batch ] || [ "$EASYRSA_BATCH" ]; then
 		if [ "$unique_serial_true" ]; then
-			unset -v unique_serial_true internal_batch
+			unset -v unique_serial_true
 			return 0
 		else
-			unset -v unique_serial_true internal_batch
+			unset -v unique_serial_true
 			return 1
 		fi
 	fi

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2449,6 +2449,13 @@ Certificate created at:
 # Check serial in db
 check_serial_unique() {
 	[ "$1" ] || user_error "Serial number required!"
+	case "$1" in
+	(*[!1234567890abcdef]*)
+		user_error "Invalid serial number: '$1'"
+	;;
+	*)
+		: # ok
+	esac
 
 	[ "$2" = batch ] && internal_batch=1
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2282,7 +2282,7 @@ Writing 'copy_exts' to SSL config temp-file failed"
 		create_x509_type COMMON > "$x509_COMMON_tmp" || \
 			die "sign_req - create_x509_type COMMON"
 
-		x509_COMMON_file="$x509_type_tmp"
+		x509_COMMON_file="$x509_COMMON_tmp"
 	fi
 
 	# Support a dynamic CA path length when present:

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1522,219 +1522,6 @@ install_data_to_pki - Missing: '$x509_types_dir'"
 	verbose "install_data_to_pki: $context - COMPLETED"
 } # => install_data_to_pki ()
 
-# Create X509-type files
-create_x509_type() {
-	x509_type="$1"
-	[ "$x509_type" ] || \
-		die "create_x509_type - type undefined"
-
-	case "$x509_type" in
-	COMMON)
-		cat <<- "X509_TYPE_COMMON"
-		X509_TYPE_COMMON
-	;;
-	serverClient)
-		create_x509_type_easyrsa
-		cat <<- "X509_TYPE_SERV_CLI"
-		extendedKeyUsage = serverAuth,clientAuth
-		X509_TYPE_SERV_CLI
-	;;
-	server)
-		create_x509_type_easyrsa
-		cat <<- "X509_TYPE_SERV"
-		extendedKeyUsage = serverAuth
-		X509_TYPE_SERV
-	;;
-	client)
-		create_x509_type_easyrsa
-		cat <<- "X509_TYPE_CLI"
-		extendedKeyUsage = clientAuth
-		X509_TYPE_CLI
-	;;
-	ca)
-		cat <<- "X509_TYPE_CA"
-		basicConstraints = CA:TRUE
-		subjectKeyIdentifier = hash
-		authorityKeyIdentifier = keyid:always,issuer:always
-		keyUsage = cRLSign, keyCertSign
-		X509_TYPE_CA
-	;;
-	*)
-		# Unknown type: User MUST supply the X509 file
-		die "Unknown X509 type: $x509_type"
-	esac
-} # => create_x509_type()
-
-# Create x509-type/easyrsa
-# This could be COMMON but not is not suitable for a CA
-create_x509_type_easyrsa() {
-	cat <<- "X509_TYPE_EASYRSA"
-		basicConstraints = CA:FALSE
-		subjectKeyIdentifier = hash
-		authorityKeyIdentifier = keyid,issuer:always
-		keyUsage = digitalSignature,keyEncipherment
-		X509_TYPE_EASYRSA
-} # => create_x509_type_easyrsa()
-
-# Create vars.example - Not used
-# TODO
-create_vars_example() {
-	cat << "VARSEXFILECOMPLETE"
-VARSEXFILECOMPLETE
-} # => create_vars_example()
-
-# Create openssl-easyrsa.cnf
-create_openssl_easyrsa_cnf() {
-	cat << "SSLCONFCOMPLETE"
-# For use with Easy-RSA 3.0+ and OpenSSL or LibreSSL
-
-####################################################################
-[ ca ]
-default_ca	= CA_default		# The default ca section
-
-####################################################################
-[ CA_default ]
-
-dir		= $ENV::EASYRSA_PKI	# Where everything is kept
-certs		= $dir			# Where the issued certs are kept
-crl_dir		= $dir			# Where the issued crl are kept
-database	= $dir/index.txt	# database index file.
-new_certs_dir	= $dir/certs_by_serial	# default place for new certs.
-
-certificate	= $dir/ca.crt		# The CA certificate
-serial		= $dir/serial		# The current serial number
-crl		= $dir/crl.pem		# The current CRL
-private_key	= $dir/private/ca.key	# The private key
-RANDFILE	= $dir/.rand		# private random number file
-
-x509_extensions	= basic_exts		# The extensions to add to the cert
-
-# A placeholder to handle the --copy-ext feature:
-#%COPY_EXTS%	# Do NOT remove or change this line as --copy-ext support requires it
-
-# This allows a V2 CRL. Ancient browsers don't like it, but anything Easy-RSA
-# is designed for will. In return, we get the Issuer attached to CRLs.
-crl_extensions	= crl_ext
-
-default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
-default_crl_days	= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
-default_md	= $ENV::EASYRSA_DIGEST		# use public key default MD
-preserve	= no			# keep passed DN ordering
-
-# This allows to renew certificates which have not been revoked
-unique_subject	= no
-
-# A few different ways of specifying how similar the request should look
-# For type CA, the listed attributes must be the same, and the optional
-# and supplied fields are just that :-)
-policy		= policy_anything
-
-# For the 'anything' policy, which defines allowed DN fields
-[ policy_anything ]
-countryName		= optional
-stateOrProvinceName	= optional
-localityName		= optional
-organizationName	= optional
-organizationalUnitName	= optional
-commonName		= supplied
-emailAddress		= optional
-serialNumber	= optional
-
-####################################################################
-# Easy-RSA request handling
-# We key off $DN_MODE to determine how to format the DN
-[ req ]
-default_bits		= $ENV::EASYRSA_KEY_SIZE
-default_keyfile	= privkey.pem
-default_md		= $ENV::EASYRSA_DIGEST
-distinguished_name	= $ENV::EASYRSA_DN
-x509_extensions		= easyrsa_ca	# The extensions to add to the self signed cert
-
-# A placeholder to handle the $EXTRA_EXTS feature:
-#%EXTRA_EXTS%	# Do NOT remove or change this line as $EXTRA_EXTS support requires it
-
-####################################################################
-# Easy-RSA DN (Subject) handling
-
-# Easy-RSA DN for cn_only support:
-[ cn_only ]
-commonName		= Common Name (eg: your user, host, or server name)
-commonName_max		= 64
-commonName_default	= $ENV::EASYRSA_REQ_CN
-
-# Easy-RSA DN for org support:
-[ org ]
-countryName			= Country Name (2 letter code)
-countryName_default		= $ENV::EASYRSA_REQ_COUNTRY
-countryName_min			= 2
-countryName_max			= 2
-
-stateOrProvinceName		= State or Province Name (full name)
-stateOrProvinceName_default	= $ENV::EASYRSA_REQ_PROVINCE
-
-localityName			= Locality Name (eg, city)
-localityName_default		= $ENV::EASYRSA_REQ_CITY
-
-0.organizationName		= Organization Name (eg, company)
-0.organizationName_default	= $ENV::EASYRSA_REQ_ORG
-
-organizationalUnitName		= Organizational Unit Name (eg, section)
-organizationalUnitName_default	= $ENV::EASYRSA_REQ_OU
-
-commonName			= Common Name (eg: your user, host, or server name)
-commonName_max			= 64
-commonName_default		= $ENV::EASYRSA_REQ_CN
-
-emailAddress			= Email Address
-emailAddress_default		= $ENV::EASYRSA_REQ_EMAIL
-emailAddress_max		= 64
-
-serialNumber		= Serial-number (eg, device serial-number)
-serialNumber_default	= $ENV::EASYRSA_REQ_SERIAL
-
-####################################################################
-# Easy-RSA cert extension handling
-
-# This section is effectively unused as the main script sets extensions
-# dynamically. This core section is left to support the odd usecase where
-# a user calls openssl directly.
-[ basic_exts ]
-basicConstraints	= CA:FALSE
-subjectKeyIdentifier	= hash
-authorityKeyIdentifier	= keyid,issuer:always
-
-# The Easy-RSA CA extensions
-[ easyrsa_ca ]
-
-# PKIX recommendations:
-
-subjectKeyIdentifier=hash
-authorityKeyIdentifier=keyid:always,issuer:always
-
-# This could be marked critical, but it's nice to support reading by any
-# broken clients who attempt to do so.
-basicConstraints = CA:true
-
-# Limit key usage to CA tasks. If you really want to use the generated pair as
-# a self-signed cert, comment this out.
-keyUsage = cRLSign, keyCertSign
-
-# nsCertType omitted by default. Let's try to let the deprecated stuff die.
-# nsCertType = sslCA
-
-# A placeholder to handle the $X509_TYPES and CA extra extensions $EXTRA_EXTS:
-#%CA_X509_TYPES_EXTRA_EXTS%	# Do NOT remove or change this line as $X509_TYPES and EXTRA_EXTS demands it
-
-# CRL extensions.
-[ crl_ext ]
-
-# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
-
-# issuerAltName=issuer:copy
-authorityKeyIdentifier=keyid:always,issuer:always'
-SSLCONFCOMPLETE
-} # => create_openssl_easyrsa_cnf()
-
 # Disable terminal echo, if possible, otherwise warn
 hide_read_pass()
 {
@@ -5940,6 +5727,381 @@ force_set_var() {
 	unset -v "$1" || die "force_set_var - unset"
 	set_var "$1" "$2" || die "force_set_var - set_var"
 } # => force_set_var()
+
+
+
+############################################################################
+#
+# Create X509-type files
+create_x509_type() {
+	case "$1" in
+	COMMON)
+		cat <<- "X509_TYPE_COMMON"
+		X509_TYPE_COMMON
+	;;
+	serverClient)
+		create_x509_type_easyrsa
+		cat <<- "X509_TYPE_SERV_CLI"
+		extendedKeyUsage = serverAuth,clientAuth
+		X509_TYPE_SERV_CLI
+	;;
+	server)
+		create_x509_type_easyrsa
+		cat <<- "X509_TYPE_SERV"
+		extendedKeyUsage = serverAuth
+		X509_TYPE_SERV
+	;;
+	client)
+		create_x509_type_easyrsa
+		cat <<- "X509_TYPE_CLI"
+		extendedKeyUsage = clientAuth
+		X509_TYPE_CLI
+	;;
+	ca)
+		cat <<- "X509_TYPE_CA"
+		basicConstraints = CA:TRUE
+		subjectKeyIdentifier = hash
+		authorityKeyIdentifier = keyid:always,issuer:always
+		keyUsage = cRLSign, keyCertSign
+		X509_TYPE_CA
+	;;
+	*)
+		# Unknown type: User MUST supply the X509 file
+		die "create_x509_type - Unknown X509 type: '$1'"
+	esac
+} # => create_x509_type()
+
+# Create x509-type/easyrsa
+# This could be COMMON but not is not suitable for a CA
+create_x509_type_easyrsa() {
+	cat <<- "X509_TYPE_EASYRSA"
+		basicConstraints = CA:FALSE
+		subjectKeyIdentifier = hash
+		authorityKeyIdentifier = keyid,issuer:always
+		keyUsage = digitalSignature,keyEncipherment
+		X509_TYPE_EASYRSA
+} # => create_x509_type_easyrsa()
+
+# Create vars.example - Minimum settings only
+create_vars_example() {
+	cat << "VARS_EXAMPLE"
+# Easy-RSA 3 parameter settings
+
+# NOTE: If you installed Easy-RSA from your package manager, do not edit
+# this file in place -- instead, you should copy the entire easy-rsa directory
+# to another location so future upgrades do not wipe out your changes.
+
+# HOW TO USE THIS FILE
+#
+# vars.example contains built-in examples to Easy-RSA settings. You MUST name
+# this file "vars" if you want it to be used as a configuration file. If you
+# do not, it WILL NOT be automatically read when you call easyrsa commands.
+#
+# It is not necessary to use this config file unless you wish to change
+# operational defaults. These defaults should be fine for many uses without
+# the need to copy and edit the "vars" file.
+#
+# All of the editable settings are shown commented and start with the command
+# "set_var" -- this means any set_var command that is uncommented has been
+# modified by the user. If you are happy with a default, there is no need to
+# define the value to its default.
+
+# NOTES FOR WINDOWS USERS
+#
+# Paths for Windows  *MUST* use forward slashes, or optionally double-escaped
+# backslashes (single forward slashes are recommended.) This means your path
+# to the openssl binary might look like this:
+# "C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
+
+# A little housekeeping: DO NOT EDIT THIS SECTION
+#
+# Easy-RSA 3.x does not source into the environment directly.
+# Complain if a user tries to do this:
+if [ -z "$EASYRSA_CALLER" ]; then
+	echo "You appear to be sourcing an Easy-RSA *vars* file. This is" >&2
+	echo "no longer necessary and is disallowed. See the section called" >&2
+	echo "*How to use this file* near the top comments for more details." >&2
+	return 1
+fi
+
+# DO YOUR EDITS BELOW THIS POINT
+
+# This variable is used as the base location of configuration files needed by
+# easyrsa.  More specific variables for specific files (eg: EASYRSA_SSL_CONF)
+# may override this default.
+#
+# The default value of this variable is the location of the easyrsa script
+# itself, which is also where the configuration files are located in the
+# easy-rsa tree.
+#
+#set_var EASYRSA	"${0%/*}"
+
+# If your OpenSSL command is not in the system PATH, you will need to define
+# the path here. Normally this means a full path to the executable, otherwise
+# you could have left it undefined here and the shown default would be used.
+#
+# Windows users, remember to use paths with forward-slashes (or escaped
+# back-slashes.) Windows users should declare the full path to the openssl
+# binary here if it is not in their system PATH.
+#
+#set_var EASYRSA_OPENSSL	"openssl"
+#
+# This sample is in Windows syntax -- edit it for your path if not using PATH:
+#set_var EASYRSA_OPENSSL	"C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
+
+# Edit this variable to point to your soon-to-be-created key directory.
+# By default, this will be "$PWD/pki" (ie: the "pki" subdirectory of the
+# directory you are currently in).
+#
+# WARNING: init-pki will do a rm -rf on this directory so make sure you define
+# it correctly!  Interactive mode will prompt before acting.
+#
+#set_var EASYRSA_PKI		"$PWD/pki"
+
+# Define directory for temporary subdirectories.
+#
+#set_var EASYRSA_TEMP_DIR	"$EASYRSA_PKI"
+
+# Define X509 DN mode.
+#
+# This is used to adjust which elements are included in the Subject field
+# as the DN ("Distinguished Name"). Note that in 'cn_only' mode the
+# Organizational fields, listed further below, are not used.
+#
+# Choices are:
+#   cn_only  - Use just a commonName value.
+#   org      - Use the "traditional" format:
+#              Country/Province/City/Org/Org.Unit/email/commonName
+#
+#set_var EASYRSA_DN	"cn_only"
+
+# Organizational fields (used with "org" mode and ignored in "cn_only" mode).
+# These are the default values for fields which will be placed in the
+# certificate.  Do not leave any of these fields blank, although interactively
+# you may omit any specific field by typing the "." symbol (not valid for
+# email).
+#
+# NOTE: The following characters are not supported
+#       in these "Organizational fields" by Easy-RSA:
+#       back-tick (`)
+#
+#set_var EASYRSA_REQ_COUNTRY	"US"
+#set_var EASYRSA_REQ_PROVINCE	"California"
+#set_var EASYRSA_REQ_CITY	"San Francisco"
+#set_var EASYRSA_REQ_ORG	"Copyleft Certificate Co"
+#set_var EASYRSA_REQ_EMAIL	"me@example.net"
+#set_var EASYRSA_REQ_OU		"My Organizational Unit"
+
+# Preserve the Distinguished Name field order
+# of the certificate signing request
+# *Only* effective in --dn-mode=org
+#
+#set_var EASYRSA_PRESERVE_DN	1
+
+# Set no password mode - This will create the entire PKI without passwords.
+# This can be better managed by choosing which entity private keys should be
+# encrypted with the following command line options:
+# Global option '--no-pass' or command option 'nopass'.
+#
+#set_var EASYRSA_NO_PASS	1
+
+# Choose a size in bits for your keypairs. The recommended value is 2048.
+# Using 2048-bit keys is considered more than sufficient for many years into
+# the future. Larger keysizes will slow down TLS negotiation and make key/DH
+# param generation take much longer. Values up to 4096 should be accepted by
+# most software. Only used when the crypto alg is rsa, see below.
+#
+#set_var EASYRSA_KEY_SIZE	2048
+
+# The default crypto mode is rsa; ec can enable elliptic curve support.
+# Note that not all software supports ECC, so use care when enabling it.
+# Choices for crypto alg are: (each in lower-case)
+#  * rsa
+#  * ec
+#  * ed
+#
+#set_var EASYRSA_ALGO		rsa
+
+# Define the named curve, used in ec & ed modes:
+#
+#set_var EASYRSA_CURVE		secp384r1
+
+# In how many days should the root CA key expire?
+#
+#set_var EASYRSA_CA_EXPIRE	3650
+
+# In how many days should certificates expire?
+#
+#set_var EASYRSA_CERT_EXPIRE	825
+
+# How many days until the next CRL publish date?  Note that the CRL can still
+# be parsed after this timeframe passes. It is only used for an expected next
+# publication date.
+#
+#set_var EASYRSA_CRL_DAYS	180
+
+# Random serial numbers by default.
+# Set to 'no' for the old incremental serial numbers.
+#
+#set_var EASYRSA_RAND_SN	"yes"
+
+# Cut-off window for checking expiring certificates.
+#
+#set_var EASYRSA_PRE_EXPIRY_WINDOW	90
+VARS_EXAMPLE
+} # => create_vars_example()
+
+# Create openssl-easyrsa.cnf
+create_openssl_easyrsa_cnf() {
+	cat << "SSL_CONFIG"
+# For use with Easy-RSA 3.0+ and OpenSSL or LibreSSL
+
+####################################################################
+[ ca ]
+default_ca	= CA_default		# The default ca section
+
+####################################################################
+[ CA_default ]
+
+dir		= $ENV::EASYRSA_PKI	# Where everything is kept
+certs		= $dir			# Where the issued certs are kept
+crl_dir		= $dir			# Where the issued crl are kept
+database	= $dir/index.txt	# database index file.
+new_certs_dir	= $dir/certs_by_serial	# default place for new certs.
+
+certificate	= $dir/ca.crt		# The CA certificate
+serial		= $dir/serial		# The current serial number
+crl		= $dir/crl.pem		# The current CRL
+private_key	= $dir/private/ca.key	# The private key
+RANDFILE	= $dir/.rand		# private random number file
+
+x509_extensions	= basic_exts		# The extensions to add to the cert
+
+# A placeholder to handle the --copy-ext feature:
+#%COPY_EXTS%	# Do NOT remove or change this line as --copy-ext support requires it
+
+# This allows a V2 CRL. Ancient browsers don't like it, but anything Easy-RSA
+# is designed for will. In return, we get the Issuer attached to CRLs.
+crl_extensions	= crl_ext
+
+default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
+default_crl_days	= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
+default_md	= $ENV::EASYRSA_DIGEST		# use public key default MD
+preserve	= no			# keep passed DN ordering
+
+# This allows to renew certificates which have not been revoked
+unique_subject	= no
+
+# A few different ways of specifying how similar the request should look
+# For type CA, the listed attributes must be the same, and the optional
+# and supplied fields are just that :-)
+policy		= policy_anything
+
+# For the 'anything' policy, which defines allowed DN fields
+[ policy_anything ]
+countryName		= optional
+stateOrProvinceName	= optional
+localityName		= optional
+organizationName	= optional
+organizationalUnitName	= optional
+commonName		= supplied
+emailAddress		= optional
+serialNumber	= optional
+
+####################################################################
+# Easy-RSA request handling
+# We key off $DN_MODE to determine how to format the DN
+[ req ]
+default_bits		= $ENV::EASYRSA_KEY_SIZE
+default_keyfile	= privkey.pem
+default_md		= $ENV::EASYRSA_DIGEST
+distinguished_name	= $ENV::EASYRSA_DN
+x509_extensions		= easyrsa_ca	# The extensions to add to the self signed cert
+
+# A placeholder to handle the $EXTRA_EXTS feature:
+#%EXTRA_EXTS%	# Do NOT remove or change this line as $EXTRA_EXTS support requires it
+
+####################################################################
+# Easy-RSA DN (Subject) handling
+
+# Easy-RSA DN for cn_only support:
+[ cn_only ]
+commonName		= Common Name (eg: your user, host, or server name)
+commonName_max		= 64
+commonName_default	= $ENV::EASYRSA_REQ_CN
+
+# Easy-RSA DN for org support:
+[ org ]
+countryName			= Country Name (2 letter code)
+countryName_default		= $ENV::EASYRSA_REQ_COUNTRY
+countryName_min			= 2
+countryName_max			= 2
+
+stateOrProvinceName		= State or Province Name (full name)
+stateOrProvinceName_default	= $ENV::EASYRSA_REQ_PROVINCE
+
+localityName			= Locality Name (eg, city)
+localityName_default		= $ENV::EASYRSA_REQ_CITY
+
+0.organizationName		= Organization Name (eg, company)
+0.organizationName_default	= $ENV::EASYRSA_REQ_ORG
+
+organizationalUnitName		= Organizational Unit Name (eg, section)
+organizationalUnitName_default	= $ENV::EASYRSA_REQ_OU
+
+commonName			= Common Name (eg: your user, host, or server name)
+commonName_max			= 64
+commonName_default		= $ENV::EASYRSA_REQ_CN
+
+emailAddress			= Email Address
+emailAddress_default		= $ENV::EASYRSA_REQ_EMAIL
+emailAddress_max		= 64
+
+serialNumber		= Serial-number (eg, device serial-number)
+serialNumber_default	= $ENV::EASYRSA_REQ_SERIAL
+
+####################################################################
+# Easy-RSA cert extension handling
+
+# This section is effectively unused as the main script sets extensions
+# dynamically. This core section is left to support the odd usecase where
+# a user calls openssl directly.
+[ basic_exts ]
+basicConstraints	= CA:FALSE
+subjectKeyIdentifier	= hash
+authorityKeyIdentifier	= keyid,issuer:always
+
+# The Easy-RSA CA extensions
+[ easyrsa_ca ]
+
+# PKIX recommendations:
+
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer:always
+
+# This could be marked critical, but it's nice to support reading by any
+# broken clients who attempt to do so.
+basicConstraints = CA:true
+
+# Limit key usage to CA tasks. If you really want to use the generated pair as
+# a self-signed cert, comment this out.
+keyUsage = cRLSign, keyCertSign
+
+# nsCertType omitted by default. Let's try to let the deprecated stuff die.
+# nsCertType = sslCA
+
+# A placeholder to handle the $X509_TYPES and CA extra extensions $EXTRA_EXTS:
+#%CA_X509_TYPES_EXTRA_EXTS%	# Do NOT remove or change this line as $X509_TYPES and EXTRA_EXTS demands it
+
+# CRL extensions.
+[ crl_ext ]
+
+# Only issuerAltName and authorityKeyIdentifier make any sense in a CRL.
+
+# issuerAltName=issuer:copy
+authorityKeyIdentifier=keyid:always,issuer:always'
+SSL_CONFIG
+} # => create_openssl_easyrsa_cnf()
 
 
 


### PR DESCRIPTION
Move extension data preparation to before printing extension temp-file.
This allows the { extensions output command group } to always complete,
without error.

Consolidate create_x509_type_*() functions in one single function.
create_x509_type_easyrsa() remains as a separate function.
This file does not exist in x509-types directory. It is similar to the
COMMON x509-type; The details are the common extensions shared by x509
types: serverClient, server and client. Not suitable for x509-type ca.