### PR TITLE
Simplify run-once control for exanding conf files

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1786,9 +1786,9 @@ Raw CA mode
 	fi
 
 	# Assign tmp-file for config
-	conf_tmp=""
-	easyrsa_mktemp conf_tmp || \
-		die "build_ca - easyrsa_mktemp conf_tmp"
+	raw_ssl_cnf_tmp=""
+	easyrsa_mktemp raw_ssl_cnf_tmp || \
+		die "build_ca - easyrsa_mktemp raw_ssl_cnf_tmp"
 
 	# Assign awkscript to insert EASYRSA_EXTRA_EXTS
 	# shellcheck disable=SC2016 # vars don't expand in ''
@@ -1819,12 +1819,12 @@ Raw CA mode
 			print "$EASYRSA_EXTRA_EXTS"
 
 	} | awk "$awkscript" "$EASYRSA_SSL_CONF" \
-			> "$conf_tmp" || \
+			> "$raw_ssl_cnf_tmp" || \
 			die "Copying X509_TYPES to config file failed"
 	verbose "build-ca: insert x509 and extensions OK"
 
 	# Use this new SSL config for the rest of this function
-	EASYRSA_SSL_CONF="$conf_tmp"
+	EASYRSA_SSL_CONF="$raw_ssl_cnf_tmp"
 
 	# Generate CA Key
 	if [ "$EASYRSA_RAW_CA" ]; then
@@ -2100,18 +2100,18 @@ $EASYRSA_EXTRA_EXTS"
  {print}
 }'
 		# Assign temp-file for confg
-		conf_tmp=""
-		easyrsa_mktemp conf_tmp || \
-			die "gen_req - easyrsa_mktemp conf_tmp"
+		raw_ssl_cnf_tmp=""
+		easyrsa_mktemp raw_ssl_cnf_tmp || \
+			die "gen_req - easyrsa_mktemp raw_ssl_cnf_tmp"
 
 		# Insert $extra_exts @ %EXTRA_EXTS% in SSL Config
 		print "$extra_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
-			> "$conf_tmp" || \
+			> "$raw_ssl_cnf_tmp" || \
 				die "Writing SSL config to temp file failed"
 
 		# Use this SSL config for the rest of this function
-		EASYRSA_SSL_CONF="$conf_tmp"
+		EASYRSA_SSL_CONF="$raw_ssl_cnf_tmp"
 	fi
 
 	# Name temp files
@@ -2272,17 +2272,17 @@ to the latest Easy-RSA release."
  {print}
 }'
 		# Assign temp-file for confg
-		conf_tmp=""
-		easyrsa_mktemp conf_tmp || \
-			die "sign_req - easyrsa_mktemp conf_tmp"
+		raw_ssl_cnf_tmp=""
+		easyrsa_mktemp raw_ssl_cnf_tmp || \
+			die "sign_req - easyrsa_mktemp raw_ssl_cnf_tmp"
 
 		print "$copy_exts" | \
 			awk "$awkscript" "$EASYRSA_SSL_CONF" \
-				> "$conf_tmp" || die "\
+				> "$raw_ssl_cnf_tmp" || die "\
 Writing 'copy_exts' to SSL config temp-file failed"
 
 		# Use this SSL config for the rest of this function
-		EASYRSA_SSL_CONF="$conf_tmp"
+		EASYRSA_SSL_CONF="$raw_ssl_cnf_tmp"
 		verbose "sign_req: Using '$copy_exts'"
 	fi
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -941,9 +941,9 @@ escape_hazard() {
 	working_safe_org_conf=1
 
 	# Assign temp-file
-	vars_org_tmp=""
-	easyrsa_mktemp vars_org_tmp || die \
-		"escape_hazard - easyrsa_mktemp vars_org_tmp"
+	escape_hazard_tmp=""
+	easyrsa_mktemp escape_hazard_tmp || die \
+		"escape_hazard - easyrsa_mktemp escape_hazard_tmp"
 
 	# write org fields to org temp-file and escape '&' and '$'
 	print "\
@@ -956,17 +956,17 @@ export EASYRSA_REQ_EMAIL=\"$EASYRSA_REQ_EMAIL\"
 export EASYRSA_REQ_SERIAL=\"$EASYRSA_REQ_SERIAL\"\
 " | sed -e s\`'\&'\`'\\\&'\`g \
 		-e s\`'\$'\`'\\\$'\`g \
-			> "$vars_org_tmp" || die "\
+			> "$escape_hazard_tmp" || die "\
 escape_hazard - Failed to write temp-file"
 
 	# Reload fields from fully escaped temp-file
 	# shellcheck disable=SC1090 # can't follow ...
-	(. "$vars_org_tmp") || die "\
+	(. "$escape_hazard_tmp") || die "\
 escape_hazard - Failed to source temp-file"
 
 	verbose "escape_hazard: COMPLETED"
 	# shellcheck disable=SC1090 # can't follow ...
-	. "$vars_org_tmp"
+	. "$escape_hazard_tmp"
 } # => escape_hazard()
 
 # Replace environment variable names with current value

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -907,7 +907,28 @@ make_safe_ssl: NEW SSL cnf file: $easyrsa_safe_ssl_conf"
 } # => make_safe_ssl_copy()
 
 # Escape hazardous characters
+# Auto-escape hazardous characters:
+# '&' - Workaround 'sed' behavior
+# '$' - Workaround 'easyrsa' based limitation
+# This is required for all SSL libs, otherwise,
+# there are unacceptable differences in behavior
 escape_hazard() {
+	# Run once
+	if [ "$EASYRSA_FORCE_SAFE_SSL" ]; then
+		# Always run
+		verbose "escape_hazard: FORCED"
+	elif [ "$EASYRSA_NO_SAFE_SSL" ]; then
+		# Never run
+		verbose "escape_hazard: DENIED"
+		return
+	elif [ "$working_safe_org_conf" ]; then
+		verbose "escape_hazard: IGNORED"
+		return
+	else
+		# set Run once
+		working_safe_org_conf=1
+	fi
+
 	# Assign temp file
 	easyrsa_vars_org=""
 	easyrsa_mktemp easyrsa_vars_org || die \
@@ -931,6 +952,8 @@ escape_hazard - Failed to write temp-file"
 	# shellcheck disable=SC1090 # can't follow ...
 	(. "$easyrsa_vars_org") || die "\
 escape_hazard - Failed to source temp-file"
+
+	verbose "escape_hazard: COMPLETED"
 	# shellcheck disable=SC1090 # can't follow ...
 	. "$easyrsa_vars_org"
 } # => escape_hazard()
@@ -938,8 +961,31 @@ escape_hazard - Failed to source temp-file"
 # Replace environment variable names with current value
 # and write to temp-file or return error from sed
 easyrsa_rewrite_ssl_config () {
+	if [ "$EASYRSA_FORCE_SAFE_SSL" ]; then
+		# Always run
+		verbose "easyrsa_rewrite_ssl_config: FORCED"
+	elif [ "$EASYRSA_NO_SAFE_SSL" ]; then
+		# Never run
+		verbose "easyrsa_rewrite_ssl_config: DENIED"
+		return
+	elif [ "$working_safe_ssl_conf" ]; then
+		# Has run once
+		verbose "easyrsa_rewrite_ssl_config: IGNORED"
+		return
+	else
+		# set Run once
+		working_safe_ssl_conf=1
+	fi
+
+	# Assign easyrsa_safe_ssl_conf temp-file
+	easyrsa_safe_ssl_conf=""
+	easyrsa_mktemp easyrsa_safe_ssl_conf || die "\
+easyrsa_rewrite_ssl_config - \
+easyrsa_mktemp easyrsa_safe_ssl_conf"
+
+	# Rewrite
 	# shellcheck disable=SC2016 # No expansion inside ''
-	sed \
+	if sed \
 \
 -e s\`'$dir'\`\
 \""$EASYRSA_PKI"\"\`g \
@@ -987,6 +1033,11 @@ easyrsa_rewrite_ssl_config () {
 \""$EASYRSA_REQ_SERIAL"\"\`g \
 \
 	"$EASYRSA_SSL_CONF" > "$easyrsa_safe_ssl_conf"
+	then
+		verbose "easyrsa_rewrite_ssl_config: COMPLETED"
+	else
+		return 1
+	fi
 } # => easyrsa_rewrite_ssl_config()
 
 # Easy-RSA meta-wrapper for SSL
@@ -1014,57 +1065,16 @@ easyrsa_openssl() {
 		has_config=1
 	fi
 
-	# Make LibreSSL safe config file from OpenSSL config file
-	# $require_safe_ssl_conf is ALWAYS set by verify_ssl_lib()
-	# Can be over-ruled for OpenSSL by option --no-safe-ssl
-	if [ "$require_safe_ssl_conf" ] || \
-		[ "$EASYRSA_FORCE_SAFE_SSL" ]
-	then
+	# Auto-escape hazardous characters
+	escape_hazard || \
+		die "easyrsa_openssl - escape_hazard failed"
 
-		# Only create a new safe config,
-		# if it has not been done before.
-		# EASYRSA_FORCE_SAFE_SSL will always over-ride
-		if  [ -z "$EASYRSA_FORCE_SAFE_SSL" ] && \
-			[ "$working_safe_ssl_conf" ]
-		then
-			# ok - This has been done before
-			# Set SAFE SSL conf to working SAFE SSL conf
-			easyrsa_safe_ssl_conf="$working_safe_ssl_conf"
-			verbose "\
-easyrsa_openssl: escape_hazard SKIPPED"
-			verbose "\
-easyrsa_openssl: easyrsa_rewrite_ssl_config SKIPPED"
-		else
-			# Auto-escape hazardous characters:
-			# '&' - Workaround 'sed' behavior
-			# '$' - Workaround 'easyrsa' based limitation
-			# This is required for all SSL libs, otherwise,
-			# there are unacceptable differences in behavior
-			escape_hazard || \
-				die "easyrsa_openssl - escape_hazard failed"
-			verbose "\
-easyrsa_openssl: escape_hazard COMPLETED"
+	# Rewrite SSL config
+	easyrsa_rewrite_ssl_config || \
+		die "easyrsa_openssl - easyrsa_rewrite_ssl_config failed"
 
-			# Assign easyrsa_safe_ssl_conf temp-file
-			easyrsa_safe_ssl_conf=""
-			easyrsa_mktemp easyrsa_safe_ssl_conf || die "\
-easyrsa_openssl - easyrsa_mktemp easyrsa_safe_ssl_conf"
-
-			# Write a safe SSL config temp-file
-			if easyrsa_rewrite_ssl_config; then
-				verbose "\
-easyrsa_openssl: easyrsa_rewrite_ssl_config COMPLETED"
-				# Save the the safe conf file-name
-				working_safe_ssl_conf="$easyrsa_safe_ssl_conf"
-				verbose "\
-easyrsa_openssl: NEW SAFE SSL config: $easyrsa_safe_ssl_conf"
-			else
-				die "\
-easyrsa_openssl - easyrsa_rewrite_ssl_config"
-			fi
-		fi
-
-	else
+	# Support --no-safe-ssl
+	if [ "$EASYRSA_NO_SAFE_SSL" ]; then
 		# Assign safe temp file as Original openssl-easyrsa.conf
 		easyrsa_safe_ssl_conf="$EASYRSA_SSL_CONF"
 		verbose "easyrsa_openssl: No SAFE SSL config"
@@ -1789,6 +1799,7 @@ Raw CA mode
 	} | awk "$awkscript" "$EASYRSA_SSL_CONF" \
 			> "$conf_tmp" || \
 			die "Copying X509_TYPES to config file failed"
+	verbose "build-ca: insert x509 and extensions OK"
 
 	# Use this new SSL config for the rest of this function
 	EASYRSA_SSL_CONF="$conf_tmp"
@@ -6751,7 +6762,7 @@ detect_host
 unset -v \
 	verify_ssl_lib_ok \
 	secured_session \
-	working_safe_ssl_conf \
+	working_safe_ssl_conf working_safe_org_conf \
 	alias_days \
 	prohibit_no_pass \
 	found_vars no_new_vars user_vars_true \

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -897,8 +897,8 @@ Temporary session not preserved."
 
 # Make a copy safe SSL config file
 make_safe_ssl() {
-	EASYRSA_FORCE_SAFE_SSL=1
 	easyrsa_openssl makesafeconf
+
 	notice "\
 Safe SSL config file created at:
 * $EASYRSA_SAFE_CONF"
@@ -913,8 +913,9 @@ make_safe_ssl: NEW SSL cnf file: $safe_ssl_cnf_tmp"
 # This is required for all SSL libs, otherwise,
 # there are unacceptable differences in behavior
 escape_hazard() {
-	# Run once
-	if [ "$EASYRSA_FORCE_SAFE_SSL" ]; then
+	if [ "$EASYRSA_FORCE_SAFE_SSL" ] || \
+		[ "$makesafeconf" ]
+	then
 		# Always run
 		verbose "escape_hazard: FORCED"
 	elif [ "$EASYRSA_NO_SAFE_SSL" ]; then
@@ -922,14 +923,17 @@ escape_hazard() {
 		verbose "escape_hazard: DENIED"
 		return
 	elif [ "$working_safe_org_conf" ]; then
+		# Has run once
 		verbose "escape_hazard: IGNORED"
 		return
 	else
-		# set Run once
-		working_safe_org_conf=1
+		verbose "escape_hazard: RUN-ONCE"
 	fi
 
-	# Assign temp file
+	# Set run once
+	working_safe_org_conf=1
+
+	# Assign temp-file
 	vars_org_tmp=""
 	easyrsa_mktemp vars_org_tmp || die \
 		"escape_hazard - easyrsa_mktemp vars_org_tmp"
@@ -961,7 +965,9 @@ escape_hazard - Failed to source temp-file"
 # Replace environment variable names with current value
 # and write to temp-file or return error from sed
 expand_ssl_config() {
-	if [ "$EASYRSA_FORCE_SAFE_SSL" ]; then
+	if [ "$EASYRSA_FORCE_SAFE_SSL" ] || \
+		[ "$makesafeconf" ]
+	then
 		# Always run
 		verbose "expand_ssl_config: FORCED"
 	elif [ "$EASYRSA_NO_SAFE_SSL" ]; then
@@ -973,11 +979,13 @@ expand_ssl_config() {
 		verbose "expand_ssl_config: IGNORED"
 		return
 	else
-		# set Run once
-		working_safe_ssl_conf=1
+		verbose "expand_ssl_config: RUN-ONCE"
 	fi
 
-	# Assign safe_ssl_cnf_tmp temp-file
+	# Set run once
+	working_safe_ssl_conf=1
+
+	# Assign temp-file
 	safe_ssl_cnf_tmp=""
 	easyrsa_mktemp safe_ssl_cnf_tmp || die "\
 expand_ssl_config - \
@@ -1051,7 +1059,7 @@ easyrsa_openssl() {
 		rand)
 			die "easyrsa_openssl: Illegal SSL command: rand"
 		;;
-		makesafeconf) require_safe_ssl_conf=1 ;;
+		makesafeconf) makesafeconf=1 ;;
 		ca|req|srp|ts) has_config=1 ;;
 		*) unset -v has_config
 	esac
@@ -1095,6 +1103,7 @@ easyrsa_openssl - Safe SSL conf MISSING: $safe_ssl_cnf_tmp"
 	# Execute command - Return on success
 	if [ "$openssl_command" = "makesafeconf" ]; then
 		# COPY temp-file to safessl-easyrsa.cnf
+		unset -v makesafeconf
 		cp -f "$safe_ssl_cnf_tmp" "$EASYRSA_SAFE_CONF" && \
 				return
 
@@ -1144,14 +1153,10 @@ verify_ssl_lib() {
 	ssl_version="$val"
 
 	# SSL lib name
-	require_safe_ssl_conf=1
 	case "${val%% *}" in
 	# OpenSSL does require a safe config-file for ampersand
 	OpenSSL)
 		ssl_lib=openssl
-		if [ "$EASYRSA_NO_SAFE_SSL" ]; then
-			unset -v require_safe_ssl_conf
-		fi
 	;;
 	LibreSSL)
 		ssl_lib=libressl
@@ -4749,10 +4754,6 @@ read_db() {
 			die "read_db - remove_secure_session"
 		secure_session || \
 			die "read_db - secure_session"
-		if [ "$require_safe_ssl_conf" ];  then
-			EASYRSA_SILENT=1 make_safe_ssl || \
-				die "read_db - make_safe_ssl"
-		fi
 
 		# Interpret the db/certificate record
 		unset -v db_serial db_cn db_revoke_date db_reason
@@ -6763,6 +6764,7 @@ unset -v \
 	verify_ssl_lib_ok \
 	secured_session \
 	working_safe_ssl_conf working_safe_org_conf \
+	makesafeconf \
 	alias_days \
 	prohibit_no_pass \
 	found_vars no_new_vars user_vars_true \
@@ -7001,7 +7003,8 @@ case "$cmd" in
 	*)
 		require_pki=1
 		case "$cmd" in
-			gen-req|gen-dh|build-ca|show-req)
+			gen-req|gen-dh|build-ca|show-req| \
+			make-safe-ssl)
 				unset -v require_ca
 			;;
 			*)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -930,9 +930,9 @@ escape_hazard() {
 	fi
 
 	# Assign temp file
-	easyrsa_vars_org=""
-	easyrsa_mktemp easyrsa_vars_org || die \
-		"escape_hazard - easyrsa_mktemp easyrsa_vars_org"
+	vars_org_tmp=""
+	easyrsa_mktemp vars_org_tmp || die \
+		"escape_hazard - easyrsa_mktemp vars_org_tmp"
 
 	# write org fields to org temp-file and escape '&' and '$'
 	print "\
@@ -945,17 +945,17 @@ export EASYRSA_REQ_EMAIL=\"$EASYRSA_REQ_EMAIL\"
 export EASYRSA_REQ_SERIAL=\"$EASYRSA_REQ_SERIAL\"\
 " | sed -e s\`'\&'\`'\\\&'\`g \
 		-e s\`'\$'\`'\\\$'\`g \
-			> "$easyrsa_vars_org" || die "\
+			> "$vars_org_tmp" || die "\
 escape_hazard - Failed to write temp-file"
 
 	# Reload fields from fully escaped temp-file
 	# shellcheck disable=SC1090 # can't follow ...
-	(. "$easyrsa_vars_org") || die "\
+	(. "$vars_org_tmp") || die "\
 escape_hazard - Failed to source temp-file"
 
 	verbose "escape_hazard: COMPLETED"
 	# shellcheck disable=SC1090 # can't follow ...
-	. "$easyrsa_vars_org"
+	. "$vars_org_tmp"
 } # => escape_hazard()
 
 # Replace environment variable names with current value

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -695,7 +695,7 @@ secure_session() {
 		if mkdir "$secured_session"; then
 			# New session requires safe-ssl conf
 			unset -v mktemp_counter \
-				OPENSSL_CONF easyrsa_safe_ssl_conf \
+				OPENSSL_CONF safe_ssl_cnf_tmp \
 				working_safe_ssl_conf
 			easyrsa_err_log="$secured_session/error.log"
 			verbose "\
@@ -716,7 +716,7 @@ remove_secure_session() {
 			verbose "\
 remove_secure_session: DELETED: $secured_session"
 			unset -v secured_session mktemp_counter \
-				OPENSSL_CONF easyrsa_safe_ssl_conf \
+				OPENSSL_CONF safe_ssl_cnf_tmp \
 				working_safe_ssl_conf
 			return
 		fi
@@ -903,7 +903,7 @@ make_safe_ssl() {
 Safe SSL config file created at:
 * $EASYRSA_SAFE_CONF"
 	verbose "\
-make_safe_ssl: NEW SSL cnf file: $easyrsa_safe_ssl_conf"
+make_safe_ssl: NEW SSL cnf file: $safe_ssl_cnf_tmp"
 } # => make_safe_ssl_copy()
 
 # Escape hazardous characters
@@ -977,11 +977,11 @@ expand_ssl_config() {
 		working_safe_ssl_conf=1
 	fi
 
-	# Assign easyrsa_safe_ssl_conf temp-file
-	easyrsa_safe_ssl_conf=""
-	easyrsa_mktemp easyrsa_safe_ssl_conf || die "\
+	# Assign safe_ssl_cnf_tmp temp-file
+	safe_ssl_cnf_tmp=""
+	easyrsa_mktemp safe_ssl_cnf_tmp || die "\
 expand_ssl_config - \
-easyrsa_mktemp easyrsa_safe_ssl_conf"
+easyrsa_mktemp safe_ssl_cnf_tmp"
 
 	# Rewrite
 	# shellcheck disable=SC2016 # No expansion inside ''
@@ -1032,7 +1032,7 @@ easyrsa_mktemp easyrsa_safe_ssl_conf"
 -e s\`'$ENV::EASYRSA_REQ_SERIAL'\`\
 \""$EASYRSA_REQ_SERIAL"\"\`g \
 \
-	"$EASYRSA_SSL_CONF" > "$easyrsa_safe_ssl_conf"
+	"$EASYRSA_SSL_CONF" > "$safe_ssl_cnf_tmp"
 	then
 		verbose "expand_ssl_config: COMPLETED"
 	else
@@ -1076,26 +1076,26 @@ easyrsa_openssl() {
 	# Support --no-safe-ssl
 	if [ "$EASYRSA_NO_SAFE_SSL" ]; then
 		# Assign safe temp file as Original openssl-easyrsa.conf
-		easyrsa_safe_ssl_conf="$EASYRSA_SSL_CONF"
+		safe_ssl_cnf_tmp="$EASYRSA_SSL_CONF"
 		verbose "easyrsa_openssl: No SAFE SSL config"
 	fi
 
 	# VERIFY safe temp-file exists
-	if [ -e "$easyrsa_safe_ssl_conf" ]; then
+	if [ -e "$safe_ssl_cnf_tmp" ]; then
 		verbose "\
-easyrsa_openssl: Safe SSL conf OK: $easyrsa_safe_ssl_conf"
+easyrsa_openssl: Safe SSL conf OK: $safe_ssl_cnf_tmp"
 	else
 		die "\
-easyrsa_openssl - Safe SSL conf MISSING: $easyrsa_safe_ssl_conf"
+easyrsa_openssl - Safe SSL conf MISSING: $safe_ssl_cnf_tmp"
 	fi
 
 	# set $OPENSSL_CONF - Use which-ever file is assigned above
-	export OPENSSL_CONF="$easyrsa_safe_ssl_conf"
+	export OPENSSL_CONF="$safe_ssl_cnf_tmp"
 
 	# Execute command - Return on success
 	if [ "$openssl_command" = "makesafeconf" ]; then
 		# COPY temp-file to safessl-easyrsa.cnf
-		cp -f "$easyrsa_safe_ssl_conf" "$EASYRSA_SAFE_CONF" && \
+		cp -f "$safe_ssl_cnf_tmp" "$EASYRSA_SAFE_CONF" && \
 				return
 
 	elif [ "$has_config" ]; then
@@ -1103,12 +1103,12 @@ easyrsa_openssl - Safe SSL conf MISSING: $easyrsa_safe_ssl_conf"
 		if [ "$EASYRSA_SILENT_SSL" ] && [ "$EASYRSA_BATCH" ]
 		then
 			"$EASYRSA_OPENSSL" "$openssl_command" \
-				-config "$easyrsa_safe_ssl_conf" "$@" \
+				-config "$safe_ssl_cnf_tmp" "$@" \
 				2>/dev/null && \
 					return
 		else
 			"$EASYRSA_OPENSSL" "$openssl_command" \
-				-config "$easyrsa_safe_ssl_conf" "$@" && \
+				-config "$safe_ssl_cnf_tmp" "$@" && \
 					return
 		fi
 
@@ -1129,7 +1129,7 @@ easyrsa_openssl - Safe SSL conf MISSING: $easyrsa_safe_ssl_conf"
 	die "\
 easyrsa_openssl - Command has failed:
 * $EASYRSA_OPENSSL $openssl_command \
-${has_config:+-config $easyrsa_safe_ssl_conf }$*"
+${has_config:+-config $safe_ssl_cnf_tmp }$*"
 } # => easyrsa_openssl()
 
 # Verify the SSL library is functional

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -918,15 +918,22 @@ escape_hazard() {
 	then
 		# Always run
 		verbose "escape_hazard: FORCED"
-	elif [ "$EASYRSA_NO_SAFE_SSL" ]; then
-		# Never run
-		verbose "escape_hazard: DENIED"
-		return
+	# Do not respect --no-safe-ssl, escape the fields
+	# before they are expanded by OpenSSL or easyrsa.
+	#elif [ "$EASYRSA_NO_SAFE_SSL" ]; then
+	#	# Never run
+	#	verbose "escape_hazard: DENIED"
+	#	return
 	elif [ "$working_safe_org_conf" ]; then
 		# Has run once
+		verbose "escape_hazard: BYPASSED"
+		return
+	elif [ -z "$has_config" ]; then
+		# SSL Config not required
 		verbose "escape_hazard: IGNORED"
 		return
 	else
+		# Run once
 		verbose "escape_hazard: RUN-ONCE"
 	fi
 
@@ -976,9 +983,14 @@ expand_ssl_config() {
 		return
 	elif [ "$working_safe_ssl_conf" ]; then
 		# Has run once
+		verbose "expand_ssl_config: BYPASSED"
+		return
+	elif [ -z "$has_config" ]; then
+		# SSL Config not required
 		verbose "expand_ssl_config: IGNORED"
 		return
 	else
+		# Run once
 		verbose "expand_ssl_config: RUN-ONCE"
 	fi
 
@@ -1051,6 +1063,11 @@ easyrsa_mktemp safe_ssl_cnf_tmp"
 # Easy-RSA meta-wrapper for SSL
 # WARNING: Running easyrsa_openssl in a subshell
 # will hide error message and verbose messages
+#
+# The expansion here takes place on EASYRSA_SSL_CONF,
+# which may have already been replaced by a temp-file
+# with the extensions having been inserted by build-ca,
+# sign-req or gen-req.
 easyrsa_openssl() {
 	openssl_command="$1"; shift
 
@@ -1059,7 +1076,7 @@ easyrsa_openssl() {
 		rand)
 			die "easyrsa_openssl: Illegal SSL command: rand"
 		;;
-		makesafeconf) makesafeconf=1 ;;
+		makesafeconf) makesafeconf=1; has_config=1 ;;
 		ca|req|srp|ts) has_config=1 ;;
 		*) unset -v has_config
 	esac
@@ -1093,7 +1110,7 @@ easyrsa_openssl() {
 		verbose "\
 easyrsa_openssl: Safe SSL conf OK: $safe_ssl_cnf_tmp"
 	else
-		die "\
+		[ "$has_config" ] && die "\
 easyrsa_openssl - Safe SSL conf MISSING: $safe_ssl_cnf_tmp"
 	fi
 
@@ -4247,7 +4264,7 @@ $in_file"
 This file is not a valid $type file:
 $in_file"
 
-	notice "
+	notice "\
 Showing details for CA certificate, at:
 * $in_file${NL}"
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -779,7 +779,7 @@ easyrsa_mktemp: temp-file EXISTS: $want_tmp_file"
 						if force_set_var "$1" "$want_tmp_file"
 						then
 							verbose "\
-easyrsa_mktemp: $1 temp-file OK: $want_tmp_file"
+easyrsa_mktemp: $1 OK: $want_tmp_file"
 
 							if [ "$easyrsa_host_os" = win ]; then
 								set +o noclobber

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -960,17 +960,17 @@ escape_hazard - Failed to source temp-file"
 
 # Replace environment variable names with current value
 # and write to temp-file or return error from sed
-easyrsa_rewrite_ssl_config () {
+expand_ssl_config() {
 	if [ "$EASYRSA_FORCE_SAFE_SSL" ]; then
 		# Always run
-		verbose "easyrsa_rewrite_ssl_config: FORCED"
+		verbose "expand_ssl_config: FORCED"
 	elif [ "$EASYRSA_NO_SAFE_SSL" ]; then
 		# Never run
-		verbose "easyrsa_rewrite_ssl_config: DENIED"
+		verbose "expand_ssl_config: DENIED"
 		return
 	elif [ "$working_safe_ssl_conf" ]; then
 		# Has run once
-		verbose "easyrsa_rewrite_ssl_config: IGNORED"
+		verbose "expand_ssl_config: IGNORED"
 		return
 	else
 		# set Run once
@@ -980,7 +980,7 @@ easyrsa_rewrite_ssl_config () {
 	# Assign easyrsa_safe_ssl_conf temp-file
 	easyrsa_safe_ssl_conf=""
 	easyrsa_mktemp easyrsa_safe_ssl_conf || die "\
-easyrsa_rewrite_ssl_config - \
+expand_ssl_config - \
 easyrsa_mktemp easyrsa_safe_ssl_conf"
 
 	# Rewrite
@@ -1034,11 +1034,11 @@ easyrsa_mktemp easyrsa_safe_ssl_conf"
 \
 	"$EASYRSA_SSL_CONF" > "$easyrsa_safe_ssl_conf"
 	then
-		verbose "easyrsa_rewrite_ssl_config: COMPLETED"
+		verbose "expand_ssl_config: COMPLETED"
 	else
 		return 1
 	fi
-} # => easyrsa_rewrite_ssl_config()
+} # => expand_ssl_config()
 
 # Easy-RSA meta-wrapper for SSL
 # WARNING: Running easyrsa_openssl in a subshell
@@ -1070,8 +1070,8 @@ easyrsa_openssl() {
 		die "easyrsa_openssl - escape_hazard failed"
 
 	# Rewrite SSL config
-	easyrsa_rewrite_ssl_config || \
-		die "easyrsa_openssl - easyrsa_rewrite_ssl_config failed"
+	expand_ssl_config || \
+		die "easyrsa_openssl - expand_ssl_config failed"
 
 	# Support --no-safe-ssl
 	if [ "$EASYRSA_NO_SAFE_SSL" ]; then


### PR DESCRIPTION
Replace complex (ugly) code in `easyrsa_opessl()` with simple code in the functions `easyrsa_rewrite_ssl_conf()` and `escape_hazard()`.

Subsequently, rename functions, variables and temp-file names, for simplicity and conformity.