### PR TITLE
Inline v2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 Easy-RSA 3 ChangeLog
 
 3.1.6 (2023-10-13)
+   * New commands: 'inline' and 'x509-eku' (#993)
+     inline: Build an inline file for a commonName
+     x509-eku: Extract X509v3 extended key usage from a certificate
    * Expose serial-check, display-dn, display-san and default-san to
      command line. (#980) (Debugging functions, which remain undocumented)
    * Expand default status to include vars-file and CA status (#973)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1335,7 +1335,7 @@ and initialize a fresh PKI here."
 	fi
 
 	# new dirs:
-	for i in private reqs; do
+	for i in private reqs inline; do
 		mkdir -p "$EASYRSA_PKI/$i" || \
 			die "\
 Failed to create PKI file structure (permissions?)"
@@ -1656,7 +1656,7 @@ current CA. To start a new CA, run init-pki first."
 	# create necessary dirs:
 	err_msg="\
 Unable to create necessary PKI files (permissions?)"
-	for i in issued inline certs_by_serial \
+	for i in issued certs_by_serial \
 		revoked/certs_by_serial revoked/private_by_serial \
 		revoked/reqs_by_serial
 	do
@@ -7204,7 +7204,7 @@ case "$cmd" in
 		require_pki=1
 		case "$cmd" in
 			gen-req|gen-dh|build-ca|show-req| \
-			make-safe-ssl|export-p*)
+			make-safe-ssl|export-p*|inline)
 				unset -v require_ca
 			;;
 			*)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4352,6 +4352,57 @@ Showing details for CA certificate, at:
 			die "OpenSSL failure to process the input"
 } # => show_ca()
 
+# Certificate X509v3 Extended Key Usage
+ssl_cert_x509v3_eku() {
+	[ "$1" ] || die "ssl_cert_x509v3_eku - Missing input"
+
+	# check input file name
+	if [ -e "$1" ]; then
+		__crt="$1"
+	else
+		__crt="${EASYRSA_PKI}/issued/${1}.crt"
+		[ -e "$__crt" ] || \
+			die "ssl_cert_x509v3_eku - Missing cert '$__crt'"
+	fi
+
+	# Set output variable
+	__var="$2"
+	shift "$#"
+
+	# required variables
+	__pattern="X509v3 Extended Key Usage:"
+	__cli="TLS Web Client Authentication"
+	__srv="TLS Web Server Authentication"
+	__srv_cli="${__srv}, ${__cli}"
+
+	# Extract certificate usage from old cert
+	__eku="$(
+		easyrsa_openssl x509 -in "${__crt}" -noout -text | \
+			sed -n "/${__pattern}/{n;s/^ *//g;p;}"
+		)"
+
+	case "$__eku" in
+	"$__cli")
+		__type=client
+	;;
+	"$__srv")
+		__type=server
+	;;
+	"$__srv_cli")
+		__type=serverClient
+	;;
+	*) die "Unknown key usage: $__eku"
+	esac
+
+	# Set variable to return
+	if [ "$__var" ]; then
+		force_set_var "$__var" "$__type"
+	else
+		information "${NL}* EasyRSA Certificate type: $__type"
+	fi
+	unset -v __crt __var __pattern __eku __type
+} # => ssl_cert_x509v3_eku()
+
 # get the serial number of the certificate -> serial=XXXX
 ssl_cert_serial() {
 	[ "$#" = 2 ] || die "ssl_cert_serial - input error"
@@ -7295,6 +7346,10 @@ case "$cmd" in
 	default-san)
 		verify_working_env
 		default_server_san "$@"
+		;;
+	x509-eku)
+		verify_working_env
+		ssl_cert_x509v3_eku "$@"
 		;;
 	upgrade)
 		verify_working_env

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -33,6 +33,7 @@ A list of commands is shown below:
   build-client-full <file_name_base> [ cmd-opts ]
   build-server-full <file_name_base> [ cmd-opts ]
   build-serverClient-full <file_name_base> [ cmd-opts ]
+  inline <file_name_base>
   revoke <file_name_base> [ cmd-opts ]
   renew <file_name_base>
   revoke-renewed <file_name_base> [ cmd-opts ]
@@ -181,6 +182,15 @@ cmd_help() {
 		opts="
       * nopass  - Do not encrypt the private key (Default: encrypted)
                   (Equivalent to global option '--nopass|--no-pass')"
+	;;
+	inline)
+		text="
+* inline <file_name_base>
+
+      Print inline data for <file_name_base>, with key and CA.
+
+  * NOTE: To create an inline-file the output must be redirected.
+          If the output is incomplete then an error is retruned."
 	;;
 	revoke)
 		text="
@@ -2589,27 +2599,81 @@ Inline file created:
 * $inline_out"
 	else
 		warn "\
-Failed to write inline file:
+INCOMPLETE Inline file created:
 * $inline_out"
 	fi
 
 	return 0
 } # => build_full()
 
-# Create inline credentials file for this node
-inline_creds ()
-{
-	[ "$1" ] || die "inline_creds - Name missing"
-	printf "%s\n\n" "# $crt_type: $1"
-	printf "%s\n" "<cert>"
-	cat "$crt_out"
-	printf "%s\n\n" "</cert>"
-	printf "%s\n" "<key>"
-	[ -e "$key_out" ] && cat "$key_out"
-	printf "%s\n\n" "</key>"
-	printf "%s\n" "<ca>"
-	cat "$EASYRSA_PKI/ca.crt"
-	printf "%s\n\n" "</ca>"
+# Print inline data for file_name_base
+inline_creds () {
+	[ "$1" ] || die "inline_creds - Missing file_name_base"
+
+	# Source files
+	crt_source="${EASYRSA_PKI}/issued/${1}.crt"
+	key_source="${EASYRSA_PKI}/private/${1}.key"
+	ca_source="$EASYRSA_PKI/ca.crt"
+	incomplete=0
+
+	# Generate data
+	if [ -e "$crt_source" ]; then
+		# Get EasyRSA cert type
+		ssl_cert_x509v3_eku "$1" type_data
+
+		crt_data="\
+<cert>
+$(cat "$crt_source")
+</cert>"
+	else
+		# Set EasyRSA cert type to 'undefined'
+		type_data=undefined
+		incomplete=1
+		crt_data="\
+<cert>
+* Paste your user certificate here *
+</cert>"
+	fi
+
+	if [ -e "$key_source" ]; then
+		key_data="\
+<key>
+$(cat "$key_source")
+</key>"
+	else
+		incomplete=1
+		key_data="\
+<key>
+* Paste your private key here *
+</key>"
+	fi
+
+	if [ -e "$ca_source" ]; then
+		ca_data="\
+<ca>
+$(cat "$ca_source")
+</ca>"
+	else
+		incomplete=1
+		ca_data="\
+<ca>
+* Paste your CA certificate here *
+</ca>"
+	fi
+
+	# Print data
+	print "\
+# Easy-RSA Type: ${type_data}
+# Name: ${1}
+
+$crt_data
+
+$key_data
+
+$ca_data
+"
+	# If inline file is incomplete then return error
+	return "$incomplete"
 } # => inline_creds ()
 
 # revoke backend
@@ -2992,7 +3056,7 @@ Inline file created:
 * $inline_in"
 	else
 		warn "\
-Failed to write inline file:
+INCOMPLETE Inline file created:
 * $inline_in"
 	fi
 
@@ -7248,6 +7312,11 @@ case "$cmd" in
 	import-req)
 		verify_working_env
 		import_req "$@"
+		;;
+	inline)
+		verify_working_env
+		inline_creds "$@" || \
+			easyrsa_exit_with_error=1
 		;;
 	export-p12)
 		verify_working_env

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2619,7 +2619,7 @@ inline_creds () {
 	# Generate data
 	if [ -e "$crt_source" ]; then
 		# Get EasyRSA cert type
-		ssl_cert_x509v3_eku "$1" type_data
+		ssl_cert_x509v3_eku "$crt_source" type_data
 
 		crt_data="\
 <cert>
@@ -2971,23 +2971,7 @@ Cannot renew this certificate, a conflicting file exists:
 			die "Failed to create inline directoy."
 
 	# Extract certificate usage from old cert
-	cert_ext_key_usage="$(
-		easyrsa_openssl x509 -in "$crt_in" -noout -text |
-		sed -n "/X509v3 Extended Key Usage:/{n;s/^ *//g;p;}"
-		)"
-
-	case "$cert_ext_key_usage" in
-		"TLS Web Client Authentication")
-			cert_type=client
-		;;
-		"TLS Web Server Authentication")
-			cert_type=server
-		;;
-		"TLS Web Server Auth"*", TLS Web Client Auth"*)
-			cert_type=serverClient
-		;;
-		*) die "Unknown key usage: $cert_ext_key_usage"
-	esac
+	ssl_cert_x509v3_eku "$crt_in" cert_type
 
 	# Use SAN from --san if set else use SAN from old cert
 	if echo "$EASYRSA_EXTRA_EXTS" | grep -q subjectAltName


### PR DESCRIPTION
Rewrite `inline_cert()` so that any files to be _inlined_ can be missing.
This allows for any combination of files to create an inline file.

Move certificate type extraction to a new function, `ssl_cert_x509v3_eku()`, which can be reused.