### PR TITLE
vars: Conditionally disable "Prefer vars in PKI" message

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -6135,16 +6135,6 @@ fi
 
 # DO YOUR EDITS BELOW THIS POINT
 
-# This variable is used as the base location of configuration files needed by
-# easyrsa.  More specific variables for specific files (eg: EASYRSA_SSL_CONF)
-# may override this default.
-#
-# The default value of this variable is the location of the easyrsa script
-# itself, which is also where the configuration files are located in the
-# easy-rsa tree.
-#
-#set_var EASYRSA	"${0%/*}"
-
 # If your OpenSSL command is not in the system PATH, you will need to define
 # the path here. Normally this means a full path to the executable, otherwise
 # you could have left it undefined here and the shown default would be used.
@@ -6157,19 +6147,6 @@ fi
 #
 # This sample is in Windows syntax -- edit it for your path if not using PATH:
 #set_var EASYRSA_OPENSSL	"C:/Program Files/OpenSSL-Win32/bin/openssl.exe"
-
-# Edit this variable to point to your soon-to-be-created key directory.
-# By default, this will be "$PWD/pki" (ie: the "pki" subdirectory of the
-# directory you are currently in).
-#
-# WARNING: init-pki will do a rm -rf on this directory so make sure you define
-# it correctly!  Interactive mode will prompt before acting.
-#
-#set_var EASYRSA_PKI		"$PWD/pki"
-
-# Define directory for temporary subdirectories.
-#
-#set_var EASYRSA_TEMP_DIR	"$EASYRSA_PKI"
 
 # Define X509 DN mode.
 #

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1395,8 +1395,10 @@ init_pki: x509-types dir ${EASYRSA_EXT_DIR:-Not found}"
 
 # Must be used in two places, so made it a function
 prefer_vars_in_pki_msg() {
-	if [ "$vars_in_pki" ] || [ "$user_vars_true" ] ||
+	if [ "$vars_in_pki" ] ||
+		[ "$user_vars_true" ] ||
 		[ "$EASYRSA_NO_VARS" ]
+		[ "$user_pki_true" ]
 	then
 		return
 	fi
@@ -5809,10 +5811,42 @@ Remove 'unset' ('force_set_var' may also work)."
 		( . "$vars" ) || \
 			die "Failed to source the vars file."
 
+		# Take note of important variables
+		# set before sourcing vars
+		unset -v before_EASYRSA
+			[ -z "$EASYRSA" ] || before_EASYRSA=1
+		unset -v before_EASYRSA_PKI
+			[ -z "$EASYRSA_PKI" ] || before_EASYRSA_PKI=1
+
 		# Source 'vars' now
 		# shellcheck disable=1090 # can't follow .. vars
 		. "$vars" 2>/dev/null
 		unset -v EASYRSA_CALLER
+
+		# Take note of important variables
+		# set after sourcing vars
+		unset -v after_EASYRSA
+			[ -z "$EASYRSA" ] || after_EASYRSA=1
+		unset -v after_EASYRSA_PKI
+			[ -z "$EASYRSA_PKI" ] || after_EASYRSA_PKI=1
+
+		# If the user has set something important
+		# then they know what they are doing
+		if [ "$before_EASYRSA" ] ||
+			[ "$before_EASYRSA_PKI" ] ||
+			[ "$after_EASYRSA" ] ||
+			[ "$after_EASYRSA_PKI" ]
+		then
+			# Don't pester about vars in PKI
+			user_pki_true=1
+			verbose "\
+vars_setup: disable vars_in_pki_msg, user pki"
+		else
+			unset -v user_pki_true
+		fi
+		unset -v \
+			before_EASYRSA before_EASYRSA_PKI \
+			after_EASYRSA after_EASYRSA_PKI
 	fi
 
 	# Set defaults, preferring existing env-vars if present


### PR DESCRIPTION
When EASYRSA or EASYRSA_PKI is set in vars then consider the user has done this intentionally and disable "vars in PKI" message.

If either of these are set then moving 'vars' to the PKI will cause EasyRSA to be unable to find 'vars' and will assume default PKI.

Superseded-by: #1014 (Possibly)

