### PR TITLE
Disable prefer_vars_in_pki_msg(), until further notice

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ Easy-RSA 3 ChangeLog
 3.2.0 (TBD)
 
 3.1.7 (ETA 2023-10-13)
+   * Guard against default 'pki/vars' setting a different PKI (#1014)
+   * Retract preference for 'vars' file to exist in the PKI (#1014)
    * Disable all code which requests vars in PKI (#1014)
    * Update OpenSSL to 3.1.2
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,10 @@
 Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
-   * Update OpenSSL to 3.1.6
+
+3.1.7 (ETA 2023-10-13)
+   * Disable all code which requests vars in PKI (#1014)
+   * Update OpenSSL to 3.1.2
 
 3.1.6 (2023-07-18)
    * New commands: 'inline' and 'x509-eku' (#993)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Easy-RSA 3 ChangeLog
 3.2.0 (TBD)
 
 3.1.7 (ETA 2023-10-13)
+   * Insert required errors and warning to control vars location (#1014)
    * Guard against default 'pki/vars' setting a different PKI (#1014)
    * Retract preference for 'vars' file to exist in the PKI (#1014)
    * Disable all code which requests vars in PKI (#1014)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5785,7 +5785,13 @@ Remove 'unset' ('force_set_var' may also work)."
 	# Required for init-pki
 	case "$cmd" in
 		init-pki|clean-all)
-			expected_pki="${expected_pki:-"$PWD/pki"}"
+			if [ "$EASYRSA_PKI" ]; then
+				expected_pki="${expected_pki:-"$EASYRSA_PKI"}"
+			elif [ "$EASYRSA" ]; then
+				expected_pki="${expected_pki:-"$EASYRSA/pki"}"
+			else
+				expected_pki="${expected_pki:-"$PWD/pki"}"
+			fi
 		;;
 		*) : # ok
 	esac

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5742,8 +5742,8 @@ or remove the 'vars' files which are not in use."
 		# If PKI is required then warn
 		# For init-pki, version and help, skip this
 		if [ "$require_pki" ]; then
-			warn "\
-No Easy-RSA 'vars' configuration file exists!"
+			information "\
+No Easy-RSA 'vars' configuration file exists."
 		fi
 
 	# If a vars file was located then source it

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1293,14 +1293,13 @@ and initialize a fresh PKI here."
 		# now remove it:
 		case "$reset" in
 		hard)
-
 			# Promote use of soft init
-			confirm "Remove current 'vars' file? " yes "\
-* SECOND WARNING!!!
-
-* This will remove everything in your current PKI directory.
-  To keep your current settings use 'init-pki soft' instead.
-  Using 'init-pki soft' is recommended."
+#			confirm "Completely remove current PKI ? " yes "\
+#* SECOND WARNING!!!
+#
+#* This will remove everything in your current PKI directory.
+#  To keep your current settings use 'init-pki soft' instead.
+#  Using 'init-pki soft' is recommended."
 
 			# # # shellcheck disable=SC2115 # Use "${var:?}"
 			rm -rf "$EASYRSA_PKI" || \
@@ -1333,6 +1332,7 @@ and initialize a fresh PKI here."
 			user_error "Unknown reset type: $reset"
 		esac
 	fi
+	verbose "init-pki $reset: Removal COMPLETE"
 
 	# new dirs:
 	for i in private reqs inline; do
@@ -1502,6 +1502,11 @@ install_data_to_pki: $context - Not creating pki/vars"
 	else
 		case "$context" in
 		init-pki)
+		# Disable creating a vars file
+		if :
+		then
+			verbose "install_data_to_pki: New vars DISABLED"
+		else
 			# Only create for 'init-pki', if one does not exist
 			# 'init-pki soft' should have it's own 'vars' file
 			if [ -e "${EASYRSA_PKI}/${vars_file_example}" ] && \
@@ -1523,6 +1528,7 @@ install_data_to_pki: $context - vars = '$vars'"
 install_data_to_pki: $context - Failed to install vars file"
 				fi
 			fi
+		fi
 		;;
 		vars-setup)
 			: ;; # No change to current 'vars' required

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5600,36 +5600,32 @@ vars_setup() {
 	vars=
 
 	# Find vars
-	# Explicit user defined vars file:
+	# Explicit user defined NO vars file:
 	if [ "$EASYRSA_NO_VARS" ]; then
-		# Found exactly zero vars files
+		user_vars_true=1
 		found_vars=0
-		warn "\
-EASYRSA_NO_VARS is enabled, not using a 'vars' file.${NL}"
 
+	# Explicit user defined vars file:
 	elif [ "$EASYRSA_VARS_FILE" ]; then
-		if [ -e "$EASYRSA_VARS_FILE" ]; then
-			vars="$EASYRSA_VARS_FILE"
-			# User set vars turns off pki/var warning
+		vars="$EASYRSA_VARS_FILE"
+		user_vars_true=1
+		found_vars=1
+
+	# Implicit User defined EASYRSA vars
+	elif [ "$EASYRSA" ]; then
+		vars="${EASYRSA}/vars"
+		if [ -e "${EASYRSA}/vars" ]; then
 			user_vars_true=1
-			# Found exactly one vars file
 			found_vars=1
 		else
-			# If the --vars option does not point to a file
-			user_error "\
-The 'vars' file was not found:
-* $EASYRSA_VARS_FILE"
+			# Allow without a default vars file
+			unset -v vars
+			user_vars_true=1
+			found_vars=0
 		fi
 
 	# Otherwise, find vars
 	else
-
-		# User defined EASYRSA vars
-		if [ "$EASYRSA" ]; then
-			easy_vars="${EASYRSA}/vars"
-		else
-			unset -v easy_vars
-		fi
 
 		# Working dir vars
 		# This location is most suitable
@@ -5655,11 +5651,8 @@ The 'vars' file was not found:
 
 		# Clear flags
 		unset -v \
-			e_pki_vars e_easy_vars e_pwd_vars e_prog_vars \
+			e_pki_vars e_pwd_vars e_prog_vars \
 			found_vars vars_in_pki
-
-		# EASYRSA, if defined:
-		[ -e "$easy_vars" ] && e_easy_vars=1
 
 		# Working dir:
 		[ -e "$pwd_vars" ] && e_pwd_vars=1
@@ -5672,7 +5665,7 @@ The 'vars' file was not found:
 
 		# Count found vars files
 		found_vars="$((
-			e_pki_vars + e_easy_vars + e_pwd_vars + e_prog_vars
+			e_pwd_vars + e_prog_vars + e_pki_vars
 			))"
 		verbose "vars_setup: found_vars = '$found_vars'"
 
@@ -5685,9 +5678,7 @@ The 'vars' file was not found:
 		1)
 			# If a SINGLE vars file is found then
 			# Select single vars file, with priority
-			if [ "$e_easy_vars" ]; then
-				vars="$easy_vars"
-			elif [ "$e_pwd_vars" ]; then
+			if [ "$e_pwd_vars" ]; then
 				vars="$pwd_vars"
 			elif [ "$e_prog_vars" ]; then
 				vars="$prog_vars"
@@ -5708,8 +5699,6 @@ Either declare which 'vars' file to use with --vars=<FILE>
 or remove the 'vars' files which are not in use.${NL}"
 
 			# Show found vars files
-			[ "$e_easy_vars" ] && \
-				print "  easy_vars Found: $easy_vars"
 			[ "$e_pwd_vars" ] && \
 				print "  pwd_vars  Found: $pwd_vars"
 			[ "$e_prog_vars" ] && \
@@ -5718,14 +5707,13 @@ or remove the 'vars' files which are not in use.${NL}"
 				print "  pki_vars  Found: $pki_vars"
 
 			# Select single vars file, with priority
-			if [ "$e_easy_vars" ]; then
-				vars="$easy_vars"
-			elif [ "$e_pwd_vars" ]; then
+			if [ "$e_pwd_vars" ]; then
 				vars="$pwd_vars"
 			elif [ "$e_prog_vars" ]; then
 				vars="$prog_vars"
 			elif [ "$e_pki_vars" ]; then
 				vars="$pki_vars"
+				vars_in_pki=1
 			else
 				# This cannot happen
 				die "Detecting vars file failed!"
@@ -5765,7 +5753,7 @@ No Easy-RSA 'vars' configuration file exists."
 Missing vars file:
 * $vars"
 
-		# Installation information
+		# Show the vars file in use
 		[ "$require_pki" ] && information "\
 Using Easy-RSA 'vars' configuration:
 * $vars"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5590,7 +5590,7 @@ Use of --silent and --verbose is unresolvable."
 # Here sourcing of 'vars' if present occurs.
 # If not present, defaults are used to support
 # running without a sourced config format
-vars_setup() {
+setup_vars() {
 	# Try to locate a 'vars' file in order of preference.
 	# If one is found then source it.
 	# NOTE: EASYRSA_PKI is never set here,
@@ -5633,7 +5633,7 @@ vars_setup() {
 
 		# Program dir
 		prog_dir="${0%/*}"
-		verbose "vars_setup: prog_dir=$prog_dir"
+		verbose "setup_vars: prog_dir = $prog_dir"
 
 		# If prog_dir is PWD then do not check prog_vars
 		if [ "$prog_dir" = . ] || [ "$prog_dir" = "$PWD" ]
@@ -5667,7 +5667,7 @@ vars_setup() {
 		found_vars="$((
 			e_pwd_vars + e_prog_vars + e_pki_vars
 			))"
-		verbose "vars_setup: found_vars = '$found_vars'"
+		verbose "setup_vars: found_vars = '$found_vars'"
 
 		# If found_vars greater than 1
 		# then output user info
@@ -5728,7 +5728,10 @@ or remove the 'vars' files which are not in use.${NL}"
 		unset -v prog_vars pwd_vars easy_vars pki_vars
 	# END: Find vars
 	fi
+} # => setup_vars()
 
+# Source vars file and set defaults
+source_vars() {
 	# If EASYRSA_NO_VARS is defined then do not use vars
 	# If PKI is not required then located vars files are
 	# not required
@@ -5871,8 +5874,8 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 	if [ "$require_pki" ]; then
 		prefer_vars_in_pki_msg
 	fi
-	verbose "vars_setup: COMPLETED"
-} # => vars_setup()
+	verbose "source_vars: COMPLETED"
+} # => source_vars()
 
 # Verify working environment
 verify_working_env() {
@@ -7272,8 +7275,11 @@ case "$cmd" in
 		esac
 esac
 
-# Intelligent env-var detection and auto-loading:
-vars_setup
+# Determine which vars file to use
+setup_vars
+
+# Source the vars file
+source_vars
 
 # Check for conflicting input options
 mutual_exclusions

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1390,6 +1390,10 @@ prefer_vars_in_pki_msg() {
 		return
 	fi
 
+	# disable this until v3.2-ish
+	verbose "prefer_vars_in_pki_msg: DISABLED"
+	return 0
+
 	information "
 IMPORTANT:
   The preferred location for 'vars' is within the PKI folder.

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1538,7 +1538,8 @@ install_data_to_pki $context: Failed to install vars file"
 	else
 		create_openssl_easyrsa_cnf > \
 			"${EASYRSA_PKI}/${ssl_cnf_file}" || die "\
-install_data_to_pki - Missing: '$ssl_cnf_file'"
+install_data_to_pki $context: \
+Missing: '${EASYRSA_PKI}/${ssl_cnf_file}'"
 		verbose "\
 install_data_to_pki $context: create_openssl_easyrsa_cnf OK"
 	fi

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1389,6 +1389,13 @@ vars_in_pki_msg() {
 		return
 	fi
 
+	# Resolve setting EASYRSA_PKI in vars file
+	# when vars file is default 'pki/vars'
+	# and potentially points to a different PKI.
+	# Once resolved, a user set PKI will over-rule
+	# a vars setting and this message can be disabled
+	#return
+
 	information "
 IMPORTANT:
   Do NOT keep your 'vars' within your PKI directory.
@@ -5656,8 +5663,10 @@ setup_vars() {
 		[ -e "$prog_vars" ] && e_prog_vars=1
 
 		# PKI location, if present:
-		[ -e "$pki_vars" ] && e_pki_vars=1 && \
+		if [ -e "$pki_vars" ]; then
+			e_pki_vars=1
 			vars_in_pki=1
+		fi
 
 		# Count found vars files
 		found_vars="$((
@@ -5680,6 +5689,9 @@ setup_vars() {
 				vars="$prog_vars"
 			elif [ "$e_pki_vars" ]; then
 				vars="$pki_vars"
+				# Set expected_pki
+				# to stop vars changing EASYRSA_PKI
+				expected_pki="${pki_vars%/*}"
 			else
 				# This cannot happen
 				die "Detecting vars file failed!"
@@ -5708,6 +5720,9 @@ or remove the 'vars' files which are not in use.${NL}"
 				vars="$prog_vars"
 			elif [ "$e_pki_vars" ]; then
 				vars="$pki_vars"
+				# Set expected_pki
+				# to stop vars changing EASYRSA_PKI
+				expected_pki="${pki_vars%/*}"
 			else
 				# This cannot happen
 				die "Detecting vars file failed!"
@@ -5862,6 +5877,34 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 	set_var EASYRSA_KDC_REALM		"CHANGEME.EXAMPLE.COM"
 
 	set_var EASYRSA_MAX_TEMP		4
+
+	# expected_pki is set when default 'pki/vars' is used
+	# This blocks pki/vars changing EASYRSA_PKI
+	if [ "$expected_pki" ] # && [ "$require_pki" ]
+	then
+		if [ "$expected_pki" = "$EASYRSA_PKI" ]
+		then
+			: # ok
+		else
+			# Show warning
+			warn "\
+'EASYRSA_PKI' is set incorrectly in the 'vars' file.
+
+  This vars file:
+  * $vars
+
+  Uses this PKI:
+  * $EASYRSA_PKI"
+
+			# Require user consent to continue
+			confirm "\
+  Continue with invalid configuration ? " yes "
+  'vars' configuration for 'EASYRSA_PKI' is invalid."
+
+			verbose "\
+source_vars: Invalid PKI accepted for EASYRSA_PKI"
+		fi
+	fi
 
 	# if the vars file in use is not in the PKI
 	# and not user defined then Show the messages
@@ -7018,6 +7061,7 @@ detect_host
 
 # Initialisation requirements
 unset -v \
+	expected_pki \
 	verify_ssl_lib_ok \
 	secured_session \
 	working_safe_ssl_conf working_safe_org_conf \

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -93,10 +93,6 @@ DIRECTORY STATUS (commands would take effect on these locations)
    vars-file: $vars_status
   x509-types: ${EASYRSA_EXT_DIR:-Missing or undefined}
 $CA_status"
-
-	# if the vars file in use is in the PKI
-	# and not user defined then Show the message
-	vars_in_pki_msg
 } # => usage()
 
 # Detailed command help
@@ -875,6 +871,10 @@ Temporary session not preserved."
 		*) warn "prompt_restore: '$prompt_restore'"
 	esac
 
+	# if the vars file in use is in the PKI
+	# and not user defined then Show the message
+	vars_in_pki_msg
+
 	# Get a clean line
 	[ "$EASYRSA_SILENT" ] || print
 
@@ -892,7 +892,7 @@ Temporary session not preserved."
 
 	# Exit: SIGINT
 	if [ "$1" = 2 ]; then
-		verbose "exit SIGINT = true"
+		verbose "Exit: SIGINT = true"
 		kill -2 "$$"
 	fi
 
@@ -5599,10 +5599,30 @@ setup_vars() {
 		# Program location:
 		[ -e "$prog_vars" ] && e_prog_vars=1
 
-		# PKI location, if present:
+		# PKI location, least desirable:
 		if [ -e "$pki_vars" ]; then
 			e_pki_vars=1
 			vars_in_pki=1
+
+			# Conflicting vars:
+			if [ "$e_pwd_vars" ] || [ "$e_prog_vars" ]
+			then
+				user_error "\
+There is a 'vars' file located inside the default PKI.
+This 'vars' file must be moved to the working directory.
+
+  'vars' file:
+  * $pki_vars
+
+  PKI directory:
+  * ${pki_vars%/vars}
+
+  Working directory:
+  * $PWD
+
+  Info:
+  * https://github.com/OpenVPN/easy-rsa/issues/1009"
+			fi
 		fi
 
 		# Count found vars files
@@ -5698,12 +5718,12 @@ No Easy-RSA 'vars' configuration file exists."
 	# If a vars file was located then source it
 	else
 		# 'vars' MUST not be a directory
-		[ -d "$vars" ] && die "\
+		[ -d "$vars" ] && user_error "\
 Missing vars file:
 * $vars"
 
 		# 'vars' now MUST exist
-		[ -e "$vars" ] || die "\
+		[ -e "$vars" ] || user_error "\
 Missing vars file:
 * $vars"
 
@@ -5736,7 +5756,7 @@ Please, correct these errors and try again."
 			-e '[[:blank:]]unset[[:blank:]]*' \
 			"$vars"
 		then
-			warn "\
+			user_error "\
 One or more of these problems has been found in your 'vars' file:
 
 * Use of 'export':
@@ -5815,33 +5835,26 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 
 	set_var EASYRSA_MAX_TEMP		4
 
+	# https://github.com/OpenVPN/easy-rsa/issues/1009
 	# expected_pki is set when default 'pki/vars' is used
-	# This blocks pki/vars changing EASYRSA_PKI
-	if [ "$expected_pki" ] # && [ "$require_pki" ]
-	then
-		if [ "$expected_pki" = "$EASYRSA_PKI" ]
-		then
+	# This blocks pki/vars UNEXPECTEDLY changing EASYRSA_PKI
+	if [ "$expected_pki" ]; then
+		if [ "$expected_pki" = "$EASYRSA_PKI" ]; then
 			: # ok
 		else
-			# Show warning
 			user_error "\
-'EASYRSA_PKI' is set incorrectly in the 'vars' file.
+'EASYRSA_PKI' is set incorrectly in the default 'vars' file.
 
-  This vars file:
+  The default pki/vars file:
   * $vars
 
-  Uses this PKI:
+  Uses a different PKI:
   * $EASYRSA_PKI
 
 Cannot continue with invalid configuration."
 		fi
 	fi
 
-	# if the vars file in use is not in the PKI
-	# and not user defined then Show the messages
-	if [ "$require_pki" ]; then
-		vars_in_pki_msg
-	fi
 	verbose "source_vars: COMPLETED"
 } # => source_vars()
 
@@ -5894,7 +5907,7 @@ verify_working_env - install_data_to_pki vars-setup failed"
 			# Last setup msg
 			information "
 Using SSL:
-* $EASYRSA_OPENSSL $ssl_version"
+* $EASYRSA_OPENSSL $ssl_version${NL}"
 
 		else
 			# The directory does not exist
@@ -7226,10 +7239,12 @@ cmd="$1"
 # Establish PKI and CA initialisation requirements
 # This avoids unnecessary warnings and notices
 case "$cmd" in
-	init-pki|clean-all|\
-	help|-h|--help|--usage|\
-	show-host|\
-	version|upgrade|'')
+	version|upgrade|show-host)
+		unset -v require_pki require_ca
+		EASYRSA_NO_VARS=1
+	;;
+	help|-h|--help|--usage|''| \
+	init-pki|clean-all)
 		unset -v require_pki require_ca
 	;;
 	*)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1477,7 +1477,7 @@ install_data_to_pki() {
 	# Short circuit for x509-types-only
 	if [ "$context" = x509-types-only ]; then
 		verbose "\
-install_data_to_pki: $context - COMPLETED"
+install_data_to_pki $context: $EASYRSA_EXT_DIR"
 		return
 	fi
 
@@ -1488,7 +1488,7 @@ install_data_to_pki: $context - COMPLETED"
 		create_vars_example > "$EASYRSA_PKI/vars.example" || \
 			die "install_data_to_pki - create_vars_example FAILED"
 		verbose "\
-install_data_to_pki: $context - create_vars_example OK"
+install_data_to_pki $context: create_vars_example OK"
 	fi
 
 	# Create PKI/vars from PKI/example
@@ -1498,14 +1498,15 @@ install_data_to_pki: $context - create_vars_example OK"
 	then
 		: # ok - Do not make a PKI/vars if another vars exists
 		verbose "\
-install_data_to_pki: $context - Not creating pki/vars"
+install_data_to_pki $context: Not creating pki/vars"
 	else
 		case "$context" in
 		init-pki)
-		# Disable creating a vars file
+		# ALWAYS Disable creating a vars file
 		if :
 		then
-			verbose "install_data_to_pki: New vars DISABLED"
+			verbose "\
+install_data_to_pki $context: New vars DISABLED"
 		else
 			# Only create for 'init-pki', if one does not exist
 			# 'init-pki soft' should have it's own 'vars' file
@@ -1521,11 +1522,11 @@ install_data_to_pki: $context - Not creating pki/vars"
 					new_vars_true=1
 					vars="${EASYRSA_PKI}/${vars_file}"
 					verbose "\
-install_data_to_pki: $context - vars = '$vars'"
+install_data_to_pki $context: vars = '$vars'"
 				else
 					unset -v new_vars_true vars
 					warn "\
-install_data_to_pki: $context - Failed to install vars file"
+install_data_to_pki $context: Failed to install vars file"
 				fi
 			fi
 		fi
@@ -1549,12 +1550,12 @@ install_data_to_pki: $context - Failed to install vars file"
 			"${EASYRSA_PKI}/${ssl_cnf_file}" || die "\
 install_data_to_pki - Missing: '$ssl_cnf_file'"
 		verbose "\
-install_data_to_pki: $context - create_openssl_easyrsa_cnf OK"
+install_data_to_pki $context: create_openssl_easyrsa_cnf OK"
 	fi
 
 	[ -d "$EASYRSA_EXT_DIR" ] || verbose "\
 install_data_to_pki: $context - Missing: '$x509_types_dir'"
-	verbose "install_data_to_pki: $context - COMPLETED"
+	verbose "install_data_to_pki $context: COMPLETED"
 } # => install_data_to_pki ()
 
 # Disable terminal echo, if possible, otherwise warn
@@ -5642,12 +5643,14 @@ The 'vars' file was not found:
 			unset -v prog_in_pwd
 		fi
 
-		# Program dir vars - This location is least wanted.
+		# Program dir vars
 		prog_vars="${prog_dir}/vars"
 
-		# set up PKI path vars - Top preference
+		# set up PKI path vars
+		# Due to EASYRSA_PKI being a usable variable
+		# in the vars file, this is currently NOT a
+		# suitable location for vars
 		pki_vars="${EASYRSA_PKI:-$PWD/pki}/vars"
-		expected_pki_vars="$pki_vars"
 
 		# Some other place vars, out of scope.
 		if [ "$EASYRSA" ]; then
@@ -5656,10 +5659,11 @@ The 'vars' file was not found:
 			unset -v easy_vars
 		fi
 
-		# vars of last resort
+		# Working dir vars
+		# This location is most suitable
 		pwd_vars="$PWD/vars"
 
-		# Clear flags - This is the preferred order to find:
+		# Clear flags
 		unset -v \
 			e_pki_vars e_easy_vars e_pwd_vars e_prog_vars \
 			found_vars vars_in_pki
@@ -5670,10 +5674,10 @@ The 'vars' file was not found:
 		# EASYRSA, if defined:
 		[ -e "$easy_vars" ] && e_easy_vars=1
 
-		# vars of last resort
+		# Working dir:
 		[ -e "$pwd_vars" ] && e_pwd_vars=1
 
-		# program location:
+		# Program location:
 		[ -e "$prog_vars" ] && e_prog_vars=1
 
 		# Filter duplicates
@@ -5712,19 +5716,19 @@ The 'vars' file was not found:
 			[ "$e_prog_vars" ] && print "Found: $prog_vars"
 
 			# For init-pki, version and help, skip this
-			if [ "$require_pki" ]; then
+			#if [ "$require_pki" ]; then
 				user_error "\
-Conflicting 'vars' files found.
-
-Priority should be given to your PKI vars file:
-* $expected_pki_vars"
-			fi
+Conflicting 'vars' files found, see above.
+EasyRSA cannot be used with multiple 'vars' files.
+Either declare which 'vars' file to use with --vars=<FILE>
+or remove the 'vars' files which are not in use."
+			#fi
 
 			# For init-pki, pki/vars will be deleted
 			# However, another vars file exists
 			# so don't create pki/vars
-			no_new_vars=1
-			verbose "vars_setup: no_new_vars = '$no_new_vars'"
+			#no_new_vars=1
+			#verbose "vars_setup: no_new_vars = '$no_new_vars'"
 		esac
 
 		verbose "vars_setup: vars = '$vars'"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1293,14 +1293,6 @@ and initialize a fresh PKI here."
 		# now remove it:
 		case "$reset" in
 		hard)
-			# Promote use of soft init
-#			confirm "Completely remove current PKI ? " yes "\
-#* SECOND WARNING!!!
-#
-#* This will remove everything in your current PKI directory.
-#  To keep your current settings use 'init-pki soft' instead.
-#  Using 'init-pki soft' is recommended."
-
 			# # # shellcheck disable=SC2115 # Use "${var:?}"
 			rm -rf "$EASYRSA_PKI" || \
 				die "init-pki hard reset failed."
@@ -1352,31 +1344,6 @@ Failed to install required data-files to PKI. (init)"
 Your newly created PKI dir is:
 * $EASYRSA_PKI"
 
-	# Installation information
-	# if $no_new_vars then there are one or more known vars
-	# which are not in the PKI
-	if [ "$no_new_vars" ]; then
-		warn "\
-A vars file has not been created in your new PKI because
-conflicting vars files have been found elsewhere."
-		vars_in_pki_msg
-	else
-		information "
-Using Easy-RSA configuration:
-* ${vars:-undefined}"
-	fi
-
-	# For new PKIs , pki/vars was auto-created, show message
-	if [ "$new_vars_true" ]; then
-		information "
-IMPORTANT:
-  Easy-RSA 'vars' template file has been created in your new PKI.
-  Edit this 'vars' file to customise the settings for your PKI.
-  To use a global vars file, use global option --vars=<FILE>"
-
-	else
-		vars_in_pki_msg
-	fi
 	verbose "\
 init_pki: x509-types dir ${EASYRSA_EXT_DIR:-Not found}"
 } # => init_pki()

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5624,26 +5624,7 @@ The 'vars' file was not found:
 	# Otherwise, find vars
 	else
 
-		# set up program path
-		prog_file="$0"
-		prog_dir="${prog_file%/*}"
-		if [ "$prog_dir" = . ] || [ "$prog_dir" = "$PWD" ]
-		then
-			prog_in_pwd=1
-		else
-			unset -v prog_in_pwd
-		fi
-
-		# Program dir vars
-		prog_vars="${prog_dir}/vars"
-
-		# set up PKI path vars
-		# Due to EASYRSA_PKI being a usable variable
-		# in the vars file, this is currently NOT a
-		# suitable location for vars
-		pki_vars="${EASYRSA_PKI:-$PWD/pki}/vars"
-
-		# Some other place vars, out of scope.
+		# User defined EASYRSA vars
 		if [ "$EASYRSA" ]; then
 			easy_vars="${EASYRSA}/vars"
 		else
@@ -5654,13 +5635,28 @@ The 'vars' file was not found:
 		# This location is most suitable
 		pwd_vars="$PWD/vars"
 
+		# Program dir
+		prog_dir="${0%/*}"
+		verbose "vars_setup: prog_dir=$prog_dir"
+
+		# If prog_dir is PWD then do not check prog_vars
+		if [ "$prog_dir" = . ] || [ "$prog_dir" = "$PWD" ]
+		then
+			unset -v prog_vars
+		else
+			prog_vars="${prog_dir}/vars"
+		fi
+
+		# set up PKI path vars
+		# Due to EASYRSA_PKI being a usable variable
+		# in the vars file, this is currently NOT a
+		# suitable location for vars
+		pki_vars="${EASYRSA_PKI:-$PWD/pki}/vars"
+
 		# Clear flags
 		unset -v \
 			e_pki_vars e_easy_vars e_pwd_vars e_prog_vars \
 			found_vars vars_in_pki
-
-		# PKI location, if present:
-		[ -e "$pki_vars" ] && e_pki_vars=1
 
 		# EASYRSA, if defined:
 		[ -e "$easy_vars" ] && e_easy_vars=1
@@ -5671,62 +5667,77 @@ The 'vars' file was not found:
 		# Program location:
 		[ -e "$prog_vars" ] && e_prog_vars=1
 
-		# Filter duplicates
-		if [ "$e_prog_vars" ] && [ "$e_pwd_vars" ] && \
-			[ "$prog_in_pwd" ]
-		then
-			unset -v prog_vars e_prog_vars
-		fi
+		# PKI location, if present:
+		[ -e "$pki_vars" ] && e_pki_vars=1
 
-		# Allow only one vars to be found, No exceptions!
+		# Count found vars files
 		found_vars="$((
 			e_pki_vars + e_easy_vars + e_pwd_vars + e_prog_vars
 			))"
 		verbose "vars_setup: found_vars = '$found_vars'"
 
 		# If found_vars greater than 1
-		# then output user info and exit
+		# then output user info
 		case "$found_vars" in
 		0)
 			: # ok
 		;;
 		1)
-			# If a SINGLE vars file is found
-			# then assign $vars
-			[ "$e_prog_vars" ] && vars="$prog_vars"
-			[ "$e_pwd_vars" ] && vars="$pwd_vars"
-			[ "$e_easy_vars" ] && vars="$easy_vars"
-			[ "$e_pki_vars" ] && \
-				vars="$pki_vars" && vars_in_pki=1
-			: # Wipe error status
+			# If a SINGLE vars file is found then
+			# Select single vars file, with priority
+			if [ "$e_easy_vars" ]; then
+				vars="$easy_vars"
+			elif [ "$e_pwd_vars" ]; then
+				vars="$pwd_vars"
+			elif [ "$e_prog_vars" ]; then
+				vars="$prog_vars"
+			elif [ "$e_pki_vars" ]; then
+				vars="$pki_vars"
+				vars_in_pki=1
+			else
+				# This cannot happen
+				die "Detecting vars file failed!"
+			fi
 		;;
 		*)
-			[ "$e_pki_vars" ] && print "Found: $pki_vars"
-			[ "$e_easy_vars" ] && print "Found: $easy_vars"
-			[ "$e_pwd_vars" ] && print "Found: $pwd_vars"
-			[ "$e_prog_vars" ] && print "Found: $prog_vars"
-
-			# For init-pki, version and help, skip this
-			#if [ "$require_pki" ]; then
-				user_error "\
-Conflicting 'vars' files found, see above.
+			# Multiple vars files
+			warn "\
+Conflicting 'vars' files found, see below.
 EasyRSA cannot be used with multiple 'vars' files.
 Either declare which 'vars' file to use with --vars=<FILE>
-or remove the 'vars' files which are not in use."
-			#fi
+or remove the 'vars' files which are not in use.${NL}"
 
-			# For init-pki, pki/vars will be deleted
-			# However, another vars file exists
-			# so don't create pki/vars
-			#no_new_vars=1
-			#verbose "vars_setup: no_new_vars = '$no_new_vars'"
+			# Show found vars files
+			[ "$e_easy_vars" ] && \
+				print "  easy_vars Found: $easy_vars"
+			[ "$e_pwd_vars" ] && \
+				print "  pwd_vars  Found: $pwd_vars"
+			[ "$e_prog_vars" ] && \
+				print "  prog_vars Found: $prog_vars"
+			[ "$e_pki_vars" ] && \
+				print "  pki_vars  Found: $pki_vars"
+
+			# Select single vars file, with priority
+			if [ "$e_easy_vars" ]; then
+				vars="$easy_vars"
+			elif [ "$e_pwd_vars" ]; then
+				vars="$pwd_vars"
+			elif [ "$e_prog_vars" ]; then
+				vars="$prog_vars"
+			elif [ "$e_pki_vars" ]; then
+				vars="$pki_vars"
+			else
+				# This cannot happen
+				die "Detecting vars file failed!"
+			fi
 		esac
 
-		verbose "vars_setup: vars = '$vars'"
+		# Show selected vars
+		print "  * Selected vars: $vars"
+		[ "$EASYRSA_VERBOSE" ] && print
 
 		# Clean up
-		unset -v prog_vars pwd_vars easy_vars pki_vars \
-				expected_pki_vars
+		unset -v prog_vars pwd_vars easy_vars pki_vars
 	# END: Find vars
 	fi
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5887,22 +5887,16 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 			: # ok
 		else
 			# Show warning
-			warn "\
+			user_error "\
 'EASYRSA_PKI' is set incorrectly in the 'vars' file.
 
   This vars file:
   * $vars
 
   Uses this PKI:
-  * $EASYRSA_PKI"
+  * $EASYRSA_PKI
 
-			# Require user consent to continue
-			confirm "\
-  Continue with invalid configuration ? " yes "
-  'vars' configuration for 'EASYRSA_PKI' is invalid."
-
-			verbose "\
-source_vars: Invalid PKI accepted for EASYRSA_PKI"
+Cannot continue with invalid configuration."
 		fi
 	fi
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -94,9 +94,9 @@ DIRECTORY STATUS (commands would take effect on these locations)
   x509-types: ${EASYRSA_EXT_DIR:-Missing or undefined}
 $CA_status"
 
-	# if the vars file in use is not in the PKI
-	# and not user defined then Show the messages
-	prefer_vars_in_pki_msg
+	# if the vars file in use is in the PKI
+	# and not user defined then Show the message
+	vars_in_pki_msg
 } # => usage()
 
 # Detailed command help
@@ -1308,7 +1308,7 @@ and initialize a fresh PKI here."
 			# If vars was in the old pki, it has been removed
 			# If vars was somewhere else, it is user defined
 			# Clear found_vars, we MUST not find pki/vars
-			[ "$vars_in_pki" ] && unset -v found_vars
+			unset -v vars_in_pki found_vars
 		;;
 		soft)
 		# There is no unit test for a soft reset
@@ -1354,13 +1354,12 @@ Your newly created PKI dir is:
 
 	# Installation information
 	# if $no_new_vars then there are one or more known vars
-	# which are not in the PKI. All further commands will fail
-	# until vars is manually corrected
+	# which are not in the PKI
 	if [ "$no_new_vars" ]; then
 		warn "\
 A vars file has not been created in your new PKI because
 conflicting vars files have been found elsewhere."
-		prefer_vars_in_pki_msg
+		vars_in_pki_msg
 	else
 		information "
 Using Easy-RSA configuration:
@@ -1376,30 +1375,26 @@ IMPORTANT:
   To use a global vars file, use global option --vars=<FILE>"
 
 	else
-		prefer_vars_in_pki_msg
+		vars_in_pki_msg
 	fi
 	verbose "\
 init_pki: x509-types dir ${EASYRSA_EXT_DIR:-Not found}"
 } # => init_pki()
 
 # Must be used in two places, so made it a function
-prefer_vars_in_pki_msg() {
-	if [ "$vars_in_pki" ] || [ "$user_vars_true" ] ||
-		[ "$EASYRSA_NO_VARS" ]
+vars_in_pki_msg() {
+	[ "$vars_in_pki" ] || return 0
+	if [ "$user_vars_true" ] || [ "$EASYRSA_NO_VARS" ]
 	then
 		return
 	fi
 
-	# disable this until v3.2-ish
-	verbose "prefer_vars_in_pki_msg: DISABLED"
-	return 0
-
 	information "
 IMPORTANT:
-  The preferred location for 'vars' is within the PKI folder.
-  To silence this message move your 'vars' file to your PKI
+  Do NOT keep your 'vars' within your PKI directory.
+  To silence this message, move your 'vars' file out of your PKI
   or declare your 'vars' file with option: --vars=<FILE>"
-} # => prefer_vars_in_pki_msg()
+} # => vars_in_pki_msg()
 
 # Copy data-files from various sources
 install_data_to_pki() {
@@ -5661,7 +5656,8 @@ setup_vars() {
 		[ -e "$prog_vars" ] && e_prog_vars=1
 
 		# PKI location, if present:
-		[ -e "$pki_vars" ] && e_pki_vars=1
+		[ -e "$pki_vars" ] && e_pki_vars=1 && \
+			vars_in_pki=1
 
 		# Count found vars files
 		found_vars="$((
@@ -5684,7 +5680,6 @@ setup_vars() {
 				vars="$prog_vars"
 			elif [ "$e_pki_vars" ]; then
 				vars="$pki_vars"
-				vars_in_pki=1
 			else
 				# This cannot happen
 				die "Detecting vars file failed!"
@@ -5713,16 +5708,15 @@ or remove the 'vars' files which are not in use.${NL}"
 				vars="$prog_vars"
 			elif [ "$e_pki_vars" ]; then
 				vars="$pki_vars"
-				vars_in_pki=1
 			else
 				# This cannot happen
 				die "Detecting vars file failed!"
 			fi
-		esac
 
-		# Show selected vars
-		print "  * Selected vars: $vars"
-		[ "$EASYRSA_VERBOSE" ] && print
+			# Show selected vars
+			print "  * Selected vars: $vars"
+			[ "$EASYRSA_VERBOSE" ] && print
+		esac
 
 		# Clean up
 		unset -v prog_vars pwd_vars easy_vars pki_vars
@@ -5872,7 +5866,7 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 	# if the vars file in use is not in the PKI
 	# and not user defined then Show the messages
 	if [ "$require_pki" ]; then
-		prefer_vars_in_pki_msg
+		vars_in_pki_msg
 	fi
 	verbose "source_vars: COMPLETED"
 } # => source_vars()

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1455,9 +1455,9 @@ install_data_to_pki() {
 				EASYRSA_EXT_DIR "${area}/${x509_types_dir}"
 
 			# Find other files - Omitting "$vars_file"
+			# shellcheck disable=SC2066 # loop will only run once
 			for source in \
-				"$vars_file_example" \
-				"$ssl_cnf_file" \
+				"$ssl_cnf_file"
 				# EOL
 			do
 				# Find each item
@@ -1479,16 +1479,6 @@ install_data_to_pki() {
 		verbose "\
 install_data_to_pki $context: $EASYRSA_EXT_DIR"
 		return
-	fi
-
-	# Always require a pki/vars.example file
-	if [ -e "$EASYRSA_PKI/vars.example" ];then
-		: # ok
-	else
-		create_vars_example > "$EASYRSA_PKI/vars.example" || \
-			die "install_data_to_pki - create_vars_example FAILED"
-		verbose "\
-install_data_to_pki $context: create_vars_example OK"
 	fi
 
 	# Create PKI/vars from PKI/example

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -607,7 +607,8 @@ EasyRSA version $EASYRSA_version
 Error
 -----
 $1"
-	exit 1
+	easyrsa_exit_with_error=1
+	cleanup
 } # => user_error()
 
 # verbose information
@@ -5604,7 +5605,7 @@ setup_vars() {
 			e_pki_vars=1
 			vars_in_pki=1
 
-			# Conflicting vars:
+			# Conflicting default pki/vars:
 			if [ "$e_pwd_vars" ] || [ "$e_prog_vars" ]
 			then
 				user_error "\
@@ -5702,7 +5703,7 @@ source_vars() {
 	# If PKI is not required then located vars files are
 	# not required
 	if [ "$EASYRSA_NO_VARS" ]; then
-		: # ok
+		verbose "source_vars: Explicit NO vars"
 
 	# $vars remains undefined .. no vars found
 	# 'install_data_to_pki vars-setup' will NOT
@@ -5712,7 +5713,7 @@ source_vars() {
 		# For init-pki, version and help, skip this
 		if [ "$require_pki" ]; then
 			information "\
-No Easy-RSA 'vars' configuration file exists."
+No Easy-RSA 'vars' configuration file exists.${NL}"
 		fi
 
 	# If a vars file was located then source it
@@ -5730,7 +5731,19 @@ Missing vars file:
 		# Show the vars file in use
 		[ "$require_pki" ] && information "\
 Using Easy-RSA 'vars' configuration:
-* $vars"
+* $vars${NL}"
+
+		# Setup: catch vars file changing PKI unexpectedly
+		if [ "$EASYRSA_PKI" ]; then
+			expected_pki="${expected_pki:-"$EASYRSA_PKI"}"
+		elif [ "$EASYRSA" ]; then
+			expected_pki="${expected_pki:-"$EASYRSA/pki"}"
+		elif [ "$user_vars_true" ]; then
+			expected_pki=
+		else
+			expected_pki="${expected_pki:-"$PWD/pki"}"
+		fi
+		verbose "source_vars: expected_pki=$expected_pki"
 
 		# Sanitize vars
 		if grep -q \
@@ -5772,29 +5785,25 @@ Remove 'unset' ('force_set_var' may also work)."
 
 		# Test sourcing 'vars' in a subshell
 		# shellcheck disable=1090 # can't follow .. vars
-		( . "$vars" ) || \
-			die "Failed to source the vars file."
+		if ( . "$vars" ); then
+			: # ok
+		else
+			if [ "$vars" = "${vars%/*}" ]; then
+				user_error "\
+Failed to source the vars file: '$vars'
+Perhaps you need to specify the PATH. eg: './$vars'"
+			else
+				die "\
+Failed to source the vars file: '$vars'
+The error above may have more information."
+			fi
+		fi
 
 		# Source 'vars' now
 		# shellcheck disable=1090 # can't follow .. vars
-		. "$vars" 2>/dev/null
+		. "$vars"
 		unset -v EASYRSA_CALLER
 	fi
-
-	# Set expected PKI to determine if vars has changed PKI
-	# Required for init-pki
-	case "$cmd" in
-		init-pki|clean-all)
-			if [ "$EASYRSA_PKI" ]; then
-				expected_pki="${expected_pki:-"$EASYRSA_PKI"}"
-			elif [ "$EASYRSA" ]; then
-				expected_pki="${expected_pki:-"$EASYRSA/pki"}"
-			else
-				expected_pki="${expected_pki:-"$PWD/pki"}"
-			fi
-		;;
-		*) : # ok
-	esac
 
 	# Set defaults, preferring existing env-vars if present
 	set_var EASYRSA					"$PWD"
@@ -5855,7 +5864,7 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 	# This blocks pki/vars UNEXPECTEDLY changing EASYRSA_PKI
 	if [ "$expected_pki" ]; then
 		if [ "$expected_pki" = "$EASYRSA_PKI" ]; then
-			: # ok
+			verbose "source_vars: expected_pki OK"
 		else
 			user_error "\
 'EASYRSA_PKI' is set incorrectly in the default 'vars' file.
@@ -5866,8 +5875,13 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
   Uses a different PKI:
   * $EASYRSA_PKI
 
+  Expected PKI to be:
+  * $expected_pki
+
 Cannot continue with invalid configuration."
 		fi
+	else
+		verbose "source_vars: expected_pki NOT defined"
 	fi
 
 	verbose "source_vars: COMPLETED"
@@ -5920,7 +5934,8 @@ verify_working_env - install_data_to_pki vars-setup failed"
 			fi
 
 			# Last setup msg
-			information "
+			[ "$EASYRSA_VERBOSE" ] && print
+			information "\
 Using SSL:
 * $EASYRSA_OPENSSL $ssl_version${NL}"
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5748,6 +5748,11 @@ No Easy-RSA 'vars' configuration file exists."
 
 	# If a vars file was located then source it
 	else
+		# 'vars' MUST not be a directory
+		[ -d "$vars" ] && die "\
+Missing vars file:
+* $vars"
+
 		# 'vars' now MUST exist
 		[ -e "$vars" ] || die "\
 Missing vars file:

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1385,8 +1385,6 @@ install_data_to_pki() {
 	shift
 
 	# Set required sources
-	vars_file='vars'
-	vars_file_example='vars.example'
 	ssl_cnf_file='openssl-easyrsa.cnf'
 	x509_types_dir='x509-types'
 
@@ -1461,35 +1459,7 @@ install_data_to_pki $context: Not creating pki/vars"
 	else
 		case "$context" in
 		init-pki)
-		# ALWAYS Disable creating a vars file
-		if :
-		then
-			verbose "\
-install_data_to_pki $context: New vars DISABLED"
-		else
-			# Only create for 'init-pki', if one does not exist
-			# 'init-pki soft' should have it's own 'vars' file
-			if [ -e "${EASYRSA_PKI}/${vars_file_example}" ] && \
-				[ ! -e "${EASYRSA_PKI}/${vars_file}" ]
-			then
-				# Failure means that no vars will exist and
-				# 'cp' will generate an error message
-				# This is not a fatal error
-				if cp "${EASYRSA_PKI}/${vars_file_example}" \
-					"${EASYRSA_PKI}/${vars_file}"
-				then
-					new_vars_true=1
-					vars="${EASYRSA_PKI}/${vars_file}"
-					verbose "\
-install_data_to_pki $context: vars = '$vars'"
-				else
-					unset -v new_vars_true vars
-					warn "\
-install_data_to_pki $context: Failed to install vars file"
-				fi
-			fi
-		fi
-		;;
+			: ;; # No change to current 'vars' required
 		vars-setup)
 			: ;; # No change to current 'vars' required
 		x509-types-only)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5781,6 +5781,15 @@ Remove 'unset' ('force_set_var' may also work)."
 		unset -v EASYRSA_CALLER
 	fi
 
+	# Set expected PKI to determine if vars has changed PKI
+	# Required for init-pki
+	case "$cmd" in
+		init-pki|clean-all)
+			expected_pki="${expected_pki:-"$PWD/pki"}"
+		;;
+		*) : # ok
+	esac
+
 	# Set defaults, preferring existing env-vars if present
 	set_var EASYRSA					"$PWD"
 	set_var EASYRSA_OPENSSL			openssl


### PR DESCRIPTION
This patch set completes the following:

1
4cb05fe
* **Disable prefer_vars_in_pki_msg().**
  No other changes.

2
2e5865a
* **install_data_to_pki: Disable creating new vars file.**
  Stop 'init-pki' creating a new vars file inside the new PKI.
  Disable confirmation advising user to use 'init-pki soft'
  ('init-pki soft' is no longer useful and will be removed)

3
f18c9a0
* **Disable creating a vars file and only allow one vars file to exist**
  Completely disable creating any vars file
  If more than one vars file exists is a fatal error
  (Changed from FATAL to WARNING in b19beb2 below)

4
d05a89e
* **Never create a pki/vars.example file**

5
8d55b9f
* **Update ChangeLog: Disable code which requests vars be moved to the PKI**

6
53f443c
* **vars_setup: Downgrade warning to info for "no vars file exists"**

7
3b4ac2e
* **install_data_to_pki: Correct error message "text" only**

8
b19beb2
* **vars_setup: Multiple vars files, downgrade FATAL error to WARNING**
  Finding multiple vars files will result in a WARNING instead of a
  FATAL error, then a vars file is selected.

9
1c0228b
* **vars_setup: Prioritise pre-defined EASYRSA/vars over standard search**
  EASYRSA can only be set by the user so prioritise "$EASYRSA/vars"

10
b75c8b0
* **vars_setup: Prohibit specifying vars as a directory. eg: ./**

11
4a80b21
* **vars_setup: Split into setup_vars() and source_vars()**

12
b9914c6
* **Repurpose prefer_vars_in_pki_msg() to "warn against vars in PKI"**

13
92a6341
* **Add explicit confirmation for default 'pki/vars' setting a different PKI**
  (Possible bug (Fix) caused by moving vars to the PKI)

14
a68edb3
* **Update ChangeLog: Retract "preference for vars in the PKI"**

15
bb1adae
* **Change to FATAL error when default 'pki/vars' sets a different PKI**
  (Changes 13 92a6341 above)

16
fab09e6
* **init-pki: Remove unnecessary user information concerning vars**

17
0e53ae1
* **install_data_to_pki() init-pki: Remove code to create a 'pki/vars' file**

18
6f88df3
* **Insert required errors and warning to control vars location**

19
d2c25de
* **Forbid 'pki/vars' setting PKI for command 'init-pki'**

20
dc15f35
* **'init-pki', prioritise USER set EASYRSA_PKI and EASYRSA**

21
0c8fd82
* **Move "Setup: catch vars file changing PKI unexpectedly"**
  Prioritise command line options above 'vars' file assignments