### PR TITLE
gen-crl: preserve existing crl.pem ownership+mode

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3721,6 +3721,11 @@ gen_crl() {
 	easyrsa_mktemp out_file_tmp || \
 		die "gen_crl - easyrsa_mktemp out_file_tmp"
 
+	if [ -r "$out_file" ]; then 
+		cp -p "$out_file" "$out_file_tmp" || \
+			warn "Failed to copy existing crl.pem - won't preserve file permissions."
+	fi
+
 	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" \
 		${EASYRSA_CRL_DAYS:+ -days "$EASYRSA_CRL_DAYS"} \
 		${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} || \


### PR DESCRIPTION
When updating a revocation list, the crl.pem file is recreated and its ownership and mode set to user:group/0600.
This is a side effect of doing atomic file operations. OpenSSL changes only file contents, not metadata.

This change preserves ownership and mode of an existing crl.pem in a posix compatible way.

Specifically intended for use cases where openvpn --crl-verify is pointing directly to the PKI's crl.pem file and it needs different permissions for OpenVPN to read it.
In principle, it just fixes unexpected behaviour of easyrsa meddling with metadata.