### PR TITLE
show-expire: Calculate certificate expire seconds from Database date

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
-   * Forbid "default vars in the default PKI" for all commands #1021
+   * show-expire: Calculate cert. expire seconds from DB date (#1023)
+   * Forbid "default vars in the default PKI" for all commands (#1021)
      There can be only one default vars file, that is now './vars' ONLY.
      Use of other 'vars' files can be done by using option --vars=<FILE>
    * Update OpenSSL to 3.1.2

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4834,6 +4834,7 @@ db_date_to_iso_8601_date - input error"
 
 	# Assign iso_8601 date
 	out_date="${yyyy}-${mm}-${dd} ${HH}:${MM}:${SS}${TZ}"
+	verbose "db_date_to_iso_8601_date: out_date=$out_date"
 
 	# Return out_date
 	force_set_var "$2" "$out_date" || die "\
@@ -5086,10 +5087,14 @@ expire_status: FALL-BACK completed"
 
 	else
 		verbose "expire_status: cert does NOT exist"
-		# Translate db date to usable date
+		# Translate db date to 8601_date
 		cert_not_after_date=
 		db_date_to_iso_8601_date \
 			"$db_notAfter" cert_not_after_date
+
+		# Translate 8601_date to time-stamp-seconds
+		iso_8601_timestamp_to_seconds \
+			"$cert_not_after_date" cert_expire_date_s
 		# Cert does not exist
 	fi
 


### PR DESCRIPTION
When a certificate CN is not the same as the file-name then show-expire must calculate the expiry date, in seconds, from the database field.

This is done by functions:
* db_date_to_iso_8601_date() Translate from database format to ISO_8601 date format.
* iso_8601_timestamp_to_seconds() Translate from ISO_86012 date format to time-stamp in seconds.