### PR TITLE
`v3.2.0-beta2`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,7 @@ Easy-RSA 3 ChangeLog
    PENDING: Branch-merge: v3.2.0-beta2 (#1055)
    * Always use here-doc version of openssl-easyrsa.cnf (2a8c0de)
      Only use here-doc if the current version is recognised by sha256 hash.
+     This will DELETE any default version of openssl-easyrsa.cnf
    * export-p12: New command option 'legacy'. OpenSSL V3 Only (f8514de)
      Fallback to encryption algorithm RC2_CBC or 3DES_CBC
    * export-p12: Always set 'friendlyName' to file-name-base (da9e594)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,9 +3,10 @@ Easy-RSA 3 ChangeLog
 3.2.0 (TBD)
 
    PENDING: Branch-merge: v3.2.0-beta2 (#1055)
-   * export-p12: New command option 'legacy'
+   * export-p12: New command option 'legacy'. OpenSSL V3 Only (f8514de)
+     Fallback to encryption algorithm RC2_CBC or 3DES_CBC
    * export-p12: Always set 'friendlyName' to file-name-base (da9e594)
-   * Update OpenSSL to 3.2.0
+   * Update OpenSSL to 3.2.0 (03e4829)
 
    Branch-merge: v3.2.0-beta1 (#1046) 2023/12/15 Commit: 7120876
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,26 +1,38 @@
 Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
-   * Rename X509-type file `code-signing` to `codeSigning` (Part of #1046)
-     The original file will be retained as `code-signing`, however, the automatic
-     X509-types creation will name the file `codeSigning`. This effectively means
-     that both are valid X509-types, until `code-signing` is dropped.
+
+   PENDING: Branch-merge: v3.2.0-beta2 (#1055)
+   * export-p12: Always set 'friendlyName' to file-name-base (da9e594)
+   * Update OpenSSL to 3.2.0
+
+   Branch-merge: v3.2.0-beta1 (#1046) 2023/12/15 Commit: 7120876
+
    * Important note: As of Easy-RSA version 3.2.0-beta1, the configuration files
      `vars.example`, `openssl-eayrsa.cnf` and all files in `x509-types` directory
      are no longer required. Package maintainers can omit these files in the future.
      All files are created as required and deleted upon command completion.
-     `vars.example` is created during `init-pki` and placed in the fresh PKI. 66a8f3e
+     `vars.example` is created during `init-pki` and placed in the fresh PKI.
      These files will be retained for downstream packaging compatibility.
-   * New command 'write': Write 'legacy' files to stdout or files (#1046) c814e0a
-   * New Command 'rand': Expose easyrsa_random() to the command line (#1046) 6131cbf
-   * Remove function 'set_pass_legacy()' (#1045)
-   * Remove command 'rewind-renew' (#1045)
-   * Remove command 'rebuild' (#1045)
-   * Remove command 'upgrade' (#1045)
-   * Remove EASYRSA_NO_VARS; Allow graceful use without a vars file (#1043)
+
+   * Rename X509-type file `code-signing` to `codeSigning` (1c6b31a)
+     The original file will be retained as `code-signing`, however, the automatic
+     X509-types creation will name the file `codeSigning`. This effectively means
+     that both are valid X509-types, until `code-signing` is dropped.
+   * init-pki: Always write vars.example file to fresh PKI (66a8f3e)
+   * New command 'write': Write 'legacy' files to stdout or files (c814e0a)
+   * New Command 'rand': Expose easyrsa_random() to the command line (6131cbf)
+   * Remove function 'set_pass_legacy()' (7470c2a)
+   * Remove command 'rewind-renew' (72b4079)
+   * Remove command 'rebuild' (d6953cc)
+   * Remove command 'upgrade' (6a88edd)
+
+   Branch-merge: v3.2.0-alpha2 (#1043) 2023/12/7 Commit: ed0dc46
+   * Remove EASYRSA_NO_VARS; Allow graceful use without a vars file (3c0ca17)
+
+   Branch-merge: v3.2.0-alpha1 (#1041) 2023/12/2 Commit: 42c2e95
    * New diagnostic command 'display-cn' (#1040)
    * Expand renewable certificate types to include code-signing (#1039)
-   * Update OpenSSL to 3.2.0
 
 3.1.7 (2023-10-13)
    * Rewrite vars-auto-detect, adhere to EasyRSA-Advanced.md (#1029)

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,7 +5,7 @@ Easy-RSA 3 ChangeLog
    PENDING: Branch-merge: v3.2.0-beta2 (#1055)
    * Always use here-doc version of openssl-easyrsa.cnf (2a8c0de)
      Only use here-doc if the current version is recognised by sha256 hash.
-     This will DELETE any default version of openssl-easyrsa.cnf
+     The current file is NEVER deleted (60216d5). Partially revert: 2a8c0de
    * export-p12: New command option 'legacy'. OpenSSL V3 Only (f8514de)
      Fallback to encryption algorithm RC2_CBC or 3DES_CBC
    * export-p12: Always set 'friendlyName' to file-name-base (da9e594)

--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@ Easy-RSA 3 ChangeLog
      that both are valid X509-types, until `code-signing` is dropped.
    * init-pki: Always write vars.example file to fresh PKI (66a8f3e)
    * New command 'write': Write 'legacy' files to stdout or files (c814e0a)
+   * Remove command 'make-safe-ssl': Replaced by command 'write safe-cnf' (c814e0a)
    * New Command 'rand': Expose easyrsa_random() to the command line (6131cbf)
    * Remove function 'set_pass_legacy()' (7470c2a)
    * Remove command 'rewind-renew' (72b4079)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,8 @@ Easy-RSA 3 ChangeLog
 3.2.0 (TBD)
 
    PENDING: Branch-merge: v3.2.0-beta2 (#1055)
+   * Always use here-doc version of openssl-easyrsa.cnf (2a8c0de)
+     Only use here-doc if the current version is recognised by sha256 hash.
    * export-p12: New command option 'legacy'. OpenSSL V3 Only (f8514de)
      Fallback to encryption algorithm RC2_CBC or 3DES_CBC
    * export-p12: Always set 'friendlyName' to file-name-base (da9e594)

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Easy-RSA 3 ChangeLog
 3.2.0 (TBD)
 
    PENDING: Branch-merge: v3.2.0-beta2 (#1055)
+   * export-p12: New command option 'legacy'
    * export-p12: Always set 'friendlyName' to file-name-base (da9e594)
    * Update OpenSSL to 3.2.0
 

--- a/README.md
+++ b/README.md
@@ -37,21 +37,29 @@ is recommended to use a release, and priority will be given to bugs identified i
 the most recent release.
 
 The prior 2.x and 1.x versions are available as release branches for
-tracking and possible back-porting of relevant fixes. Branch layout is:
+tracking and possible back-porting of relevant fixes.
 
-    master         <- v3.2.x - Rolling
-    v3.n.n-<NAME>     Pre-release branches, used for staging.
-    3.1.8             Present: bugfix/security/openssl updates for v3.1.7
-    3.0.10            Absent: bugfix/security/openssl updates for v3.0.9
-    v3.0.6            Archived: Has known bugs, OpenSSL v3 incompatible.
-    v3.0.5            Archived: Has known bugs, OpenSSL v3 incompatible.
-    v3.0.4            Archived: Has known bugs, OpenSSL v3 incompatible.
-    release/3.0       Archived: Pending deprecation to unmaintained.
-    release/2.x       Archived: Unmaintained.
-    release/1.x       Archived: Unmaintained.
-    testing           Sandbox only; Subject to change, without warning.
+Branch layout is:
+
+    master             <- Active: v3.2.x - Rolling.
+    v3.<N>.<N>-<LABEL>    Active: Development branches.
+    testing               Sandbox: Subject to change without notice.
+    v3.1.8                Sunset: Bugfix only for v3.1.7
+
+    The following are NOT compatible with OpenSSL version 3:
+
+    v3.0.6                Inactive: Archived.
+    v3.0.5                Inactive: Archived.
+    v3.0.4                Inactive: Archived.
+    release/3.0           Inactive: Archived.
+    release/2.x           Inactive: Archived.
+    release/1.x           Inactive: Unmaintained.
 
 LICENSING info for 3.x is in the [COPYING.md](COPYING.md) file
+
+## Contributing
+
+Please refer to: [doc/EasyRSA-Contributing.md](doc/EasyRSA-Contributing.md)
 
 # Code style, standards
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3187,7 +3187,7 @@ gen_crl() {
 	fi
 
 	easyrsa_openssl ca -utf8 -gencrl -out "$out_file_tmp" \
-		${EASYRSA_CRL_DAYS:+ -days "$EASYRSA_CRL_DAYS"} \
+		${EASYRSA_CRL_DAYS:+ -crldays "$EASYRSA_CRL_DAYS"} \
 		${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} || \
 			die "CRL Generation failed."
 
@@ -5801,8 +5801,14 @@ x509_extensions	= basic_exts		# The extensions to add to the cert
 # is designed for will. In return, we get the Issuer attached to CRLs.
 crl_extensions	= crl_ext
 
+# These fields are always configured via the command line.
+# These fields are removed from this here-doc but retained
+# in 'openssl-easyrsa.cnf' file, in case something breaks.
+# default_days is no longer required by Easy-RSA
 default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
-default_crl_days	= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
+# default_crl_days is no longer required by Easy-RSA
+#default_crl_days	= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
+
 default_md	= $ENV::EASYRSA_DIGEST		# use public key default MD
 preserve	= no			# keep passed DN ordering
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5445,13 +5445,28 @@ write_easyrsa_ssl_cnf_tmp() {
 		verbose "write_easyrsa_ssl_cnf_tmp: SSL config EXISTS"
 
 		# Set known hashes
-		# openssl-easyrsa.cnf sha256 hash - v3.2.x
-		known_hash_file="\
+		# 3.1.7 -> Current
+		known_file_317="\
 13ca05f031d58c5e2912652b33099ce9\
 ac05f49595e5d5fe96367229e3ce070c"
 
-		# Built-in here-doc v3.2.0-1
-		known_hash_heredoc_1="\
+		# 3.1.5 -> 3.1.6
+		known_file_315="\
+87d51ca0db1cc0ac3cc2634792fc5576\
+e0034ebf9d546de11674b897514f3afb"
+
+		# 3.1.0 -> 3.1.4
+		known_file_310="\
+5455947df40f01f845bf79c1e89f102c\
+628faaa65d71a6512d0e17bdd183feb0"
+
+		# 3.0.8 -> 3.0.9
+		known_file_308="\
+1cc6a1de93ca357b5c364aa0fa2c4bea\
+f97425686fa1976d436fa31f550641aa"
+
+		# Built-in here-doc 3.2.0
+		known_heredoc_320="\
 82439f1860838e28f6270d5d06b17717\
 56db777861e19bf9edc21222f86a310d"
 
@@ -5459,32 +5474,47 @@ ac05f49595e5d5fe96367229e3ce070c"
 		file_hash="$(
 			OPENSSL_CONF=/dev/null
 			"$EASYRSA_OPENSSL" dgst -sha256 -r "$EASYRSA_SSL_CONF"
-		)" || die "hash malfunction!"
+		)" || warn "hash malfunction!"
 
 		# Strip excess SSL info
 		file_hash="${file_hash%% *}"
 
 		# Compare SSL output
 		case "$file_hash" in
-		*[!1234567890abcdef]*)
-			die "hash failure: $file_hash"
+		*[!1234567890abcdef]*|'')
+			warn "hash failure: $file_hash"
 		esac
 
 		# Check file hash against known hash
-		case "$file_hash" in
-		"$known_hash_file") ;;
-		"$known_hash_heredoc_1") ;;
-		*)
-			# File has been changed, leave in place
-			unset -v file_hash known_hash_file known_hash_heredoc_1
-			verbose "write_easyrsa_ssl_cnf_tmp: SSL config NO CHANGE!"
+		hash_is_unknown=""
 
-			# Use the existing and changed file ONLY
-			return 0
+		case "$file_hash" in
+		"$known_file_317") ;;
+		"$known_file_315") ;;
+		"$known_file_310") ;;
+		"$known_file_308") ;;
+		"$known_heredoc_320") ;;
+
+		*)
+			# File is unknown or has been changed, leave in place
+			hash_is_unknown=1
 		esac
 
-		# Ignore this file, prefer to use a temp-file
-		unset -v file_hash known_hash_file known_hash_heredoc_1
+		# Cleanup
+		unset -v file_hash  known_heredoc_320 \
+				known_file_317 \
+				known_file_315 \
+				known_file_310 \
+				known_file_308
+
+		# Use the existing file ONLY
+		if [ "$hash_is_unknown" ]; then
+			unset -v hash_is_unknown
+			verbose "write_easyrsa_ssl_cnf_tmp: SSL config NO CHANGE!"
+			return 0
+		fi
+
+		# Ignore existing file, prefer to use a temp-file
 		verbose "write_easyrsa_ssl_cnf_tmp: SSL config IGNORED"
 	fi
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5346,6 +5346,7 @@ ${unexpected_error}"
 
 # Verify working environment
 verify_working_env() {
+	verbose "verify_working_env: BEGIN"
 	# For commands which 'require a PKI' and PKI exists
 	if  [ "$require_pki" ]; then
 		# Verify PKI is initialised
@@ -5354,6 +5355,7 @@ verify_working_env() {
 		# Temp dir session and default SSL conf file
 		if [ -z "$secured_session" ]; then
 			secure_session
+
 			# Verify or create temp EASYRSA_SSL_CONF
 			write_easyrsa_ssl_cnf_tmp
 		fi
@@ -5364,6 +5366,20 @@ verify_working_env() {
 		# Verify CA is initialised
 		if [ "$require_ca" ]; then
 			verify_ca_init
+		fi
+	else
+		# For commands that do not require a PKI
+		# but do require a temp-dir, eg. 'write'
+		# If there is a valid temp-dir:
+		# Create temp-session and openssl-easyrsa.cnf (Temp) now
+		if [ -d "$EASYRSA_TEMP_DIR" ]; then
+			# Temp dir session and default SSL conf file
+			if [ -z "$secured_session" ]; then
+				secure_session
+
+				# Verify or create: EASYRSA_SSL_CONF
+				write_easyrsa_ssl_cnf_tmp
+			fi
 		fi
 	fi
 	verbose "verify_working_env: COMPLETED Handover-to: $cmd"
@@ -5559,7 +5575,7 @@ write() {
 		fi
 	;;
 	*)
-		user_error "write - unknown type '$type'"
+		user_error "write - unknown type '$write_type'"
 	esac
 
 	# Check for output directory and file-name
@@ -6313,21 +6329,6 @@ locate_support_files
 # Verify SSL Lib - One time ONLY
 verify_ssl_lib
 
-# If there is a valid temp-dir:
-if [ "$require_pki" ]; then
-	# taken care of later by verify_working_env()
-	:
-else
-	# Create temp-session and openssl-easyrsa.cnf (Temp) now
-	if [ -d "$EASYRSA_TEMP_DIR" ]; then
-		# Temp dir session and default SSL conf file
-		secure_session
-
-		# Verify or create: EASYRSA_SSL_CONF
-		write_easyrsa_ssl_cnf_tmp
-	fi
-fi
-
 # Check $working_safe_ssl_conf, to build
 # a fully configured safe ssl conf, on the
 # next invocation of easyrsa_openssl()
@@ -6476,7 +6477,7 @@ case "$cmd" in
 			easyrsa_exit_with_error=1
 		;;
 	write)
-		# verify_working_env - Not required
+		verify_working_env
 		# Write legacy files to write_dir
 		# or EASYRSA_PKI or EASYRSA
 		case "$1" in

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5117,11 +5117,8 @@ select_vars() {
 		fi
 	fi
 
-	# User info
+	# if select_vars failed to find a vars file
 	if [ -z "$EASYRSA_VARS_FILE" ]; then
-		[ "$require_pki" ] && information "\
-No Easy-RSA 'vars' configuration file exists!"
-		# select_vars failed to find a vars file
 		verbose "select_vars: No vars"
 		return 1
 	fi
@@ -5140,11 +5137,6 @@ Missing vars file:
 	# 'vars' now MUST exist
 	[ -e "$target_file" ] || user_error "\
 Missing vars file:
-* $target_file"
-
-	# Installation information
-	[ "$require_pki" ] && information "\
-Using Easy-RSA 'vars' configuration:
 * $target_file"
 
 	# Sanitize vars
@@ -6219,11 +6211,41 @@ done
 cmd="$1"
 [ "$1" ] && shift # scrape off command
 
+# Establish PKI and CA initialisation requirements
+unset -v require_pki require_ca ignore_vars
+case "$cmd" in
+	''|help|-h|--help|--usage| \
+	version|show-host|rand|random)
+		ignore_vars=1
+	;;
+	init-pki|clean-all)
+		: # No change
+	;;
+	*)
+		require_pki=1
+		case "$cmd" in
+			gen-req|gen-dh|build-ca|show-req| \
+			make-safe-ssl|export-p*|inline|write)
+				: # No change
+			;;
+			*)
+				require_ca=1
+		esac
+esac
+
 # Intelligent env-var detection and auto-loading:
 # Select vars file as EASYRSA_VARS_FILE
 # then source the vars file, if found
 # otherwise, ignore no vars file
-select_vars && source_vars "$EASYRSA_VARS_FILE"
+if select_vars; then
+	information "\
+Using Easy-RSA 'vars' configuration:
+* $target_file"
+	source_vars "$EASYRSA_VARS_FILE"
+else
+	verbose "\
+No Easy-RSA 'vars' configuration file exists!"
+fi
 
 # then set defaults
 default_vars
@@ -6249,30 +6271,6 @@ verify_ssl_lib
 if [ "$working_safe_ssl_conf" ]; then
 	die "working_safe_ssl_conf must not be set!"
 fi
-
-# Establish PKI and CA initialisation requirements
-# This avoids unnecessary warnings and notices
-# Used by verify_working_env()
-unset -v require_pki require_ca ignore_vars
-case "$cmd" in
-	''|help|-h|--help|--usage| \
-	version|show-host|rand|random)
-		ignore_vars=1
-	;;
-	init-pki|clean-all)
-		: # No change
-	;;
-	*)
-		require_pki=1
-		case "$cmd" in
-			gen-req|gen-dh|build-ca|show-req| \
-			make-safe-ssl|export-p*|inline|write)
-				: # No change
-			;;
-			*)
-				require_ca=1
-		esac
-esac
 
 # Hand off to the function responsible
 # ONLY verify_working_env() for valid commands

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -337,7 +337,8 @@ cmd_help() {
       * nokey   - Do not include the private key in the PKCS12 output
       * nofn    - Do not set 'freindlyName'
                   For more, see: 'easyrsa help friendly'
-      * legacy  - Use legacy mode of operation"
+      * legacy  - Use legacy encryption algorithm RC2_CBC or 3DES_CBC
+                  OpenSSL V3 ONLY: Default algorithm is AES-256-CBC"
 	;;
 	friendly)
 		text_only=1
@@ -3285,6 +3286,8 @@ Run easyrsa without commands for usage and command help."
 				unset friendly_name
 			;;
 			legacy)
+				[ "$openssl_v3" ] || \
+					user_error "Option 'legacy' requires SSL version 3"
 				legacy=-legacy
 			;;
 			*)
@@ -3400,6 +3403,9 @@ Missing User Certificate, expected at:
 	case "$pkcs_type" in
 	p12)
 		pkcs_out="$EASYRSA_PKI/private/$file_name_base.p12"
+
+		[ "$legacy" ] && \
+			error_info="SSL library may not support -legacy mode"
 
 		# export the p12:
 		easyrsa_openssl pkcs12 -export \

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3238,11 +3238,15 @@ Run easyrsa without commands for usage and command help."
 	key_in="$EASYRSA_PKI/private/$file_name_base.key"
 	crt_ca="$EASYRSA_PKI/ca.crt"
 
+	# Always set a friendly_name
+	set_var EASYRSA_P12_FR_NAME "$file_name_base"
+	friendly_name="$EASYRSA_P12_FR_NAME"
+
 	# opts support
 	cipher=-aes256
 	want_ca=1
 	want_key=1
-	unset -v nokeys friendly_name
+	unset -v nokeys
 	while [ "$1" ]; do
 		case "$1" in
 			noca)
@@ -3258,10 +3262,11 @@ Run easyrsa without commands for usage and command help."
 			nopass)
 				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
 			;;
-			usefn)
-				friendly_name="$file_name_base"
+			nofn)
+				unset friendly_name
 			;;
-			*) warn "Ignoring unknown command option: '$1'"
+			*)
+				warn "Ignoring unknown option: '$1'"
 		esac
 		shift
 	done
@@ -3378,10 +3383,10 @@ Missing User Certificate, expected at:
 		easyrsa_openssl pkcs12 -export \
 			-in "$crt_in" \
 			-out "$pkcs_out" \
-			${nokeys} \
 			-inkey "$key_in" \
-			${want_ca:+ -certfile "$crt_ca"} \
+			${nokeys} \
 			${friendly_name:+ -name "$friendly_name"} \
+			${want_ca:+ -certfile "$crt_ca"} \
 			${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
 			${EASYRSA_PASSOUT:+ -passout "$EASYRSA_PASSOUT"} \
 				|| die "Failed to export PKCS#12"
@@ -6111,6 +6116,9 @@ while :; do
 		export EASYRSA_EXTRA_EXTS="\
 $EASYRSA_EXTRA_EXTS
 subjectAltName = $val"
+		;;
+	--usefn)
+		export EASYRSA_P12_FR_NAME="$val"
 		;;
 	--version)
 		shift "$#"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2766,8 +2766,15 @@ Run easyrsa without commands for usage and command help."
 	inline_in="$in_dir/inline/${file_name_base}.inline"
 
 	# Upgrade CA index.txt.attr - unique_subject = no
-	ca_unique_subject_no || \
-		die "Failed to upgrade CA to support renewal."
+	if grep -q 'unique_subject = no' \
+		"$EASYRSA_PKI/index.txt.attr"
+	then
+		: # ok
+	else
+		printf '%s\n' 'unique_subject = no' \
+			> "$EASYRSA_PKI/index.txt.attr" || \
+				die "Incompatible CA configuration"
+	fi
 
 	# deprecate ALL options
 	while [ "$1" ]; do
@@ -2996,29 +3003,6 @@ Failed to remove inline file:
 
 	return 0
 } # => renew_move()
-
-# Set unique_subject = no in index.txt.attr
-ca_unique_subject_no() {
-	[ -d "$EASYRSA_PKI" ] || return 0
-	attr_file="$EASYRSA_PKI/index.txt.attr"
-	verbose "\
-Confirm: index.txt.attr exists and 'unique_subject = no'"
-
-	if [ -f "$attr_file" ]; then
-		if grep -q '^[[:blank:]]*unique_subject = no' \
-			"$attr_file"
-		then
-			return 0
-		fi
-	else
-		return 0
-	fi
-
-	# Otherwise this is required for all easyrsa v3
-	printf '%s\n' 'unique_subject = no' > "$attr_file" || \
-		die "ca_unique_subject_no - Failed write"
-	verbose "Set unique_subject = no in index.txt.attr"
-} #=> ca_unique_subject_no()
 
 # revoke-renewed backend
 revoke_renewed() {

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -6278,17 +6278,13 @@ cmd="$1"
 unset -v require_pki require_ca quiet_vars
 case "$cmd" in
 	''|help|-h|--help|--usage| \
-	version|show-host|rand|random|write)
+	version|show-host|rand|random)
 		quiet_vars=1
+	;;
+	write)
 		# write is not compatible with diagnostics
-		case "$cmd" in
-			write)
-				unset -v EASYRSA_VERBOSE
-				EASYRSA_SILENT=1
-			;;
-			*)
-				: # ok
-		esac
+		unset -v EASYRSA_VERBOSE
+		EASYRSA_SILENT=1
 	;;
 	init-pki|clean-all)
 		: # ok

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -769,9 +769,6 @@ secure_session() {
 				working_safe_ssl_conf
 			easyrsa_err_log="$secured_session/error.log"
 
-			# Verify or create: EASYRSA_SSL_CONF
-			write_easyrsa_ssl_cnf_tmp
-
 			verbose "\
 secure_session: CREATED: $secured_session"
 			return
@@ -912,7 +909,7 @@ Temporary session not preserved."
 				mkdir -p "$keep_tmp"
 				rm -rf "$keep_tmp"
 				mv -f "$secured_session" "$keep_tmp"
-				print "Temp session preserved: $keep_tmp"
+				information "Temp session preserved: $keep_tmp"
 				unset -v secured_session
 			fi
 		fi
@@ -974,7 +971,7 @@ Temporary session not preserved."
 
 # Make a copy safe SSL config file
 make_safe_ssl() {
-	easyrsa_openssl makesafeconf
+	easyrsa_openssl makesafeconf "$@"
 	notice "\
 Safe SSL config file created at:
 * $EASYRSA_SAFE_CONF"
@@ -1139,7 +1136,10 @@ easyrsa_openssl() {
 		rand)
 			die "easyrsa_openssl: Illegal SSL command: rand"
 		;;
-		makesafeconf) makesafeconf=1 ;;
+		makesafeconf)
+			safe_target_file="$1"
+			makesafeconf=1
+		;;
 		*) :
 	esac
 
@@ -1170,8 +1170,11 @@ easyrsa_openssl() {
 	makesafeconf)
 		# COPY temp-file to safessl-easyrsa.cnf
 		unset -v makesafeconf
-		cp -f "$safe_ssl_cnf_tmp" "$EASYRSA_SAFE_CONF" && \
-			return
+		if [ "$safe_target_file" ]; then
+			cp -f "$safe_ssl_cnf_tmp" "$safe_target_file" && return
+		else
+			cat "$safe_ssl_cnf_tmp" && return
+		fi
 	;;
 	*)
 		# Exec SSL
@@ -5353,7 +5356,11 @@ verify_working_env() {
 		verify_pki_init
 
 		# Temp dir session and default SSL conf file
-		secure_session
+		if [ -z "$secured_session" ]; then
+			secure_session
+			# Verify or create temp EASYRSA_SSL_CONF
+			write_easyrsa_ssl_cnf_tmp
+		fi
 
 		# Verify selected algorithm and parameters
 		verify_algo_params
@@ -5416,6 +5423,7 @@ ac05f49595e5d5fe96367229e3ce070c"
 
 		# Get file hash
 		file_hash="$(
+			OPENSSL_CONF=/dev/null
 			"$EASYRSA_OPENSSL" dgst -sha256 -r "$EASYRSA_SSL_CONF"
 		)"
 
@@ -5478,6 +5486,15 @@ write_x509_type_tmp() {
 
 # Write ALL legacy files to $1 or default
 legacy_files() {
+	require_pki=1
+	verify_working_env
+
+	if [ "$legacy_file_over_write" ]; then
+		confirm "${NL}  Confirm OVER-WRITE files ? " yes "
+'legacy-hard' will OVER-WRITE all legacy files to default settings.
+Legacy files: openssl-easyrsa.cnf and x509-types/ directory."
+	fi
+
 	legacy_out_d="${1:-$EASYRSA_PKI}"
 	legacy_out_d="${legacy_out_d:-$EASYRSA}"
 	[ -d "$legacy_out_d" ] || \
@@ -5512,11 +5529,15 @@ write() {
 
 	case "$write_type" in
 	safe-ssl)
-		# Only write to EASYRSA_PKI
-		[ -z "$write_dir" ] || \
-			user_error "Unsupported option: '$write_dir'"
-		verify_working_env
-		make_safe_ssl || die "write failed"
+		# write to stdout or $write_dir/safessl-easyrsa.cnf
+		if [ "$write_dir" ]; then
+			[ -d "$write_dir" ] || \
+				user_error "Missing directory '$write_dir'"
+			write_file="$write_dir"/safessl-easyrsa.cnf
+			make_safe_ssl "$write_file" || die "write failed"
+		else
+			make_safe_ssl || die "write failed"
+		fi
 		return
 	;;
 	ssl-cnf)
@@ -6235,27 +6256,26 @@ cmd="$1"
 unset -v require_pki require_ca quiet_vars
 case "$cmd" in
 	''|help|-h|--help|--usage| \
-	version|show-host|rand|random)
+	version|show-host|rand|random|write)
 		quiet_vars=1
+		# write is not compatible with diagnostics
+		case "$cmd" in
+			write)
+				unset -v EASYRSA_VERBOSE
+				EASYRSA_SILENT=1
+			;;
+			*)
+				: # ok
+		esac
 	;;
 	init-pki|clean-all)
-		: # No change
+		: # ok
 	;;
 	*)
 		require_pki=1
 		case "$cmd" in
-			gen-req|gen-dh|build-ca|show-req| \
-			make-safe-ssl|export-p*|inline|write)
-				# write is not compatible with diagnostics
-				case "$cmd" in
-					write)
-						unset -v EASYRSA_VERBOSE
-						EASYRSA_SILENT=1
-						quiet_vars=1
-					;;
-					*)
-						: # ok
-				esac
+			gen-req|gen-dh|build-ca|show-req|export-p*|inline)
+				: # ok
 			;;
 			*)
 				require_ca=1
@@ -6293,6 +6313,21 @@ locate_support_files
 
 # Verify SSL Lib - One time ONLY
 verify_ssl_lib
+
+# If there is a valid temp-dir:
+if [ "$require_pki" ]; then
+	# taken care of later by verify_working_env()
+	:
+else
+	# Create temp-session and openssl-easyrsa.cnf (Temp) now
+	if [ -d "$EASYRSA_TEMP_DIR" ]; then
+		# Temp dir session and default SSL conf file
+		secure_session
+
+		# Verify or create: EASYRSA_SSL_CONF
+		write_easyrsa_ssl_cnf_tmp
+	fi
+fi
 
 # Check $working_safe_ssl_conf, to build
 # a fully configured safe ssl conf, on the
@@ -6449,16 +6484,11 @@ case "$cmd" in
 		legacy)
 			# over-write NO
 			shift
-			verify_working_env
 			legacy_files "$@"
 			;;
 		legacy-hard)
 			# over-write YES
-			confirm "${NL}  Confirm OVER-WRITE files ? " yes "
-'legacy-hard' will OVER-WRITE all legacy files to default settings.
-Legacy files: openssl-easyrsa.cnf and x509-types/ directory."
 			shift
-			verify_working_env
 			legacy_file_over_write=1
 			legacy_files "$@"
 			;;

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -242,12 +242,6 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
       This command will use the system time to update the status of
       issued certificates."
 	;;
-	make-safe-ssl)
-		text="
-* make-safe-ssl
-
-      Generate a safe SSL config file"
-	;;
 	show-req|show-cert)
 		text="
 * show-req  <file_name_base> [ cmd-opts ]

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1476,6 +1476,7 @@ get_passphrase() {
 			printf '\n%s\n' \
 				"Passphrase must be at least 4 characters!"
 		else
+			# shellcheck disable=SC2229 # does not read 't'
 			read -r "$t" <<- SECRET
 				$r
 				SECRET

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4475,6 +4475,8 @@ read_db() {
 			die "read_db - remove_secure_session"
 		secure_session || \
 			die "read_db - secure_session"
+		# Recreate openssl-easyrsa.cnf (Temp)
+		write_easyrsa_ssl_cnf_tmp
 
 		# Interpret the db/certificate record
 		unset -v db_serial db_cn db_revoke_date db_reason

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5397,13 +5397,46 @@ force_set_var() {
 	die "force_set_var - set_var '$*'"
 } # => force_set_var()
 
-
-
 # Verify: $EASYRSA_SSL_CONF pki/openssl-easyrsa.cnf
 # or create temp-file
 write_easyrsa_ssl_cnf_tmp() {
-	[ -f "$EASYRSA_SSL_CONF" ] && return
+	if [ -f "$EASYRSA_SSL_CONF" ]; then
+		# Set known hashes
+		# openssl-easyrsa.cnf sha256 hash - v3.2.x
+		known_hash_file="\
+13ca05f031d58c5e2912652b33099ce9\
+ac05f49595e5d5fe96367229e3ce070c"
 
+		# Built-in here-doc v3.2.0-1
+		known_hash_heredoc_1="\
+82439f1860838e28f6270d5d06b17717\
+56db777861e19bf9edc21222f86a310d"
+
+		# Get file hash
+		file_hash="$(
+			"$EASYRSA_OPENSSL" dgst -sha256 -r "$EASYRSA_SSL_CONF"
+		)"
+
+		# Strip excess SSL info
+		file_hash="${file_hash%% *}"
+
+		# Check file hash against known hash
+		if [ "$file_hash" = "$known_hash_file" ] || \
+			[ "$file_hash" = "$known_hash_heredoc_1" ]
+		then
+			# Permanently remove file and use temp-files
+			unset -v file_hash known_hash_file known_hash_heredoc_1
+			rm "$EASYRSA_SSL_CONF" || : # Ignore failure
+			verbose "write_easyrsa_ssl_cnf_tmp: Removed SSL Conf!"
+		else
+			# File has been changed, leave in place
+			unset -v file_hash known_hash_file known_hash_heredoc_1
+			verbose "write_easyrsa_ssl_cnf_tmp: NO CHANGE!"
+			return 0
+		fi
+	fi
+
+	# SET and USE temp-file from here-doc Now
 	# Create temp-file
 	ssl_cnf_tmp=
 	easyrsa_mktemp ssl_cnf_tmp || die "\
@@ -5769,7 +5802,7 @@ fi
 CREATE_VARS_EXAMPLE
 	;;
 	ssl-cnf)
-	# SSL config
+	# SSL config v3.2.0-1
 	cat << "CREATE_SSL_CONFIG"
 # For use with Easy-RSA 3.0+ and OpenSSL or LibreSSL
 
@@ -5805,7 +5838,7 @@ crl_extensions	= crl_ext
 # These fields are removed from this here-doc but retained
 # in 'openssl-easyrsa.cnf' file, in case something breaks.
 # default_days is no longer required by Easy-RSA
-default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
+#default_days	= $ENV::EASYRSA_CERT_EXPIRE	# how long to certify for
 # default_crl_days is no longer required by Easy-RSA
 #default_crl_days	= $ENV::EASYRSA_CRL_DAYS	# how long before next CRL
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1425,6 +1425,12 @@ locate_support_files() {
 	# Room for more..
 	# '/etc/easy-rsa' - Last resort
 
+	# Not currently used:
+	# Set EASYRSA_PKI only flag
+	#is_in_pki=1
+	#x509_dir_in_pki=""
+	#ssl_cnf_in_pki=""
+
 	# Find data-files
 	for area in \
 		"$EASYRSA_PKI" \
@@ -1436,14 +1442,26 @@ locate_support_files() {
 		'/etc/easy-rsa' \
 		# EOL
 	do
-			# Find x509-types
-			[ -e "${area}/${x509_types_dir}" ] && set_var \
-				EASYRSA_EXT_DIR "${area}/${x509_types_dir}"
+		# Find x509-types
+		if [ -e "${area}/${x509_types_dir}" ]; then
+			set_var EASYRSA_EXT_DIR "${area}/${x509_types_dir}"
+			#[ "$is_in_pki" ] && x509_dir_in_pki=1
+			verbose "> Found x509 dir: ${area}/${x509_types_dir}"
+		fi
 
-			# Find openssl-easyrsa.cnf
-			[ -e "${area}/${ssl_cnf_file}" ] && set_var \
-				EASYRSA_SSL_CONF "${area}/${ssl_cnf_file}"
+		# Find openssl-easyrsa.cnf
+		if [ -e "${area}/${ssl_cnf_file}" ]; then
+			set_var EASYRSA_SSL_CONF "${area}/${ssl_cnf_file}"
+			#[ "$is_in_pki" ] && ssl_cnf_in_pki=1
+			verbose "> Found SSL cnf: ${area}/${ssl_cnf_file}"
+		fi
+
+		# Clear EASYRSA_PKI only flag
+		#unset -v is_in_pki
 	done
+
+	verbose "> EASYRSA_EXT_DIR: $EASYRSA_EXT_DIR"
+	verbose "> EASYRSA_SSL_CONF: $EASYRSA_SSL_CONF"
 	verbose "locate_support_files: COMPLETED"
 } # => locate_support_files()
 
@@ -5289,9 +5307,10 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 	set_var EASYRSA_REQ_CN			ChangeMe
 	set_var EASYRSA_DIGEST			sha256
 
-	# verified or created by secure_session()
-	set_var EASYRSA_SSL_CONF		\
-		"$EASYRSA_PKI/openssl-easyrsa.cnf"
+	# Now set by locate_support_files()
+	#set_var EASYRSA_SSL_CONF		\
+	#	"$EASYRSA_PKI/openssl-easyrsa.cnf"
+
 	# created as required
 	set_var EASYRSA_SAFE_CONF		\
 		"$EASYRSA_PKI/safessl-easyrsa.cnf"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -78,6 +78,7 @@ A list of commands is shown below:
 		CA_status="   CA status: CA has not been built"
 	fi
 
+	# check for vars changing PKI unexpectedly!
 	if [ "$invalid_vars" ]; then
 		ivmsg="
    *WARNING*: \
@@ -974,13 +975,13 @@ Temporary session not preserved."
 # Make a copy safe SSL config file
 make_safe_ssl() {
 	easyrsa_openssl makesafeconf
-
 	notice "\
 Safe SSL config file created at:
 * $EASYRSA_SAFE_CONF"
+
 	verbose "\
 make_safe_ssl: NEW SSL cnf file: $safe_ssl_cnf_tmp"
-} # => make_safe_ssl_copy()
+} # => make_safe_ssl()
 
 # Escape hazardous characters
 # Auto-escape hazardous characters:
@@ -5334,7 +5335,7 @@ validate_default_vars() {
 
 	# This is an almost unacceptable error
 	invalid_vars=1
-	[ "$ignore_vars" ] || user_error "\
+	[ "$quiet_vars" ] || user_error "\
 The values in the vars file have unexpectedly changed the values for
 EASYRSA and/or EASYRSA_PKI. The default pki/vars file is forbidden to
 change these values.
@@ -6231,11 +6232,11 @@ cmd="$1"
 [ "$1" ] && shift # scrape off command
 
 # Establish PKI and CA initialisation requirements
-unset -v require_pki require_ca ignore_vars
+unset -v require_pki require_ca quiet_vars
 case "$cmd" in
 	''|help|-h|--help|--usage| \
 	version|show-host|rand|random)
-		ignore_vars=1
+		quiet_vars=1
 	;;
 	init-pki|clean-all)
 		: # No change
@@ -6250,6 +6251,7 @@ case "$cmd" in
 					write)
 						unset -v EASYRSA_VERBOSE
 						EASYRSA_SILENT=1
+						quiet_vars=1
 					;;
 					*)
 						: # ok
@@ -6265,7 +6267,7 @@ esac
 # then source the vars file, if found
 # otherwise, ignore no vars file
 if select_vars; then
-	[ "$ignore_vars" ] || information "\
+	[ "$quiet_vars" ] || information "\
 Using Easy-RSA 'vars' configuration:
 * $EASYRSA_VARS_FILE"
 	source_vars "$EASYRSA_VARS_FILE"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -799,7 +799,7 @@ easyrsa_mktemp - input error"
 
 	# session directory must exist
 	[ "$secured_session" ] || die "\
-easyrsa_mktemp - Temporary session undefined"
+easyrsa_mktemp - Temporary session undefined (--tmp-dir)"
 
 	# Update counter
 	mktemp_counter="$(( mktemp_counter + 1 ))"
@@ -5401,7 +5401,8 @@ force_set_var() {
 } # => force_set_var()
 
 # Verify: $EASYRSA_SSL_CONF pki/openssl-easyrsa.cnf
-# or create temp-file
+# If the existing file is default then delete it
+# and create temp-file. Otherwise, leave in place.
 write_easyrsa_ssl_cnf_tmp() {
 	if [ -f "$EASYRSA_SSL_CONF" ]; then
 		# Set known hashes
@@ -5436,6 +5437,8 @@ ac05f49595e5d5fe96367229e3ce070c"
 			# File has been changed, leave in place
 			unset -v file_hash known_hash_file known_hash_heredoc_1
 			verbose "write_easyrsa_ssl_cnf_tmp: NO CHANGE!"
+
+			# Do NOT replace the existing file
 			return 0
 		fi
 	fi

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -16,7 +16,7 @@ usage() {
 	print "
 Easy-RSA 3 usage and overview
 
-USAGE: easyrsa [global-options] COMMAND [command-options]
+$easyrsa_help_title
 
 To get detailed usage and help for a command, use:
   ./easyrsa help COMMAND
@@ -93,7 +93,7 @@ DIRECTORY STATUS (commands would take effect on these locations)
          PKI: $pki_dir
    vars-file: ${EASYRSA_VARS_FILE:-Missing or undefined}${ivmsg}
   x509-types: ${EASYRSA_EXT_DIR:-Missing or undefined}
-$CA_status"
+$CA_status${NL}"
 } # => usage()
 
 # Detailed command help
@@ -103,7 +103,10 @@ $CA_status"
 # Commands are TAB indented, while text is SPACE indented.
 # 'case' indentation is minimalistic.
 cmd_help() {
+	easyrsa_help_title="\
+Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
 	unset -v text err_text opts text_only
+
 	case "$1" in
 	init-pki|clean-all)
 		text="
@@ -407,12 +410,12 @@ cmd_help() {
       Types:
       * ssl-cnf  - Write openssl-easyrsa.cnf file.
       * COMMON|ca|server|serverClient|client|codeSigning|email|kdc
-                   Write x509-type <type> file.
+                 - Write x509-type <type> file.
       * legacy   - Write ALL support files (above) to <DIR>.
                    Will create <DIR>/x509-types directory.
                    Default <DIR> is EASYRSA_PKI or EASYRSA.
       * legacy-hard
-                   Same as 'legacy' plus OVER-WRITE files.
+                 - Same as 'legacy' plus OVER-WRITE files.
       * safe-ssl - Expand EasyRSA SSL config file for LibreSSL.
       * vars     - Write vars.example file."
 		opts="
@@ -496,9 +499,12 @@ These commands are safe to test and will NOT effect your PKI.
 	;;
 	opts|options)
 		opt_usage
+		cleanup ok
 	;;
 	"")
-		usage ;;
+		usage
+		cleanup ok
+	;;
 	*)
 		err_text="
   Unknown command: '$1' \
@@ -508,8 +514,10 @@ These commands are safe to test and will NOT effect your PKI.
 
 	if [ "$err_text" ]; then
 		print "${err_text}"
+		print "$easyrsa_help_title"
 	else
 		# display the help text
+		print "$easyrsa_help_title"
 		[ "$text" ] && print "$text"
 
 		if [ "$text_only" ]; then
@@ -6238,10 +6246,14 @@ case "$cmd" in
 			gen-req|gen-dh|build-ca|show-req| \
 			make-safe-ssl|export-p*|inline|write)
 				# write is not compatible with diagnostics
-				if [ "$cmd" = write ]; then
-					unset -v EASYRSA_VERBOSE
-					EASYRSA_SILENT=1
-				fi
+				case "$cmd" in
+					write)
+						unset -v EASYRSA_VERBOSE
+						EASYRSA_SILENT=1
+					;;
+					*)
+						: # ok
+				esac
 			;;
 			*)
 				require_ca=1
@@ -6253,9 +6265,9 @@ esac
 # then source the vars file, if found
 # otherwise, ignore no vars file
 if select_vars; then
-	information "\
+	[ "$ignore_vars" ] || information "\
 Using Easy-RSA 'vars' configuration:
-* $target_file"
+* $EASYRSA_VARS_FILE"
 	source_vars "$EASYRSA_VARS_FILE"
 else
 	verbose "\

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5145,6 +5145,7 @@ Missing vars file:
 		-e '[^(]`[^)]' \
 		-e '[[:blank:]]export[[:blank:]]*' \
 		-e '[[:blank:]]unset[[:blank:]]*' \
+		-e '^  > ' \
 		"$target_file"
 	then
 		# here we go ..
@@ -5189,6 +5190,16 @@ These problems have been found in your 'vars' settings:${NL}"
 			err_msg="${err_msg}
   Use of 'unset':
   Remove 'unset' ('force_set_var' may also work)."
+		fi
+
+		# No redirection - caused by --verbose output
+		if grep -q \
+			-e '^  > ' \
+			"$target_file"
+		then
+			err_msg="${err_msg}
+  Use of unsupported characters:
+  These characters are not supported: '>' redirection"
 		fi
 
 		# Fatal error
@@ -6226,7 +6237,11 @@ case "$cmd" in
 		case "$cmd" in
 			gen-req|gen-dh|build-ca|show-req| \
 			make-safe-ssl|export-p*|inline|write)
-				: # No change
+				# write is not compatible with diagnostics
+				if [ "$cmd" = write ]; then
+					unset -v EASYRSA_VERBOSE
+					EASYRSA_SILENT=1
+				fi
 			;;
 			*)
 				require_ca=1

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -335,7 +335,21 @@ cmd_help() {
                   (Equivalent to global option '--nopass|--no-pass')
       * noca    - Do not include the ca.crt file in the PKCS12 output
       * nokey   - Do not include the private key in the PKCS12 output
-      * usefn   - Use <file_name_base> as friendly name"
+      * nofn    - Do not set 'freindlyName'
+                  For more, see: 'easyrsa help friendly'"
+	;;
+	friendly)
+		text_only=1
+		text="
+* export-p12: Internal file label 'friendlyName'
+
+      The 'friendlyname' is always set to the file-name-base.
+
+      An alternate friendlyName can be configured by using:
+      * Global option '--usefn=<friendlyName>'
+
+      Fallback to previous behavior can be configured by using:
+      * Command option 'nofn' ('friendlyname' will not be set)"
 	;;
 	export-p7)
 		text="
@@ -566,9 +580,13 @@ Certificate & Request options: (these impact cert/req field values)
 
 --subca-len=#   : Path length of signed intermediate CA certificates
 --copy-ext      : Copy included request X509 extensions (namely subjAltName)
+
 --san|--subject-alt-name=<subjectAltName>
                 : Add a subjectAltName.
                   For more info and syntax, see: 'easyrsa help altname'
+
+--usefn=NAME    : export-p12, set 'friendlyName' to NAME
+                  For more, see: 'easyrsa help friendly'
 
 Distinguished Name mode:
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5423,6 +5423,8 @@ force_set_var() {
 # and create temp-file. Otherwise, leave in place.
 write_easyrsa_ssl_cnf_tmp() {
 	if [ -f "$EASYRSA_SSL_CONF" ]; then
+		verbose "write_easyrsa_ssl_cnf_tmp: SSL config EXISTS"
+
 		# Set known hashes
 		# openssl-easyrsa.cnf sha256 hash - v3.2.x
 		known_hash_file="\
@@ -5438,34 +5440,33 @@ ac05f49595e5d5fe96367229e3ce070c"
 		file_hash="$(
 			OPENSSL_CONF=/dev/null
 			"$EASYRSA_OPENSSL" dgst -sha256 -r "$EASYRSA_SSL_CONF"
-		)"
+		)" || die "hash malfunction!"
 
 		# Strip excess SSL info
 		file_hash="${file_hash%% *}"
 
-		# Check file hash against known hash
-		if [ "$file_hash" = "$known_hash_file" ] || \
-			[ "$file_hash" = "$known_hash_heredoc_1" ]
-		then
-			# Permanently remove file and use temp-files
-			unset -v file_hash known_hash_file known_hash_heredoc_1
+		# Compare SSL output
+		case "$file_hash" in
+		*[!1234567890abcdef]*)
+			die "hash failure: $file_hash"
+		esac
 
-			if rm "$EASYRSA_SSL_CONF" 2>/dev/null; then
-				verbose "\
-write_easyrsa_ssl_cnf_tmp: Removed SSL Conf!"
-			else
-				# Ignore failure
-				verbose "\
-write_easyrsa_ssl_cnf_tmp: Removed SSL Conf failed!"
-			fi
-		else
+		# Check file hash against known hash
+		case "$file_hash" in
+		"$known_hash_file") ;;
+		"$known_hash_heredoc_1") ;;
+		*)
 			# File has been changed, leave in place
 			unset -v file_hash known_hash_file known_hash_heredoc_1
-			verbose "write_easyrsa_ssl_cnf_tmp: NO CHANGE!"
+			verbose "write_easyrsa_ssl_cnf_tmp: SSL config NO CHANGE!"
 
-			# Do NOT replace the existing file
+			# Use the existing and changed file ONLY
 			return 0
-		fi
+		esac
+
+		# Ignore this file, prefer to use a temp-file
+		unset -v file_hash known_hash_file known_hash_heredoc_1
+		verbose "write_easyrsa_ssl_cnf_tmp: SSL config IGNORED"
 	fi
 
 	# SET and USE temp-file from here-doc Now
@@ -5481,7 +5482,7 @@ write_easyrsa_ssl_cnf_tmp - write ssl-cnf"
 	# export SSL cnf tmp
 	export EASYRSA_SSL_CONF="$ssl_cnf_tmp"
 	verbose "\
-write_easyrsa_ssl_cnf_tmp: create_openssl_easyrsa_cnf OK"
+write_easyrsa_ssl_cnf_tmp: SSL config using temp-file"
 } # => write_easyrsa_ssl_cnf_tmp()
 
 # Write x509 type file to a temp file

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -336,7 +336,8 @@ cmd_help() {
       * noca    - Do not include the ca.crt file in the PKCS12 output
       * nokey   - Do not include the private key in the PKCS12 output
       * nofn    - Do not set 'freindlyName'
-                  For more, see: 'easyrsa help friendly'"
+                  For more, see: 'easyrsa help friendly'
+      * legacy  - Use legacy mode of operation"
 	;;
 	friendly)
 		text_only=1
@@ -3264,7 +3265,7 @@ Run easyrsa without commands for usage and command help."
 	cipher=-aes256
 	want_ca=1
 	want_key=1
-	unset -v nokeys
+	unset -v nokeys legacy
 	while [ "$1" ]; do
 		case "$1" in
 			noca)
@@ -3282,6 +3283,9 @@ Run easyrsa without commands for usage and command help."
 			;;
 			nofn)
 				unset friendly_name
+			;;
+			legacy)
+				legacy=-legacy
 			;;
 			*)
 				warn "Ignoring unknown option: '$1'"
@@ -3403,6 +3407,7 @@ Missing User Certificate, expected at:
 			-out "$pkcs_out" \
 			-inkey "$key_in" \
 			${nokeys} \
+			${legacy} \
 			${friendly_name:+ -name "$friendly_name"} \
 			${want_ca:+ -certfile "$crt_ca"} \
 			${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -902,12 +902,15 @@ Temporary session not preserved."
 				rm -rf "$keep_tmp"
 				mv -f "$secured_session" "$keep_tmp"
 				print "Temp session preserved: $keep_tmp"
+				unset -v secured_session
 			fi
 		fi
 
 		# remove temp-session
-		remove_secure_session || \
-			warn "cleanup - remove_secure_session failed"
+		if [ "$secured_session" ]; then
+			remove_secure_session || \
+				warn "cleanup - remove_secure_session failed"
+		fi
 	fi
 
 	# shellcheck disable=SC3040 # POSIX set - cleanup()

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5449,8 +5449,15 @@ ac05f49595e5d5fe96367229e3ce070c"
 		then
 			# Permanently remove file and use temp-files
 			unset -v file_hash known_hash_file known_hash_heredoc_1
-			rm "$EASYRSA_SSL_CONF" || : # Ignore failure
-			verbose "write_easyrsa_ssl_cnf_tmp: Removed SSL Conf!"
+
+			if rm "$EASYRSA_SSL_CONF" 2>/dev/null; then
+				verbose "\
+write_easyrsa_ssl_cnf_tmp: Removed SSL Conf!"
+			else
+				# Ignore failure
+				verbose "\
+write_easyrsa_ssl_cnf_tmp: Removed SSL Conf failed!"
+			fi
 		else
 			# File has been changed, leave in place
 			unset -v file_hash known_hash_file known_hash_heredoc_1

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -521,6 +521,7 @@ ${opts:-
       * No supported command options}"
 		fi
 	fi
+	print
 } # => cmd_help()
 
 # Options usage
@@ -624,8 +625,8 @@ die() {
 	print "
 Easy-RSA error:
 
-$1
-"
+$1${NL}"
+
 	# error_info is for hard-to-spot errors!
 	if [ "$error_info" ]; then
 		print "  * $cmd: ${error_info}${NL}"
@@ -645,7 +646,8 @@ EasyRSA version $EASYRSA_version
 
 Error
 -----
-$1"
+$1${NL}"
+
 	easyrsa_exit_with_error=1
 	cleanup
 } # => user_error()
@@ -662,7 +664,7 @@ warn() {
 	print "
 WARNING
 =======
-$1"
+$1${NL}"
 } # => warn()
 
 # informational notices to stdout
@@ -671,7 +673,7 @@ notice() {
 	print "
 Notice
 ------
-$1"
+$1${NL}"
 } # => notice()
 
 # Helpful information

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1374,7 +1374,7 @@ and initialize a fresh PKI here."
 	fi
 
 	# new dirs:
-	for i in private reqs inline; do
+	for i in issued private reqs inline; do
 		mkdir -p "$EASYRSA_PKI/$i" || \
 			die "\
 Failed to create PKI file structure (permissions?)"
@@ -1557,7 +1557,7 @@ current CA. To start a new CA, run init-pki first."
 	# create necessary dirs:
 	err_msg="\
 Unable to create necessary PKI files (permissions?)"
-	for i in issued certs_by_serial \
+	for i in certs_by_serial \
 		revoked/certs_by_serial revoked/private_by_serial \
 		revoked/reqs_by_serial
 	do

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -417,7 +417,7 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
                    Default <DIR> is EASYRSA_PKI or EASYRSA.
       * legacy-hard
                  - Same as 'legacy' plus OVER-WRITE files.
-      * safe-ssl - Expand EasyRSA SSL config file for LibreSSL.
+      * safe-cnf - Expand EasyRSA SSL config file for LibreSSL.
       * vars     - Write vars.example file."
 		opts="
       * <DIR>    - If <DIR> is specified then files are created.
@@ -5528,7 +5528,7 @@ write() {
 	write_file=
 
 	case "$write_type" in
-	safe-ssl)
+	safe-cnf)
 		# write to stdout or $write_dir/safessl-easyrsa.cnf
 		if [ "$write_dir" ]; then
 			[ -d "$write_dir" ] || \


### PR DESCRIPTION
**Important** changes:
- Always **try** to use here-doc version of `openssl-easyrsa.cnf` - All comands. 2a8c0de
  This does not delete default `openssl-easyrsa.cnf`.
- `export-p12`: Always set `friendlyName` field. da9e594
- `export-p12`: New command option `legacy` - Fallback to old algorithms. f8514de
- Minor bugfix: `--enddate` #1056
- Minor bugfix: `gen-crl` #1059
- Remove command `make-safe-ssl` c814e0a