### PR TITLE
Make keyUsage critical in code-signing

### DIFF
--- a/easyrsa3/x509-types/code-signing
+++ b/easyrsa3/x509-types/code-signing
@@ -4,4 +4,4 @@ basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 extendedKeyUsage = codeSigning
-keyUsage = digitalSignature
+keyUsage = critical, digitalSignature


### PR DESCRIPTION
This is required, as described in:

"Baseline Requirements for the Issuance and Management of Publicly-Trusted TLS Server certificates v2.0.2", CA/Browser Forum.

See in particular table 7.1.3.2.1 where keyUsage is marked CRITICAL.

This change is required for easy-rsa certificates to be passed as valid code-signing certificates by OpenSSL 3.2.0, which gives the above as its source.