### PR TITLE
Introduce new global options: --ku-critical and --bc-critical

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4825,11 +4825,21 @@ create_legacy_stream() {
 		;;
 	easyrsa)
 	# This could be COMMON but not is not suitable for a CA
-		cat <<- "CREATE_X509_TYPE_EASYRSA"
-		basicConstraints = CA:FALSE
+		_ku='digitalSignature, keyEncipherment'
+		if [ "$EASYRSA_KU_CRITICAL" ]; then
+			_ku="${EASYRSA_KU_CRITICAL}, ${_ku}"
+		fi
+
+		_bc='CA:FALSE'
+		if [ "$EASYRSA_BC_CRITICAL" ]; then
+			_bc="${EASYRSA_BC_CRITICAL}, ${_bc}"
+		fi
+
+		cat <<- CREATE_X509_TYPE_EASYRSA
+		basicConstraints = $_bc
 		subjectKeyIdentifier = hash
 		authorityKeyIdentifier = keyid,issuer:always
-		keyUsage = digitalSignature,keyEncipherment
+		keyUsage = $_ku
 		CREATE_X509_TYPE_EASYRSA
 		;;
 	serverClient)
@@ -4855,11 +4865,21 @@ create_legacy_stream() {
 		;;
 	ca)
 	# ca
-		cat <<- "CREATE_X509_TYPE_CA"
-		basicConstraints = CA:TRUE
+		_ku='cRLSign, keyCertSign'
+		if [ "$EASYRSA_KU_CRITICAL" ]; then
+			_ku="${EASYRSA_KU_CRITICAL}, ${_ku}"
+		fi
+
+		_bc='CA:TRUE'
+		if [ "$EASYRSA_BC_CRITICAL" ]; then
+			_bc="${EASYRSA_BC_CRITICAL}, ${_bc}"
+		fi
+
+		cat <<- CREATE_X509_TYPE_CA
+		basicConstraints = $_bc
 		subjectKeyIdentifier = hash
 		authorityKeyIdentifier = keyid:always,issuer:always
-		keyUsage = cRLSign, keyCertSign
+		keyUsage = $_ku
 		CREATE_X509_TYPE_CA
 		;;
 	selfsign)
@@ -5222,6 +5242,9 @@ CREATE_SSL_CONFIG
 	*)
 		die "create_legacy_stream: unknown type '$1'"
 	esac
+
+	# Cleanup
+	unset -v _ku _bc
 } # => create_legacy_stream()
 
 # Version information


### PR DESCRIPTION
These option allow X509 'critical' attributes to be used.

--ku-critical (--ku-crit):
Configure 'keyUsage' to set 'critical' attribute.

--bc-critical (--bc-crit):
Configure 'basicContraints' to set 'critical' attribute.

Use of these options is left to the discretion of the the user task.

Supported certificate types does **not** include 'email', 'codeSigning' or 'kdc'.