### PR TITLE
LibreSSL: Add band-aid fix for missing 'x509' command option '-ext'

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3929,12 +3929,19 @@ ssl_cert_x509v3_eku() {
 	unset -v __known
 
 	# Extract certificate Extended Key Usage
-	__eku="$(
-		OPENSSL_CONF=/dev/null
-		"$EASYRSA_OPENSSL" x509 -in "${__crt}" -noout \
-			-ext extendedKeyUsage | \
-				sed -e /"${__pattern}"/d -e s/^\ *//
-		)"
+	if [ "$ssl_lib" = libressl ]; then
+		__eku="$(
+			easyrsa_openssl x509 -in "${__crt}" -noout -text | \
+				sed -n "/${__pattern}/{n;s/^ *//g;p;}"
+			)"
+	else
+		__eku="$(
+			OPENSSL_CONF=/dev/null
+			"$EASYRSA_OPENSSL" x509 -in "${__crt}" -noout \
+				-ext extendedKeyUsage | \
+					sed -e /"${__pattern}"/d -e s/^\ *//
+			)"
+	fi
 
 	# Match EKU with supported usage
 	case "$__eku" in


### PR DESCRIPTION
This is used by 'easyrsa' function ssl_cert_x509v3_eku(), to extract the X509v3 extended keyUsage, specifically.

Work around LibreSSL limitation by using tortured 'sed' regex, instead of legitimate SSL bound data.