### PR TITLE
export-p12: use OpenSSLv3-compatible ciphers (AES-256-CBC & SHA256) with OpenSSL 1.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,8 @@ Easy-RSA 3 ChangeLog
    * Windows: Introduce 'Non-Admin' mode (c2823c4) (#1073)
    * LibreSSL: Add fix for missing 'x509' option '-ext' (96dd959) (#1068)
    * Variable heredoc expansion for SSL/Safe Config file (9c5d423) (#1064)
+   * export-p12: Use OpenSSL V3-compatible ciphers under 1.1 when 'legacy'
+     is not used (#nnn)
 
    Branch-merge: v3.2.0-beta2 (#1055) 2024/01/13 Commit: d51d79b
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -333,10 +333,10 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
                   (Equivalent to global option '--nopass|--no-pass')
       * noca    - Do not include the ca.crt file in the PKCS12 output
       * nokey   - Do not include the private key in the PKCS12 output
-      * nofn    - Do not set 'freindlyName'
+      * nofn    - Do not set 'friendlyName'
                   For more, see: 'easyrsa help friendly'
       * legacy  - Use legacy encryption algorithm RC2_CBC or 3DES_CBC
-                  OpenSSL V3 ONLY: Default algorithm is AES-256-CBC"
+                  (Default algorithm is AES-256-CBC)"
 	;;
 	friendly)
 		text_only=1
@@ -3273,7 +3273,11 @@ Run easyrsa without commands for usage and command help."
 	cipher=-aes256
 	want_ca=1
 	want_key=1
-	unset -v nokeys legacy
+	unset -v nokeys legacy p12_cipher_opts
+	# Under OpenSSL 1.1, use the PBE/MAC algorithms OpenSSL 3.0 uses,
+	# unless "legacy" is set.  This makes the .p12 files readable by
+	# OpenSSL 3.0 without needing '-legacy'.
+	[ "$openssl_v3" ] || p12_cipher_opts="-keypbe AES-256-CBC -certpbe AES-256-CBC -macalg sha256"
 	while [ "$1" ]; do
 		case "$1" in
 			noca)
@@ -3293,9 +3297,11 @@ Run easyrsa without commands for usage and command help."
 				unset friendly_name
 			;;
 			legacy)
-				[ "$openssl_v3" ] || \
-					user_error "Option 'legacy' requires SSL version 3"
-				legacy=-legacy
+				if [ "$openssl_v3" ]; then
+					legacy=-legacy
+				else
+					unset -v p12_cipher_opts
+				fi
 			;;
 			*)
 				warn "Ignoring unknown option: '$1'"
@@ -3421,6 +3427,7 @@ Missing User Certificate, expected at:
 			-inkey "$key_in" \
 			${nokeys} \
 			${legacy} \
+			${p12_cipher_opts} \
 			${friendly_name:+ -name "$friendly_name"} \
 			${want_ca:+ -certfile "$crt_ca"} \
 			${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \


### PR DESCRIPTION
This is my stab at fixing #966.  It makes the exported .p12 file readable by OpenSSL v3 without needing `-legacy`.

I think it's better to have this on by default, but allow opting out where backwards compatibility is needed.  To provide compatibility, I decide to make the "export-p12 _CN_ legacy" option suppress this behavior and use the default ciphers.  

(That option is no longer OpenSSL v3-only: it now provides "legacy" behavior on all versions of OpenSSL.  For v3, it uses `-legacy`; for non-v3, it uses the default ciphers, omitting the keypbe/certpbe/macalg options.)