### PR TITLE
export-p12, OpenSSL v1.x: Upgrade PBE and MAC options

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
 
+   * export-p12, OpenSSL v1.x: Upgrade PBE and MAC options (60a508a)
+     (#1084 - Based on #1081)
    * Windows: Introduce 'Non-Admin' mode (c2823c4) (#1073)
    * LibreSSL: Add fix for missing 'x509' option '-ext' (96dd959) (#1068)
    * Variable heredoc expansion for SSL/Safe Config file (9c5d423) (#1064)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -333,10 +333,10 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
                   (Equivalent to global option '--nopass|--no-pass')
       * noca    - Do not include the ca.crt file in the PKCS12 output
       * nokey   - Do not include the private key in the PKCS12 output
-      * nofn    - Do not set 'freindlyName'
+      * nofn    - Do not set 'friendlyName'
                   For more, see: 'easyrsa help friendly'
-      * legacy  - Use legacy encryption algorithm RC2_CBC or 3DES_CBC
-                  OpenSSL V3 ONLY: Default algorithm is AES-256-CBC"
+      * legacy  - Use legacy algorithm: RC2_CBC or 3DES_CBC + MAC: SHA1
+                  (Default algorithm: AES-256-CBC + MAC: SHA256)"
 	;;
 	friendly)
 		text_only=1
@@ -3274,6 +3274,19 @@ Run easyrsa without commands for usage and command help."
 	want_ca=1
 	want_key=1
 	unset -v nokeys legacy
+
+	# Under OpenSSL 1.1, use the PBE/MAC algorithms OpenSSL 3.0 uses,
+	# unless "legacy" is set.  This makes the .p12 files readable by
+	# OpenSSL 3.0 without needing '-legacy'.
+	if [ "$openssl_v3" ]; then
+		# No cipher opts required
+		p12_cipher_opts=""
+	else
+		# Upgrade PBE & MAC opts - Reset by option 'legacy'
+		p12_cipher_opts="-keypbe AES-256-CBC -certpbe AES-256-CBC"
+		p12_cipher_opts="${p12_cipher_opts} -macalg sha256"
+	fi
+
 	while [ "$1" ]; do
 		case "$1" in
 			noca)
@@ -3290,12 +3303,15 @@ Run easyrsa without commands for usage and command help."
 				[ "$prohibit_no_pass" ] || EASYRSA_NO_PASS=1
 			;;
 			nofn)
-				unset friendly_name
+				friendly_name=""
 			;;
 			legacy)
-				[ "$openssl_v3" ] || \
-					user_error "Option 'legacy' requires SSL version 3"
-				legacy=-legacy
+				if [ "$openssl_v3" ]; then
+					legacy=-legacy
+				else
+					# Downgrade PBE & MAC opts
+					p12_cipher_opts=""
+				fi
 			;;
 			*)
 				warn "Ignoring unknown option: '$1'"
@@ -3421,6 +3437,7 @@ Missing User Certificate, expected at:
 			-inkey "$key_in" \
 			${nokeys} \
 			${legacy} \
+			${p12_cipher_opts} \
 			${friendly_name:+ -name "$friendly_name"} \
 			${want_ca:+ -certfile "$crt_ca"} \
 			${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \


### PR DESCRIPTION
OpenSSL v1.x defaults for 'pkcs12' files uses 'legacy' cryptography:
- PBE uses RC2_CBC or 3DES_CBC
- MAC uses SHA1

OpenSSL v1.x settings are no longer considered to be secure.

OpenSSL v3.x defaults for 'pkcs12' files are:
- PBE uses AES-256-CBC
- MAC uses SHA256

EasyRSA will now use OpenSSL v3.x cryptography for command 'export-p12' when using OpenSSL v1.x

Use of EasyRSA command option 'legacy' will revert to the old behavior.