### PR TITLE
Subject-Alt-Name: Correct behavior of global option --san

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
 
+   * Subject-Alt-Name: Allow multiple --san instances (379581d) (#1086)
    * Move Status Reports to 'easyrsa-tools.lib' (214b909) (#1080)
    * export-p12, OpenSSL v1.x: Upgrade PBE and MAC options (60a508a)
      (#1084 - Based on #1081)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5445,9 +5445,12 @@ while :; do
 		export EASYRSA_CP_EXT=1
 		;;
 	--subject-alt-name|--san)
-		export EASYRSA_EXTRA_EXTS="\
-$EASYRSA_EXTRA_EXTS
-subjectAltName = $val"
+		if [ "$EASYRSA_EXTRA_EXTS" ]; then
+			# Append: ",$val"
+			export EASYRSA_EXTRA_EXTS="$EASYRSA_EXTRA_EXTS,$val"
+		else
+			export EASYRSA_EXTRA_EXTS="subjectAltName = $val"
+		fi
 		;;
 	--usefn)
 		export EASYRSA_P12_FR_NAME="$val"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -400,9 +400,12 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
 
       This global option adds a subjectAltName to the request or issued
       certificate. It MUST be in a valid format accepted by openssl or
-      req/cert generation will fail. Note that including multiple such
-      names requires them to be comma-separated; further invocations of
-      this option will REPLACE the value.
+      req/cert generation will fail. NOTE: --san can be specified more
+      than once on the command line.
+      
+      The following two command line examples are equivalent:
+      1. --san=DNS:server1,DNS:serverA,IP:10.0.0.1
+      2. --san=DNS:server1 --san=DNS:serverA --san=IP:10.0.0.1
 
       Examples of the SAN_FORMAT_STRING shown below:
 


### PR DESCRIPTION
--san|--subject-alt-name current behavior is currently incorrect.

Appending any value to EASYRSA_EXTRA_EXTS repeatedly inserts OpenSSL
label 'subjectAltName = ' when this label should be specified once only.

This change correctly formats EASYRSA_EXTRA_EXTS, to only begin with the
label 'subjectAltName = ' and append user values to that string.

Example Command line:

    --san=DNS:server3 --san=DNS:swerveur3 --san=IP:10.2.2.2 --san=IP:10.1.1.1
	--nopass build-server-full s3

Resulting certificate:

    X509v3 Subject Alternative Name:
	    DNS:server3, DNS:swerveur3, IP Address:10.2.2.2, IP Address:10.1.1.1

The originally required command string:

    --san=DNS:server3,DNS:swerveur3,IP:10.2.2.2,IP:10.1.1.1 build-server-full s3

is also still supported.

Also, the Easy-RSA confirmation dialogue is shown as:
```
subject=
    commonName                = s3

X509v3 Subject Alternative Name:
    DNS:server3,DNS:swerveur3,IP:10.2.2.2,IP:10.1.1.1

Type the word 'yes' to continue, or any other input to abort.
  Confirm request details: yes
```