### PR TITLE
Replace 'mkdir -p' with individual 'mkdir' calls

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -911,11 +911,24 @@ Temporary session not preserved."
 			else
 				# create temp-snapshot
 				keep_tmp="$EASYRSA_TEMP_DIR/tmp/$EASYRSA_KEEP_TEMP"
-				mkdir -p "$keep_tmp"
-				rm -rf "$keep_tmp"
-				mv -f "$secured_session" "$keep_tmp"
-				information "Temp session preserved: $keep_tmp"
-				unset -v secured_session
+
+				if [ -d "$EASYRSA_TEMP_DIR"/tmp ]; then
+					mkdir "$keep_tmp"
+					rm -rf "$keep_tmp"
+					mv -f "$secured_session" "$keep_tmp"
+					information "Temp session preserved: $keep_tmp"
+					unset -v secured_session
+				else
+					if mkdir "$EASYRSA_TEMP_DIR"/tmp; then
+						mkdir "$keep_tmp"
+						rm -rf "$keep_tmp"
+						mv -f "$secured_session" "$keep_tmp"
+						information "Temp session preserved: $keep_tmp"
+						unset -v secured_session
+					else
+						warn "Failed to preserve Temporary session."
+					fi
+				fi
 			fi
 		fi
 
@@ -1383,9 +1396,13 @@ and initialize a fresh PKI here."
 		esac
 	fi
 
+	# make PKI
+	mkdir "$EASYRSA_PKI" || die "\
+Failed to create PKI directory (permissions?)"
+
 	# new dirs:
 	for i in issued private reqs inline; do
-		mkdir -p "$EASYRSA_PKI/$i" || \
+		mkdir "$EASYRSA_PKI/$i" || \
 			die "\
 Failed to create PKI file structure (permissions?)"
 	done
@@ -1592,11 +1609,13 @@ current CA. To start a new CA, run init-pki first."
 	# create necessary dirs:
 	err_msg="\
 Unable to create necessary PKI files (permissions?)"
-	for i in certs_by_serial \
-		revoked/certs_by_serial revoked/private_by_serial \
-		revoked/reqs_by_serial
+
+	mkdir "$EASYRSA_PKI"/certs_by_serial || die "$err_msg"
+	mkdir "$EASYRSA_PKI"/revoked || die "$err_msg"
+
+	for i in certs_by_serial private_by_serial reqs_by_serial
 	do
-		mkdir -p "$EASYRSA_PKI/$i" || die "$err_msg"
+		mkdir "$EASYRSA_PKI/revoked/$i" || die "$err_msg"
 	done
 
 	# create necessary files:
@@ -2486,7 +2505,7 @@ Conflicting file found at:
 
 	# Make inline directory
 	[ -d "$EASYRSA_PKI/inline" ] ||	\
-		mkdir -p "$EASYRSA_PKI/inline" || \
+		mkdir "$EASYRSA_PKI/inline" || \
 			die "Failed to create inline directoy."
 
 	# Confirm over write inline file
@@ -2760,14 +2779,18 @@ certificate from being accepted."
 # moves revoked certificates to the 'revoked' folder
 # allows reissuing certificates with the same name
 revoke_move() {
-	for target in "$out_dir" \
-		"$out_dir/certs_by_serial" \
-		"$out_dir/private_by_serial" \
-		"$out_dir/reqs_by_serial"
+	# make sure revoked dirs exist
+	if [ -d "$out_dir" ]; then
+		: # ok
+	else
+		mkdir "$out_dir" || die "Failed to mkdir: $out_dir"
+	fi
+
+	for target in certs_by_serial private_by_serial reqs_by_serial
 	do
-		[ -d "$target" ] && continue
-		mkdir -p "$target" ||
-			die "Failed to mkdir: $target"
+		[ -d "$out_dir/$target" ] && continue
+		mkdir "$out_dir/$target" || \
+			die "Failed to mkdir: $out_dir/$target"
 	done
 
 	# move crt, key and req file to renewed_then_revoked folders
@@ -2912,7 +2935,7 @@ Cannot renew this certificate, a conflicting file exists:
 
 	# Make inline directory
 	[ -d "$EASYRSA_PKI/inline" ] || \
-		mkdir -p "$EASYRSA_PKI/inline" || \
+		mkdir "$EASYRSA_PKI/inline" || \
 			die "Failed to create inline directoy."
 
 	# Extract certificate usage from old cert
@@ -3083,14 +3106,17 @@ Renew FAILED but files have been successfully restored."
 # allows reissuing certificates with the same name
 renew_move() {
 	# make sure renewed dirs exist
-	for target in "$out_dir" \
-		"$out_dir/issued" \
-		"$out_dir/private" \
-		"$out_dir/reqs"
+	if [ -d "$out_dir" ]; then
+		: # ok
+	else
+		mkdir "$out_dir" || die "Failed to mkdir: $out_dir"
+	fi
+
+	for target in issued private reqs
 	do
-		[ -d "$target" ] && continue
-		mkdir -p "$target" ||
-			die "Failed to mkdir: $target"
+		[ -d "$out_dir/$target" ] && continue
+		mkdir "$out_dir/$target" || \
+			die "Failed to mkdir: $out_dir\$target"
 	done
 
 	# move crt, key and req file to renewed folders
@@ -3273,14 +3299,17 @@ certificate from being accepted."
 # moves renewed then revoked certificates to the 'revoked' folder
 revoke_renewed_move() {
 	# make sure revoked dirs exist
-	for target in "$out_dir" \
-		"$out_dir/certs_by_serial" \
-		"$out_dir/private_by_serial" \
-		"$out_dir/reqs_by_serial"
+	if [ -d "$out_dir" ]; then
+		: # ok
+	else
+		mkdir "$out_dir" || die "Failed to mkdir: $out_dir"
+	fi
+
+	for target in certs_by_serial private_by_serial reqs_by_serial
 	do
-		[ -d "$target" ] && continue
-		mkdir -p "$target" ||
-			die "Failed to mkdir: $target"
+		[ -d "$out_dir/$target" ] && continue
+		mkdir "$out_dir/$target" || \
+			die "Failed to mkdir: $out_dir/$target"
 	done
 
 	# move crt, key and req file to renewed_then_revoked folders
@@ -4730,7 +4759,7 @@ Legacy files: openssl-easyrsa.cnf and x509-types/ directory."
 	if write ssl-cnf "$legacy_out_d"
 	then
 		x509_d="$legacy_out_d"/x509-types
-		mkdir -p "$x509_d" || die "legacy_files - x509_d"
+		mkdir "$x509_d" || die "legacy_files - x509_d"
 
 		write COMMON "$x509_d"
 		write ca "$x509_d"


### PR DESCRIPTION
Windows 11 does not allow 'mkdir -p' to function corrctly, the commaand always fails and never returns an error.

Replace 'mkdir -p' with individual calls for each directory depth.