### PR TITLE
New function easyrsa_mkdir_p(): Replace use of 'mkdir -p'

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -800,6 +800,23 @@ remove_secure_session: DELETED: $secured_session"
 	die "remove_secure_session: $secured_session"
 } # => remove_secure_session()
 
+# Replace 'mkdir -p', broken by win11
+easyrsa_mkdir_p() {
+	[ "$#" = 2 ] || die "easyrsa_mkdir_p: input"
+	if [ -d "$1" ]; then
+		: # ok
+	else
+		mkdir "$1" || die "(1) easyrsa_mkdir_p: $1"
+	fi
+
+	if [ -d "$1/$2" ]; then
+		return 0 # Exists ok
+	else
+		mkdir "$1/$2" && return 0 # Exists now
+	fi
+	die "(2) easyrsa_mkdir_p: $1/$2"
+} # => easyrsa_mkdir_p()
+
 # Create temp-file atomically or fail
 # WARNING: Running easyrsa_openssl in a subshell
 # will hide error message and verbose messages
@@ -911,7 +928,8 @@ Temporary session not preserved."
 			else
 				# create temp-snapshot
 				keep_tmp="$EASYRSA_TEMP_DIR/tmp/$EASYRSA_KEEP_TEMP"
-				mkdir -p "$keep_tmp"
+				easyrsa_mkdir_p \
+					"$EASYRSA_TEMP_DIR/tmp" "$EASYRSA_KEEP_TEMP"
 				rm -rf "$keep_tmp"
 				mv -f "$secured_session" "$keep_tmp"
 				information "Temp session preserved: $keep_tmp"
@@ -1385,7 +1403,7 @@ and initialize a fresh PKI here."
 
 	# new dirs:
 	for i in issued private reqs inline; do
-		mkdir -p "$EASYRSA_PKI/$i" || \
+		easyrsa_mkdir_p "$EASYRSA_PKI" "$i" || \
 			die "\
 Failed to create PKI file structure (permissions?)"
 	done
@@ -1592,11 +1610,12 @@ current CA. To start a new CA, run init-pki first."
 	# create necessary dirs:
 	err_msg="\
 Unable to create necessary PKI files (permissions?)"
-	for i in certs_by_serial \
+
+	for i in revoked certs_by_serial \
 		revoked/certs_by_serial revoked/private_by_serial \
 		revoked/reqs_by_serial
 	do
-		mkdir -p "$EASYRSA_PKI/$i" || die "$err_msg"
+		easyrsa_mkdir_p "$EASYRSA_PKI" "$i" || die "$err_msg"
 	done
 
 	# create necessary files:
@@ -2486,7 +2505,7 @@ Conflicting file found at:
 
 	# Make inline directory
 	[ -d "$EASYRSA_PKI/inline" ] ||	\
-		mkdir -p "$EASYRSA_PKI/inline" || \
+		easyrsa_mkdir_p "$EASYRSA_PKI" inline || \
 			die "Failed to create inline directoy."
 
 	# Confirm over write inline file
@@ -2760,13 +2779,9 @@ certificate from being accepted."
 # moves revoked certificates to the 'revoked' folder
 # allows reissuing certificates with the same name
 revoke_move() {
-	for target in "$out_dir" \
-		"$out_dir/certs_by_serial" \
-		"$out_dir/private_by_serial" \
-		"$out_dir/reqs_by_serial"
+	for target in certs_by_serial private_by_serial reqs_by_serial
 	do
-		[ -d "$target" ] && continue
-		mkdir -p "$target" ||
+		easyrsa_mkdir_p "$out_dir" "$target" ||
 			die "Failed to mkdir: $target"
 	done
 
@@ -2912,7 +2927,7 @@ Cannot renew this certificate, a conflicting file exists:
 
 	# Make inline directory
 	[ -d "$EASYRSA_PKI/inline" ] || \
-		mkdir -p "$EASYRSA_PKI/inline" || \
+		easyrsa_mkdir_p "$EASYRSA_PKI" inline || \
 			die "Failed to create inline directoy."
 
 	# Extract certificate usage from old cert
@@ -3083,13 +3098,9 @@ Renew FAILED but files have been successfully restored."
 # allows reissuing certificates with the same name
 renew_move() {
 	# make sure renewed dirs exist
-	for target in "$out_dir" \
-		"$out_dir/issued" \
-		"$out_dir/private" \
-		"$out_dir/reqs"
+	for target in issued private reqs
 	do
-		[ -d "$target" ] && continue
-		mkdir -p "$target" ||
+		easyrsa_mkdir_p "$out_dir" "$target" ||
 			die "Failed to mkdir: $target"
 	done
 
@@ -3273,13 +3284,9 @@ certificate from being accepted."
 # moves renewed then revoked certificates to the 'revoked' folder
 revoke_renewed_move() {
 	# make sure revoked dirs exist
-	for target in "$out_dir" \
-		"$out_dir/certs_by_serial" \
-		"$out_dir/private_by_serial" \
-		"$out_dir/reqs_by_serial"
+	for target in certs_by_serial private_by_serial reqs_by_serial
 	do
-		[ -d "$target" ] && continue
-		mkdir -p "$target" ||
+		easyrsa_mkdir_p "$out_dir" "$target" ||
 			die "Failed to mkdir: $target"
 	done
 
@@ -4730,7 +4737,8 @@ Legacy files: openssl-easyrsa.cnf and x509-types/ directory."
 	if write ssl-cnf "$legacy_out_d"
 	then
 		x509_d="$legacy_out_d"/x509-types
-		mkdir -p "$x509_d" || die "legacy_files - x509_d"
+		easyrsa_mkdir_p "$legacy_out_d" x509-types || \
+			die "legacy_files - x509_d"
 
 		write COMMON "$x509_d"
 		write ca "$x509_d"


### PR DESCRIPTION
Windows 11 does not allow 'mkdir -p' to function correctly, it always fails to create directories and never returns an error.

easyrsa_mkdir_p() replaces 'mkdir -p' by creating individual directories for the parent and then for the child, without using 'mkdir -p' switch.