### PR TITLE
easyrsa_mkdir_p(): Ignore 'mkdir.exe' error code in favor of 'test'

### DIFF
--- a/distro/windows/bin/easyrsa-shell-init.sh
+++ b/distro/windows/bin/easyrsa-shell-init.sh
@@ -65,7 +65,7 @@ Please try using one of the following solutions:
 
 These will start EasyRSA in your user's 'home directory/easy-rsa'
 
-Press enter to exit."
+Press enter to exit.
 ACCESS_DENIED_MSG
 
 	#shellcheck disable=SC2162

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -806,13 +806,15 @@ easyrsa_mkdir_p() {
 	if [ -d "$1" ]; then
 		: # ok
 	else
-		mkdir "$1" || die "(1) easyrsa_mkdir_p: $1"
+		mkdir "$1"
+		[ -d "$1" ] || die "(1) easyrsa_mkdir_p: $1"
 	fi
 
 	if [ -d "$1/$2" ]; then
 		return 0 # Exists ok
 	else
-		mkdir "$1/$2" && return 0 # Exists now
+		mkdir "$1/$2"
+		[ -d "$1/$2" ] && return 0 # Exists now
 	fi
 	die "(2) easyrsa_mkdir_p: $1/$2"
 } # => easyrsa_mkdir_p()


### PR DESCRIPTION
Windows 11 does not recognise errors generated by 'mkdir.exe'.

Ignore errors generated by 'mkdir.exe' and test the existence of the newly created directory.