### PR TITLE
Add an option to change the subject when signing a request. `V2`

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,9 @@ Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
 
+   * Introduce Options to edit Request Subject during command 'sign-req'
+     Global Option: --new-subject -- Command 'sign-req' option: 'newsubj'
+     First proposed in: (#439) -- Completed: (83b81c7) (#1111)
    * docs: Update EasyRSA-Renew-and-Revoke.md (f6c2bf5) (#1109)
    * Remove all 'renew' code; replaced by 'expire' code (9d94207) (#1109)
    * Introduce commands: 'expire' and 'revoke-expired' (a1890fa) (#1109)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -176,6 +176,7 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
       This request file must exist in the reqs/ dir and have a .req file
       extension. See 'import-req' for importing from other sources."
 		opts="
+      * newsubj  - Replace subject. See 'help subject'.
       * preserve - Use the DN-field order of the CSR not the CA."
 	;;
 	build|build-client-full|build-server-full|build-serverClient-full)
@@ -470,6 +471,24 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
 
       Can only be used in BATCH mode."
 	;;
+	--new-subject|newsubj*|subject)
+		text_only=1
+		text="
+* Global Option: --new-subject=<SUBJECT>
+
+      This global option is used to set the new certificate subject,
+      when signing a new certificate
+
+* REQUIRES Command option: 'newsubj', for command 'sign-req'
+
+      Using command 'sign-req', add command option 'newsubj',
+      to FORCE the --new-subject to be used.
+
+      Example:
+      --new-subject='/CN=foo' sign-req client bar newsubj
+
+      See OpenSSL command 'ca', option -subj, for full details."
+	;;
 	tool*|util*|more)
 		# Test features
 		text_only=1
@@ -600,6 +619,9 @@ Certificate & Request options: (these impact cert/req field values)
 --san|--subject-alt-name=<subjectAltName>
                 : Add a subjectAltName.
                   For more info and syntax, see: 'easyrsa help altname'
+
+--new-subject   : Specify a new subject field to sign a request with.
+                  For more info and syntax, see: 'easyrsa help subject'
 
 --usefn=NAME    : export-p12, set 'friendlyName' to NAME
                   For more, see: 'easyrsa help friendly'

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2102,16 +2102,32 @@ Option conflict --req-cn:
 	# Enforce commonName
 	export EASYRSA_REQ_CN="$file_name_base"
 
-	# Check for preserve-dn
+	# Check optional subject
+	force_subj=
 	while [ "$1" ]; do
 		case "$1" in
+			newsubj*)
+				# verify force_subj opts are used correctly
+				[ "$EASYRSA_NEW_SUBJECT" ] || user_error "\
+To force a new certificate subject, global option --new-subject
+must also be specified."
+				force_subj="$EASYRSA_NEW_SUBJECT"
+			;;
 			preserve*)
 				export EASYRSA_PRESERVE_DN=1
 			;;
-			*) warn "Ignoring unknown option '$1'"
+			*)
+				user_error "Unknown option '$1'"
 		esac
 		shift
 	done
+
+	# verify force_subj opts are used correctly
+	if [ "$EASYRSA_NEW_SUBJECT" ]; then
+		[ "$force_subj" ] || user_error "\
+To force a new certificate subject, command option 'newsubj'
+must also be specified."
+	fi
 
 	# Cert type must NOT be COMMON
 	[ "$crt_type" = COMMON ] && user_error "\
@@ -2309,8 +2325,14 @@ for '$EASYRSA_CERT_EXPIRE' days"
 	fi
 
 	# Set confirm DN
-	confirm_dn="$(display_dn req "$req_in")" || \
-		die "sign-req: display_dn"
+	if [ "$force_subj" ]; then
+		confirm_dn="\
+Forced subject=
+    $force_subj"
+	else
+		confirm_dn="$(display_dn req "$req_in")" || \
+			die "sign-req: display_dn"
+	fi
 
 	# Set confirm SAN
 	# SAN from .req
@@ -2388,6 +2410,7 @@ $confirm_details" # => confirm end
 		-in "$req_in" -out "$crt_out_tmp" \
 		-extfile "$ext_tmp" \
 		${EASYRSA_PRESERVE_DN:+ -preserveDN} \
+		${force_subj:+ -subj "$force_subj"} \
 		${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
 		${EASYRSA_NO_TEXT:+ -notext} \
 		${EASYRSA_CERT_EXPIRE:+ -days "$EASYRSA_CERT_EXPIRE"} \
@@ -5163,6 +5186,9 @@ while :; do
 		else
 			EASYRSA_SAN="$val"
 		fi
+		;;
+	--new-subject)
+		export EASYRSA_NEW_SUBJECT="$val"
 		;;
 	--usefn)
 		export EASYRSA_P12_FR_NAME="$val"


### PR DESCRIPTION
Add the OpenSSL method to change a `subject`, when signing a request.

See OpenSSL command `ca`, option `-subj`, for details.

Initially proposed by: #439

Extensively tested locally.