### PR TITLE
build-ca: Command 'req', remove SSL option '-keyout'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
 
+   * build-ca: Command 'req', remove SSL option '-keyout' (4e02c8a) (#1123)
    * Remove escape_hazard(), obsolete (ca76697)
    * Remove command and function display_cn(), unused (be8f400) (#1114)
    * Introduce Options to edit Request Subject during command 'sign-req'

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1794,7 +1794,7 @@ build_ca: CA key password created via temp-files"
 
 	# Generate the CA keypair:
 	easyrsa_openssl req -utf8 -new \
-		-key "$out_key_tmp" -keyout "$out_key_tmp" \
+		-key "$out_key_tmp" \
 		-out "$out_file_tmp" \
 		${ssl_batch:+ -batch} \
 		${x509:+ -x509} \


### PR DESCRIPTION
OpenSSL command 'req', option '-keyout' behaves differently between OpenSSL v3.x verses v1.x

When the private key is encrypted:
- v1.x ignores '-keyout' and does not create a new key.
- v3.x creates a new key with different parameters to the original key.

v3.x creates the original key, encrypted by AES-256-CBC; then creates the unnecessary, secondary key, encrypted by DES-EDE3-CBC.

Because EasyRSA has already generated the private key, the 'req' command must not generate a secondary key.