### PR TITLE
build-ca: Command 'req', remove SSL option '-keyout'

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1923,7 +1923,7 @@ build_ca: CA certificate password created via RAW"
 
 	else
 		easyrsa_openssl req -utf8 -new \
-			-key "$out_key_tmp" -keyout "$out_key_tmp" \
+			-key "$out_key_tmp" \
 			-out "$out_file_tmp" \
 			${ssl_batch:+ -batch} \
 			${x509:+ -x509} \


### PR DESCRIPTION
OpenSSL command 'req', option '-keyout' behaves differently between OpenSSL v3.x verses v1.x

When the private key is encrypted:
- v1.x ignores '-keyout' and does not create a new key.
- v3.x creates a new key with different parameters to the original key.

v3.x creates the original key, encrypted by AES-256-CBC; then creates the unnecessary, secondary key, encrypted by DES-EDE3-CBC.

Because EasyRSA has already generated the private key, the 'req' command must not generate a secondary key.