### PR TITLE
Improve ssl_cert_x509v3_eku()

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3557,12 +3557,11 @@ ssl_cert_x509v3_eku() {
 	# Extract certificate Extended Key Usage
 	if [ "$ssl_lib" = libressl ]; then
 		__eku="$(
-			easyrsa_openssl x509 -in "${__crt}" -noout -text | \
+			"$EASYRSA_OPENSSL" x509 -in "${__crt}" -noout -text | \
 				sed -n "/${__pattern}/{n;s/^ *//g;p;}"
 			)"
 	else
 		__eku="$(
-			OPENSSL_CONF=/dev/null
 			"$EASYRSA_OPENSSL" x509 -in "${__crt}" -noout \
 				-ext extendedKeyUsage | \
 					sed -e /"${__pattern}"/d -e s/^\ *//
@@ -3614,6 +3613,8 @@ ssl_cert_x509v3_eku() {
 		return
 	fi
 
+	# Also, catch errors from SSL x509 command
+	# for '__eku' subshell+pipe
 	return 1
 } # => ssl_cert_x509v3_eku()
 


### PR DESCRIPTION
Remove subshell definition for OPENSSL_CONF, not required.

Call SSL binary directly, do not use easyrsa_openssl() wrapper.

Add comment to clarify error detection from subshell failure.