### PR TITLE
self-sign: Adjust 'X509v3 Key Usage'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
 
+   * New X509 Type: 'selfsign' Internal only (999533e) (#1135)
    * New commands: self-sign-server and self-sign-client (9f8a1d1) (#1127)
    * build-ca: Command 'req', remove SSL option '-keyout' (4e02c8a) (#1123)
    * Remove escape_hazard(), obsolete (ca76697)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1924,6 +1924,56 @@ Conflicting certificate exists at:
 	verbose "\
 self-sign: Use ALGO/CURVE to $EASYRSA_ALGO/$EASYRSA_CURVE"
 
+	# Assign tmp-file for config
+	adjusted_ssl_cnf_tmp=""
+	easyrsa_mktemp adjusted_ssl_cnf_tmp || \
+		die "build_self_sign - easyrsa_mktemp adjusted_ssl_cnf_tmp"
+
+	# Assign awkscript to insert EASYRSA_EXTRA_EXTS
+	# shellcheck disable=SC2016 # No expand '' - build_ca()
+	awkscript='\
+{if ( match($0, "^#%CA_X509_TYPES_EXTRA_EXTS%") )
+	{ while ( getline<"/dev/stdin" ) {print} next }
+ {print}
+}'
+
+	# Find or create x509 selfsign file
+	if [ -f "$EASYRSA_EXT_DIR/selfsign" ]; then
+		# Use the x509-types/selfsign file
+		x509_selfsign_file="$EASYRSA_EXT_DIR/selfsign"
+	else
+		# Use a temp file
+		write_x509_type_tmp selfsign
+		x509_selfsign_file="$write_x509_file_tmp"
+	fi
+
+	# Find or create x509 COMMON file
+	if [ -f "$EASYRSA_EXT_DIR/COMMON" ]; then
+		# Use the x509-types/COMMON file
+		x509_COMMON_file="$EASYRSA_EXT_DIR/COMMON"
+	else
+		# Use a temp file
+		write_x509_type_tmp COMMON
+		x509_COMMON_file="$write_x509_file_tmp"
+	fi
+
+	# Insert x509-types COMMON and 'selfsign' and EASYRSA_EXTRA_EXTS
+	{
+		# X509 files
+		cat "$x509_selfsign_file" "$x509_COMMON_file"
+
+		# User extentions
+		[ "$EASYRSA_EXTRA_EXTS" ] && \
+			print "$EASYRSA_EXTRA_EXTS"
+
+	} | awk "$awkscript" "$EASYRSA_SSL_CONF" \
+			> "$adjusted_ssl_cnf_tmp" || \
+				die "Copying X509_TYPES to config file failed"
+	verbose "build_self_sign: insert x509 and extensions OK"
+
+	# Use this new SSL config for the rest of this function
+	EASYRSA_SSL_CONF="$adjusted_ssl_cnf_tmp"
+
 	# temp-file for params-file
 	selfsign_params_file=""
 	easyrsa_mktemp selfsign_params_file || \
@@ -1941,7 +1991,6 @@ self-sign: Use ALGO/CURVE to $EASYRSA_ALGO/$EASYRSA_CURVE"
 		-keyout "$key_out" \
 		-out "$crt_out" \
 		-subj "/CN=$file_name_base" \
-		-addext extendedKeyUsage="$selfsign_eku" \
 		${EASYRSA_NO_PASS:+ "$no_password"} \
 		${EASYRSA_PASSIN:+ -passin "$EASYRSA_PASSIN"} \
 		${EASYRSA_PASSOUT:+ -passout "$EASYRSA_PASSOUT"} \
@@ -4557,6 +4606,12 @@ write() {
 			write_file="$write_dir/$write_type"
 		fi
 	;;
+	selfsign)
+		# write to stdout or $write_dir/$write_type [x509-type]
+		if [ "$write_dir" ]; then
+			write_file="$write_dir/$write_type"
+		fi
+	;;
 	*)
 		user_error "write - unknown type '$write_type'"
 	esac
@@ -4677,6 +4732,17 @@ create_legacy_stream() {
 		authorityKeyIdentifier = keyid:always,issuer:always
 		keyUsage = cRLSign, keyCertSign
 		CREATE_X509_TYPE_CA
+	;;
+	selfsign)
+	# selfsign
+		cat <<- "CREATE_X509_TYPE_SELFSIGN"
+		subjectKeyIdentifier = hash
+		authorityKeyIdentifier = keyid:always,issuer:always
+		basicConstraints = CA:TRUE
+		keyUsage = digitalSignature,keyEncipherment
+		CREATE_X509_TYPE_SELFSIGN
+
+		print "extendedKeyUsage = $selfsign_eku"
 	;;
 	codeSigning)
 	# codeSigning


### PR DESCRIPTION
Self signed certificates are not used for any signing purposes. Replace signing usage with standard server/client usage.

Set:
```
  X509v3 Key Usage:
    Digital Signature, Key Encipherment
```

Remove:
```
  X509v3 Key Usage:
    Certificate Sign, CRL Sign
```

If this is changed by using SSL command 'req', option -addext, without using an SSL config file then 'X509v3 Basic Constraints' is set to 'critical'.

Also, SSL command 'req' does not support -extfile, which is why the script uses the '#%CA_X509_TYPES_EXTRA_EXTS%' marker in order to insert the required extensions into the SSL config file.

This change is of no consequense to OpenVPN peer fingerprint mode but it does make all EasyRSA generated certificates use extensions consistently.

This also introduces an x509-type file for self-signed certificates. This file is not exposed via the x509-types files, it is retained for internal use only.