### PR TITLE
Revert ca76697: Remove escape_hazard()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.0 (TBD)
 
+   * Revert ca76697: Restore escape_hazard() (b1e9d7a) (#1137)
    * New X509 Type: 'selfsign' Internal only (999533e) (#1135)
    * New commands: self-sign-server and self-sign-client (9f8a1d1) (#1127)
    * build-ca: Command 'req', remove SSL option '-keyout' (4e02c8a) (#1123)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1027,6 +1027,63 @@ Temporary session not preserved."
 	exit 1
 } # => cleanup()
 
+# Escape hazardous characters
+# Auto-escape hazardous characters:
+# '&' - Workaround 'sed' behavior
+# '$' - Workaround 'easyrsa' based limitation
+# This is required for all SSL libs, otherwise,
+# there are unacceptable differences in behavior
+escape_hazard() {
+	if [ "$EASYRSA_FORCE_SAFE_SSL" ] || \
+		[ "$makesafeconf" ]
+	then
+		# Always run
+		verbose "escape_hazard: FORCED"
+	elif [ "$working_safe_org_conf" ]; then
+		# Has run once
+		verbose "escape_hazard: BYPASSED"
+		return
+	else
+		# Run once
+		verbose "escape_hazard: RUN-ONCE"
+	fi
+
+	# Only use if old 'sed' version is requested
+	if [ "$EASYRSA_LEGACY_SAFE_SSL" ]; then
+		: # ok
+	else
+		verbose "escape_hazard: REPLACED by heredoc expansion"
+		verbose "escape_hazard: ABANDONED"
+		return
+	fi
+
+	# Set run once
+	working_safe_org_conf=1
+
+	# Assign temp-file
+	escape_hazard_tmp=""
+	easyrsa_mktemp escape_hazard_tmp || die \
+		"escape_hazard - easyrsa_mktemp escape_hazard_tmp"
+
+	# write org fields to org temp-file and escape '&' and '$'
+	print "\
+export EASYRSA_REQ_COUNTRY=\"$EASYRSA_REQ_COUNTRY\"
+export EASYRSA_REQ_PROVINCE=\"$EASYRSA_REQ_PROVINCE\"
+export EASYRSA_REQ_CITY=\"$EASYRSA_REQ_CITY\"
+export EASYRSA_REQ_ORG=\"$EASYRSA_REQ_ORG\"
+export EASYRSA_REQ_OU=\"$EASYRSA_REQ_OU\"
+export EASYRSA_REQ_EMAIL=\"$EASYRSA_REQ_EMAIL\"
+export EASYRSA_REQ_SERIAL=\"$EASYRSA_REQ_SERIAL\"\
+" | sed -e s\`'\&'\`'\\\&'\`g \
+		-e s\`'\$'\`'\\\$'\`g \
+			> "$escape_hazard_tmp" || die "\
+escape_hazard - Failed to write temp-file"
+
+	# Reload fields from fully escaped temp-file
+	source_vars "$escape_hazard_tmp"
+	verbose "escape_hazard: COMPLETED"
+} # => escape_hazard()
+
 # Replace environment variable names with current value
 # and write to temp-file or return error from sed
 expand_ssl_config() {
@@ -1141,6 +1198,10 @@ easyrsa_openssl() {
 		rand)
 			die "easyrsa_openssl: Illegal SSL command: rand"
 	esac
+
+	# Auto-escape hazardous characters
+	escape_hazard || \
+		die "easyrsa_openssl - escape_hazard failed"
 
 	# Rewrite SSL config
 	expand_ssl_config || \


### PR DESCRIPTION
escape_hazard() is still required for legacy 'sed; expansion of SSL config, which is still present in v3.2.0.