### PR TITLE
easyrsa_openssl(): Always export $OPENSSL_CONF as $EASYRSA_SSL_CONF

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1163,6 +1163,10 @@ easyrsa_mktemp safe_ssl_cnf_tmp"
 			die "expand_ssl_config - write safe-cnf temp-file"
 		verbose "expand_ssl_config: via 'write' COMPLETED"
 	fi
+
+	export EASYRSA_SSL_CONF="$safe_ssl_cnf_tmp"
+	verbose "\
+expand_ssl_config: EASYRSA_SSL_CONF = $EASYRSA_SSL_CONF"
 } # => expand_ssl_config()
 
 # Easy-RSA meta-wrapper for SSL
@@ -1192,15 +1196,8 @@ easyrsa_openssl() {
 		die "easyrsa_openssl - expand_ssl_config failed"
 
 	# VERIFY safe temp-file exists
-	if [ -e "$safe_ssl_cnf_tmp" ]; then
-		verbose "\
-> easyrsa_openssl: Safe SSL conf OK: $safe_ssl_cnf_tmp"
-		export OPENSSL_CONF="$safe_ssl_cnf_tmp"
-	else
-		verbose "\
-> easyrsa_openssl: No Safe SSL conf, FALLBACK to default"
-		export OPENSSL_CONF="$EASYRSA_SSL_CONF"
-	fi
+	export OPENSSL_CONF="$EASYRSA_SSL_CONF"
+	verbose "easyrsa_openssl: OPENSSL_CONF = $EASYRSA_SSL_CONF"
 
 	# Debug level
 	[ -z "$EASYRSA_DEBUG" ] || \
@@ -2396,6 +2393,7 @@ Writing 'copy_exts' to SSL config temp-file failed"
 		# Use this SSL config for the rest of this function
 		EASYRSA_SSL_CONF="$adjusted_ssl_cnf_tmp"
 		verbose "sign_req: Using '$copy_exts'"
+		verbose "sign_req: EASYRSA_SSL_CONF = $EASYRSA_SSL_CONF"
 	fi
 
 	# Find or create x509-type file
@@ -2739,7 +2737,9 @@ Option conflict --req-cn:
 	do_build_full=1
 
 	# create request
+	verbose "build_full: BEGIN gen_req"
 	gen_req "$name" batch
+	verbose "build_full: END gen_req"
 
 	# Require --copy-ext
 	export EASYRSA_CP_EXT=1
@@ -2748,6 +2748,7 @@ Option conflict --req-cn:
 	export EASYRSA_REQ_CN=ChangeMe
 
 	# Sign it
+	verbose "build_full: BEGIN sign_req"
 	error_build_full_cleanup=1
 	if sign_req "$crt_type" "$name"; then
 		unset -v error_build_full_cleanup do_build_full
@@ -2756,6 +2757,7 @@ Option conflict --req-cn:
 Failed to sign '$name' - \
 See error messages above for details."
 	fi
+	verbose "build_full: END sign_req"
 
 	# inline it
 	if inline_creds "$name" > "$inline_out"; then
@@ -4279,18 +4281,6 @@ Algorithm '$EASYRSA_ALGO' is invalid: Must be 'rsa', 'ec' or 'ed'"
 	set_var EASYRSA_REQ_CN			ChangeMe
 	set_var EASYRSA_DIGEST			sha256
 
-	# Now set by locate_support_files()
-	#set_var EASYRSA_SSL_CONF		\
-	#	"$EASYRSA_PKI/openssl-easyrsa.cnf"
-
-	# created as required
-	set_var EASYRSA_SAFE_CONF		\
-		"$EASYRSA_PKI/safessl-easyrsa.cnf"
-
-	# Now set by locate_support_files()
-	#set_var EASYRSA_TOOLS_LIB		\
-	#	"$EASYRSA/dev/easyrsa-tools.lib"
-
 	set_var EASYRSA_KDC_REALM		"CHANGEME.EXAMPLE.COM"
 
 	set_var EASYRSA_MAX_TEMP		4
@@ -4505,12 +4495,12 @@ write_easyrsa_ssl_cnf_tmp - easyrsa_mktemp"
 
 	# Write SSL cnf to temp-file
 	write ssl-cnf > "$ssl_cnf_tmp" || die "\
-write_easyrsa_ssl_cnf_tmp - write ssl-cnf"
+write_easyrsa_ssl_cnf_tmp - write ssl-cnf: $ssl_cnf_tmp"
 
 	# export SSL cnf tmp
 	export EASYRSA_SSL_CONF="$ssl_cnf_tmp"
 	verbose "\
-write_easyrsa_ssl_cnf_tmp: SSL config using temp-file"
+write_easyrsa_ssl_cnf_tmp: EASYRSA_SSL_CONF = $ssl_cnf_tmp"
 } # => write_easyrsa_ssl_cnf_tmp()
 
 # Write x509 type file to a temp file


### PR DESCRIPTION
The problem was that easyrsa_openssl() would select an SSL config file based on the existence of the $EASYRSA_SAFE_CONF file. This caused the selector to ignore a newer $EASYRSA_SSL_CONF file.

This only occurs: 1. During build_full(), when gen_req() and sign_req() are chained together, instead of being separate instnces. Combined with
2. When using LibreSSL, which requires expansion of the SSL config file.

This change forces easyrsa_openssl() to only ever set $OPENSSL_CONF to $EASYRSA_SSL_CONF, ignoring the safe config file.

Use of the safe config file $EASYRSA_SAFE_CONF is now completely removed.

Also includes verbose diagnostic information.