### PR TITLE
Unit-test: Add Old expansion test on nix (EASYRSA_FORCE_SAFE_SSL)

### DIFF
--- a/.github/workflows/action.yml
+++ b/.github/workflows/action.yml
@@ -43,6 +43,36 @@ jobs:
       #      echo test, and deploy your project.
       # This workflow contains a single job called "build"
 
+  xtest_old:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    env:
+      EASYRSA_BY_TINCANTECH: 1
+      EASYRSA_REMOTE_CI: 1
+      EASYRSA_NIX: 1
+      TERM: xterm-256color
+      EASYRSA_SILENT_SSL: 1
+      EASYRSA_FORCE_SAFE_SSL: 1
+      EASYRSA_LEGACY_SAFE_SSL: 1
+      EASYRSA_VERBOSE: 1
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: operational test
+        run: sh op-test.sh -vv -sc -o3 -p
+
+      # Runs a set of commands using the runners shell
+      # - name: Run a multi-line script
+      #    run: |
+      #      echo Add other actions to build,
+      #      echo test, and deploy your project.
+      # This workflow contains a single job called "build"
+
   wtest:
     # The type of runner that the job will run on
     runs-on: windows-latest


### PR DESCRIPTION
This forces the unit test to use the original `sed` expansion of `openssl-easyrsa.cnf` on Linux. This also forces use of `escape_hazard()`.