### PR TITLE
Command gen-req: Re-enable global option --req-cn - Includes build_full()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.1 (TBD)
 
+   * gen-req: Re-enable use of --req-cn (5cf8c46) (#1170)
    * write: Change syntax, target as file, not directory (722ce54) (#1165)
 
 3.2.0 (2024-05-18)

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.1 (TBD)
 
+   * build-ca: Allow use of --req-cn without batch mode (b77a0fb) (#1170)
    * gen-req: Re-enable use of --req-cn (5cf8c46) (#1170)
    * write: Change syntax, target as file, not directory (722ce54) (#1165)
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -468,18 +468,6 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
       * Cutoff days for command: show-expire.
         eg: '--days=90 show-expire'"
 	;;
-	--req-cn|req-cn)
-		text_only=1
-		text="
-* Global Option: --req-cn=NAME
-
-      This global option can be used to set the CA commonName.
-
-      * To build a new CA [or Sub-CA]:
-        eg: '--batch --req-cn=NAME build-ca [subca]'
-
-      Can only be used in BATCH mode."
-	;;
 	--new-subj*|new-subj*|newsubj*|subject)
 		text_only=1
 		text="
@@ -635,7 +623,7 @@ Distinguished Name mode:
 
 --dn-mode=MODE  : Distinguished Name mode to use 'cn_only' (Default) or 'org'
 
---req-cn=NAME   : Set CA commonName. For details, see: 'help req-cn'
+--req-cn=NAME   : Request commonName
 
   Distinguished Name Organizational options: (only used with '--dn-mode=org')
   --req-c=CC           : Country code (2-letters)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2940,14 +2940,6 @@ Run easyrsa without commands for usage and command help."
 	file_name_base="$1"
 	shift
 
-	# Prohibit --req-cn
-	[ "$EASYRSA_REQ_CN" = ChangeMe ] || user_error "\
-Option conflict --req-cn:
-* '$cmd' does not support setting an external commonName"
-
-	# Enforce commonName
-	export EASYRSA_REQ_CN="$file_name_base"
-
 	# create local SSL cnf
 	write_easyrsa_ssl_cnf_tmp
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1864,7 +1864,7 @@ CA creation complete. Your new CA certificate is at:
 } # => build_ca()
 
 # Build self signed key pair
-build_self_sign() {
+self_sign() {
 	# Define x509 type
 	case "$1" in
 		server)
@@ -1874,7 +1874,7 @@ build_self_sign() {
 			selfsign_eku=clientAuth
 			;;
 		*)
-			die "build_self_sign: Unknown EKU '$1'"
+			die "self_sign: Unknown EKU '$1'"
 	esac
 	shift
 
@@ -1959,7 +1959,7 @@ self-sign: Use ALGO/CURVE to $EASYRSA_ALGO/$EASYRSA_CURVE"
 	# Assign tmp-file for config
 	adjusted_ssl_cnf_tmp=""
 	easyrsa_mktemp adjusted_ssl_cnf_tmp || \
-		die "build_self_sign - easyrsa_mktemp adjusted_ssl_cnf_tmp"
+		die "self_sign - easyrsa_mktemp adjusted_ssl_cnf_tmp"
 
 	# Assign awkscript to insert EASYRSA_EXTRA_EXTS
 	# shellcheck disable=SC2016 # No expand '' - build_ca()
@@ -2001,7 +2001,7 @@ self-sign: Use ALGO/CURVE to $EASYRSA_ALGO/$EASYRSA_CURVE"
 	} | awk "$awkscript" "$EASYRSA_SSL_CONF" \
 			> "$adjusted_ssl_cnf_tmp" || \
 				die "Copying X509_TYPES to config file failed"
-	verbose "build_self_sign: insert x509 and extensions OK"
+	verbose "self_sign: insert x509 and extensions OK"
 
 	# Use this new SSL config for the rest of this function
 	EASYRSA_SSL_CONF="$adjusted_ssl_cnf_tmp"
@@ -2009,22 +2009,22 @@ self-sign: Use ALGO/CURVE to $EASYRSA_ALGO/$EASYRSA_CURVE"
 	# temp-file for params-file
 	selfsign_params_file=""
 	easyrsa_mktemp selfsign_params_file || \
-		die "build_self_sign - easyrsa_mktemp selfsign_params_file"
+		die "self_sign - easyrsa_mktemp selfsign_params_file"
 
 	# params-file
 	"$EASYRSA_OPENSSL" ecparam \
 		-name "$EASYRSA_CURVE" \
 		-out "$selfsign_params_file" || \
-			die "build_self_sign - params-file failed"
+			die "self_sign - params-file failed"
 
 	# Create temp-files for output
 	tmp_key_out=""
 	easyrsa_mktemp tmp_key_out || \
-		die "build_self_sign - easyrsa_mktemp tmp_key_out"
+		die "self_sign - easyrsa_mktemp tmp_key_out"
 
 	tmp_crt_out=""
 	easyrsa_mktemp tmp_crt_out || \
-		die "build_self_sign - easyrsa_mktemp tmp_crt_out"
+		die "self_sign - easyrsa_mktemp tmp_crt_out"
 
 	# create self-signed key pair
 	easyrsa_openssl req -x509 -utf8 -sha256 -text \
@@ -2051,7 +2051,7 @@ self-sign: Use ALGO/CURVE to $EASYRSA_ALGO/$EASYRSA_CURVE"
 	crt_fingerprint="$(
 		"$EASYRSA_OPENSSL" x509 -in "$crt_out" -noout \
 			-sha256 -fingerprint
-	)" || die "build_self_sign - Failed -fingerprint"
+	)" || die "self_sign - Failed -fingerprint"
 
 	# strip fingerprint prefix
 	crt_fingerprint="${crt_fingerprint#*=}"
@@ -2076,7 +2076,7 @@ Inline file created:
 INCOMPLETE Inline file created:
 * $inline_out"
 	fi
-} # => build_self_sign()
+} # => self_sign()
 
 # gen-dh backend:
 gen_dh() {
@@ -2839,7 +2839,7 @@ inline_creds() {
 				crt_fingerprint="$(
 					"$EASYRSA_OPENSSL" x509 -in "$crt_source" \
 						-noout -sha256 -fingerprint
-					)" || die "build_self_sign - Failed -fingerprint"
+					)" || die "self_sign - Failed -fingerprint"
 				# strip prefix
 				crt_fingerprint="${crt_fingerprint#*=}"
 			fi
@@ -5536,13 +5536,13 @@ case "$cmd" in
 		verify_working_env
 		[ -z "$alias_days" ] || \
 			export EASYRSA_CERT_EXPIRE="$alias_days"
-		build_self_sign server "$@"
+		self_sign server "$@"
 		;;
 	self-sign-client)
 		verify_working_env
 		[ -z "$alias_days" ] || \
 			export EASYRSA_CERT_EXPIRE="$alias_days"
-		build_self_sign client "$@"
+		self_sign client "$@"
 		;;
 	gen-dh)
 		verify_working_env

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1631,8 +1631,6 @@ Unable to create necessary PKI files (permissions?)"
 	# otherwise use default
 	if [ "$EASYRSA_BATCH" ]; then
 		ssl_batch=1
-	else
-		export EASYRSA_REQ_CN=ChangeMe
 	fi
 
 	# Default CA commonName

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2551,16 +2551,11 @@ Failed to create temp extension file (bad permissions?) at:
 		confirm_period="  Valid for:      '$EASYRSA_CERT_EXPIRE' days"
 	fi
 
-	# Set confirm force_subj
-	confirm_force_subj=
-	[ "$force_subj" ] && \
-		confirm_force_subj="${NL}* Forced Subject: '$force_subj'${NL}"
-
 	# Set confirm DN
 	if [ "$force_subj" ]; then
-		confirm_dn="$force_subj"
+		confirm_dn="${NL}* Forced Subject: '$force_subj'${NL}"
 	else
-		confirm_dn="$(display_dn req "$req_in")" || \
+		confirm_dn="${NL}$(display_dn req "$req_in")" || \
 			die "sign-req: display_dn"
 	fi
 
@@ -2593,7 +2588,6 @@ Failed to create temp extension file (bad permissions?) at:
 $confirm_CN
 $confirm_type
 $confirm_period
-$confirm_force_subj
 $confirm_dn"
 
 	# --san takes priority over req SAN and --copy-ext

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5387,7 +5387,7 @@ while :; do
 				EASYRSA_SAN="$val"
 			fi
 			;;
-		--new-subject)
+		--new-subj*)
 			export EASYRSA_NEW_SUBJECT="$val"
 			;;
 		--usefn)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2564,7 +2564,7 @@ Failed to create temp extension file (bad permissions?) at:
 	if [ "$EASYRSA_CP_EXT" ]; then
 		# cature complete CSR
 		req_text="$(
-			easyrsa_openssl req -in "$req_in" -noout -text
+			"$EASYRSA_OPENSSL" req -utf8 -in "$req_in" -noout -text
 			)" || die "sign-req: openssl: req_text"
 
 		# Check CSR for any requested SAN

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2159,13 +2159,10 @@ Run easyrsa without commands for usage and commands."
 		ssl_batch=1
 	fi
 
-	# Prohibit --req-cn
-	[ "$EASYRSA_REQ_CN" = ChangeMe ] || user_error "\
-Option conflict --req-cn:
-* '$cmd' does not support setting an external commonName"
-
-	# Enforce commonName
-	export EASYRSA_REQ_CN="$file_name_base"
+	# Set commonName
+	if [ "$EASYRSA_REQ_CN" = ChangeMe ]; then
+		export EASYRSA_REQ_CN="$file_name_base"
+	fi
 
 	# create local SSL cnf
 	write_easyrsa_ssl_cnf_tmp
@@ -2315,14 +2312,6 @@ expected 2, got $# (see command help for usage)"
 	req_in="$EASYRSA_PKI/reqs/$file_name_base.req"
 	crt_out="$EASYRSA_PKI/issued/$file_name_base.crt"
 	shift 2
-
-	# Prohibit --req-cn
-	[ "$EASYRSA_REQ_CN" = ChangeMe ] || user_error "\
-Option conflict --req-cn:
-* '$cmd' does not support setting an external commonName"
-
-	# Enforce commonName
-	export EASYRSA_REQ_CN="$file_name_base"
 
 	# create local SSL cnf
 	write_easyrsa_ssl_cnf_tmp
@@ -2546,6 +2535,13 @@ Error message: $error_msg
 Failed to create temp extension file (bad permissions?) at:
 * $ext_tmp"
 	verbose "sign_req: Generated extensions file OK"
+
+	# Get request CN
+	EASYRSA_REQ_CN="$(
+		"$EASYRSA_OPENSSL" req -utf8 -in "$req_in" -noout \
+			-subject -nameopt multiline | grep 'commonName'
+	)" || warn "sign-req - EASYRSA_REQ_CN FAILED"
+	EASYRSA_REQ_CN="${EASYRSA_REQ_CN##*= }"
 
 	# Set confirm CN
 	confirm_CN="  Requested CN:   '$EASYRSA_REQ_CN'"
@@ -2781,11 +2777,6 @@ Warning!
 An inline file for name '$name' already exists:
 * $inline_out"
 
-	# Set commonName
-	[ "$EASYRSA_REQ_CN" = ChangeMe ] || user_error "\
-Option conflict --req-cn:
-* '$cmd' does not support setting an external commonName"
-
 	# Set to modify sign-req confirmation message
 	do_build_full=1
 
@@ -2803,9 +2794,6 @@ Option conflict --req-cn:
 
 	# Require --copy-ext
 	export EASYRSA_CP_EXT=1
-
-	# Must be reset for nested commmands
-	export EASYRSA_REQ_CN=ChangeMe
 
 	# Sign it
 	verbose "build_full: BEGIN sign_req"

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2290,6 +2290,15 @@ sign_req() {
 	crt_type="$1"
 	file_name_base="$2"
 
+	# Verify $crt_type is valid
+	case "$crt_type" in
+		ca|server|serverClient|client|codeSigning|email|kdc)
+			: # All known types plus CA for sub-ca
+		;;
+		*)
+			user_error "Type is not recognised: '$crt_type'"
+	esac
+
 	# Check argument sanity:
 	[ "$file_name_base" ] || user_error "\
 Incorrect number of arguments provided to sign-req:


### PR DESCRIPTION
This allows disconnecting 'commonName' from "$file_name_base". Tested.

Revert #1098 