### PR TITLE
Command revoke: Add confirmation for possible misuse

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2978,6 +2978,62 @@ Unable to revoke as the input-file is not a valid certificate.
 Certificate was expected at:
 * $crt_in"
 
+	# Check for misuse of revoke when revoke-* is intended
+	case "${cert_dir}" in
+	issued)
+		# expired cert
+		exp_exist="${in_dir}/expired/${file_name_base}.crt"
+		if [ -f "${exp_exist}" ]; then
+			exp_endd="$(
+				"$EASYRSA_OPENSSL" x509 -in "${exp_exist}" -noout \
+					-enddate)" || die "revoke - expire -enddate"
+			exp_confirm="
+Expired certificate:
+* ${exp_exist}
+  Expiry: ${exp_endd}
+  Use command 'revoke-expired' to revoke this certificate."
+		else
+			unset -v exp_exist exp_endd exp_confirm
+		fi
+
+		# renewed cert
+		ren_exist="${in_dir}/renewed/${file_name_base}.crt"
+		if [ -f "${ren_exist}" ]; then
+			ren_endd="$(
+				"$EASYRSA_OPENSSL" x509 -in "${ren_exist}" -noout \
+					-enddate)" || die "revoke - renew -enddate"
+			ren_confirm="
+Renewed certificate:
+* ${ren_exist}
+  Expiry: ${ren_endd}
+  Use command 'revoke-renewed' to revoke this certificate."
+		else
+			unset -v ren_exist ren_endd ren_confirm
+		fi
+
+		# issued cert
+		crt_endd="$(
+			"$EASYRSA_OPENSSL" x509 -in "${crt_in}" -noout \
+				-enddate)" || die "revoke - expire -enddate"
+
+		# Confirm intended use of 'revoke'
+		if [ "${exp_exist}" ] || [ "${ren_exist}" ]; then
+			warn "The following certificate(s) exist:
+${exp_exist:+${exp_confirm}${NL}}${ren_exist:+${ren_confirm}${NL}}"
+			confirm "  Confirm intended use of 'revoke' ? " yes "\
+Please confirm your intended use of 'revoke' for the following
+issued certificate:${NL}
+* ${crt_in}
+  Expiry: ${crt_endd}${NL}"
+		fi
+	;;
+	expired|renewed)
+		: # ok
+	;;
+	*)
+		die "Invalid cert_dir: '$cert_dir'"
+	esac
+
 	# Verify request
 	if [ -e "$req_in" ]; then
 		verify_file req "$req_in" || user_error "\

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2986,11 +2986,12 @@ Certificate was expected at:
 		if [ -f "${exp_exist}" ]; then
 			exp_endd="$(
 				"$EASYRSA_OPENSSL" x509 -in "${exp_exist}" -noout \
-					-enddate)" || die "revoke - expire -enddate"
+					-enddate -serial)" || die "revoke - expire -enddate"
 			exp_confirm="
 Expired certificate:
 * ${exp_exist}
-  Expiry: ${exp_endd}
+  Expiry: ${exp_endd%%${NL}serial=*}
+  Serial: ${exp_endd##*serial=}
   Use command 'revoke-expired' to revoke this certificate."
 		else
 			unset -v exp_exist exp_endd exp_confirm
@@ -3001,11 +3002,12 @@ Expired certificate:
 		if [ -f "${ren_exist}" ]; then
 			ren_endd="$(
 				"$EASYRSA_OPENSSL" x509 -in "${ren_exist}" -noout \
-					-enddate)" || die "revoke - renew -enddate"
+					-enddate -serial)" || die "revoke - renew -enddate"
 			ren_confirm="
 Renewed certificate:
 * ${ren_exist}
-  Expiry: ${ren_endd}
+  Expiry: ${ren_endd%%${NL}serial=*}
+  Serial: ${ren_endd##*serial=}
   Use command 'revoke-renewed' to revoke this certificate."
 		else
 			unset -v ren_exist ren_endd ren_confirm
@@ -3014,7 +3016,7 @@ Renewed certificate:
 		# issued cert
 		crt_endd="$(
 			"$EASYRSA_OPENSSL" x509 -in "${crt_in}" -noout \
-				-enddate)" || die "revoke - expire -enddate"
+				-enddate -serial)" || die "revoke - expire -enddate"
 
 		# Confirm intended use of 'revoke'
 		if [ "${exp_exist}" ] || [ "${ren_exist}" ]; then
@@ -3024,7 +3026,8 @@ ${exp_exist:+${exp_confirm}${NL}}${ren_exist:+${ren_confirm}${NL}}"
 Please confirm your intended use of 'revoke' for the following
 issued certificate:${NL}
 * ${crt_in}
-  Expiry: ${crt_endd}${NL}"
+  Expiry: ${crt_endd%%${NL}serial=*}
+  Serial: ${crt_endd##*serial=}"
 		fi
 	;;
 	expired|renewed)


### PR DESCRIPTION
Misuse would be when command revoke is used but command revoke-expired was instended.  If a file of the same name as the issued target exists in the expired directory then confirm that revoke was intended.