### PR TITLE
revoke: Pass the correct certificate location to revoke function

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.1 (TBD)
 
+   * bug-fix: revoke: Pass the correct certificate location (24d5514)
    * vars.example: Add flags for auto-SAN and X509 critical attribute (a41dfcc)
    * Global option --eku-crit: Mark X509 extendedKeyUsage as critical (ca09211)
    * sign-req: Add critical and pathlen details to confirmation (deae705) (#1182)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3171,7 +3171,7 @@ issued certificate:${NL}
 		# Revoking an issued cert forces req/key to be moved
 		move_req_and_key=1
 	;;
-	expired|renewed)
+	expired|renewed/issued)
 		# Revoke-expired/renewed cert means req/key can remain
 		move_req_and_key=
 	;;
@@ -5861,7 +5861,7 @@ case "$cmd" in
 		;;
 	revoke-renewed)
 		verify_working_env
-		cert_dir=renewed
+		cert_dir=renewed/issued
 		revoke "$@"
 		;;
 	renew)


### PR DESCRIPTION
Certificates moved to the 'pki/expired' directory do not require mirroring the PKI directory structure, one directory is adequate.

Certificates moved to the 'pki/renewed' directory do require mirroring the PKI directory structure. This is inherited bahavior.

Set the correct mirrrored directory for target certificates in the 'renewed' directory structure.