### PR TITLE
sign-req: Require 128bit serial number

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.1 (TBD)
 
+   * sign-req: Require 128bit serial number (806ee19) (#1213)
    * Move command 'verify-cert' to Tools-lib; drop 'verify' shortcut (ddbf304) (#1209)
    * Windows secure_session(): Ensure $secured_session dir is created (d99b242) (#1203)
    * Switch to '-f' for file existence (6ab98c9..a02f545) (#1201)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2407,6 +2407,9 @@ The certificate request file is not in a valid X509 format:
 		for i in 1 2 3 4 5; do
 			easyrsa_random 16 serial
 
+			# Require 128bit serial number
+			[ "$serial" = "${serial#00}" ] || continue
+
 			# Check for duplicate serial in CA db
 			if check_serial_unique "$serial" batch; then
 				serial_is_unique=1


### PR DESCRIPTION
Reject `1:256` serial numbers, those beginning with `00`.

Take back _The Banks_ unfair advantage.