### PR TITLE
sign-req: Allow custom X509 Types

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.2 (TBD)
 
+   * sign-req: Allow custom X509 Types (2ee08cc) (#1238)
    * Remove redundant file index.txt.attr (da3c249) (#1233)
 
 3.2.1 (2024-09-13)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2390,7 +2390,11 @@ sign_req() {
 			: # All known types plus CA for sub-ca
 		;;
 		*)
-			user_error "Type is not recognised: '$crt_type'"
+			warn "\
+Unrecognised x509-type: '$crt_type'
+
+In order to sign a custom X509 Type certificate, there must be a
+corresponding SSL configuration file in the 'x509-type' folder."
 	esac
 
 	# Check argument sanity:
@@ -4865,6 +4869,7 @@ write_x509_type_tmp() {
 
 	write_legacy_file_v2 "$1" "$write_x509_file_tmp" || \
 		die "write_x509_type_tmp - write $1"
+
 
 	verbose ": write_x509_type_tmp: $1 COMPLETE"
 } # => write_x509_type_tmp()

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5495,8 +5495,9 @@ EasyRSA Tools version is out of date:
 		verbose "Missing: easyrsa-tools.lib"
 		tools_error_txt="Missing: easyrsa-tools.lib
 
-Use of command '$cmd' requires Easy-RSA tools library, source:
-* https://github.com/OpenVPN/easy-rsa/dev/easyrsa-tools.lib
+Use of command '$cmd' requires Easy-RSA tools library.
+Source: https://github.com/OpenVPN/easy-rsa/dev/easyrsa-tools.lib
+Download: https://raw.githubusercontent.com/OpenVPN/easy-rsa/refs/heads/master/dev/easyrsa-tools.lib
 
 Place a copy of easyrsa-tools.lib in a standard system location."
 		return 1


### PR DESCRIPTION
In order to sign a custom X509 Type certificate, there must be a corresponding SSL configuration file in the 'x509-type' folder.