### PR TITLE
easyrsa-tools.lib: renew SAN, remove excess word 'Address'

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.2 (TBD)
 
+   * bugfix: easyrsa-tools.lib: renew SAN, remove excess word 'Address' (af17492) (#1251)
    * New global variable 'EASYRSA_DISABLE_INLINE' (ad257ab) (#1245)
    * bugfix: revoke, renew: Remove pki/inline/private/$file.inline (febef85) (#1244)
      Initial bug report #1242 (Minor)

--- a/dev/easyrsa-tools.lib
+++ b/dev/easyrsa-tools.lib
@@ -775,7 +775,8 @@ Cannot renew this certificate, a conflicting file exists:
 			"$EASYRSA_OPENSSL" x509 -in "$crt_in" -noout -text | \
 				grep -A 1 'X509v3 Subject Alternative Name' | \
 					sed -e s/'^\ *'// \
-						-e /'X509v3 Subject Alternative Name'/d
+						-e /'X509v3 Subject Alternative Name'/d \
+						-e s/'IP Address'/IP/
 		)" || die "renew - EASYRSA_SAN: easyrsa_openssl subshell"
 		verbose "renew: EASYRSA_SAN: ${EASYRSA_SAN}"
 


### PR DESCRIPTION
The input data for a SAN IP address is 'IP:n.n.n.n' The output data for a SAN IP address is 'IP Address:n.n.n.n'

Command renew extracts the SAN from the current certificate, including the excess word 'Address'.

Add another sed expression to remove the word 'Address'.