### PR TITLE
Always use locate_support_files() after secure_session()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.2 (TBD)
 
+   * bugfix: Always use locate_support_files() after secure_session() (d530bc3) (#1270)
    * bugfix: easyrsa-tools.lib: renew, write full metadata to temp-file (b47d2af) (#1267)
    * Introduce new command 'revoke-issued' (38bf2d8) (#1266)
      Commands 'revoke' and 'revoke-issued' are identical.

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.2 (TBD)
 
+   * bugfix: Save and Restore $EASYRSA_SSL_CONF for compound commands (7cdb14d) (#1270)
    * bugfix: Always use locate_support_files() after secure_session() (d530bc3) (#1270)
    * bugfix: easyrsa-tools.lib: renew, write full metadata to temp-file (b47d2af) (#1267)
    * Introduce new command 'revoke-issued' (38bf2d8) (#1266)

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.2 (TBD)
 
+   * Rename global option --ssl-conf (DEPRECATED) to --ssl-cnf (c788423) (#1270)
    * bugfix: Save and Restore $EASYRSA_SSL_CONF for compound commands (7cdb14d) (#1270)
    * bugfix: Always use locate_support_files() after secure_session() (d530bc3) (#1270)
    * bugfix: easyrsa-tools.lib: renew, write full metadata to temp-file (b47d2af) (#1267)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -840,8 +840,7 @@ secure_session - Missing temporary directory:
 				die "secure_session - temp-file EXISTS"
 
 			# New session requires safe-ssl conf
-			unset -v session OPENSSL_CONF \
-				EASYRSA_SSL_CONF safe_ssl_cnf_tmp \
+			unset -v session OPENSSL_CONF safe_ssl_cnf_tmp \
 				working_safe_ssl_conf working_safe_org_conf
 
 			easyrsa_err_log="$secured_session/error.log"
@@ -859,8 +858,11 @@ remove_secure_session() {
 	if rm -rf "$secured_session"; then
 		verbose "\
 remove_secure_session: DELETED: $secured_session"
-		unset -v secured_session OPENSSL_CONF \
-			EASYRSA_SSL_CONF safe_ssl_cnf_tmp \
+
+		# Restore original EASYRSA_SSL_CONF
+		EASYRSA_SSL_CONF="$original_ssl_cnf"
+
+		unset -v secured_session OPENSSL_CONF safe_ssl_cnf_tmp \
 			working_safe_ssl_conf working_safe_org_conf
 		return
 	fi
@@ -4665,6 +4667,9 @@ verify_working_env() {
 	# Find x509-types, openssl-easyrsa.cnf
 	# and easyrsa-tools.lib
 	locate_support_files
+
+	# Save original EASYRSA_SSL_CONF
+	original_ssl_cnf="$EASYRSA_SSL_CONF"
 
 	verbose "verify_working_env: COMPLETED Handover-to: $cmd"
 } # => verify_working_env()

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -625,7 +625,7 @@ General options:
                   (Default PKI directory is sub-directory 'pki')
                   See Advanced.md for in depth usage.
 
---ssl-conf=FILE : Define a specific OpenSSL config file for Easy-RSA to use
+--ssl-cnf=FILE  : Define a specific OpenSSL config file for Easy-RSA to use
                   (Default config file is in the EasyRSA PKI directory)
 --force-safe-ssl: Always generate a safe SSL config file
                   (Default: Generate Safe SSL config once per instance)
@@ -5592,7 +5592,7 @@ while :; do
 		--tmp-dir)
 			export EASYRSA_TEMP_DIR="$val"
 			;;
-		--ssl-conf)
+		--ssl-cnf|--ssl-conf)
 			export EASYRSA_SSL_CONF="$val"
 			;;
 		--keep-tmp)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2680,6 +2680,7 @@ basicConstraints is not defined, cannot use 'pathlen'"
 
 	# Get request CN
 	# EASYRSA_REQ_CN MUST always be set to the CSR CN
+	# or use --new-subect
 	EASYRSA_REQ_CN="$(
 		"$EASYRSA_OPENSSL" req -utf8 -in "$req_in" -noout \
 			-subject -nameopt multiline | grep 'commonName'

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2984,8 +2984,8 @@ Conflicting file found at:
 	# Recreate temp-session and
 	# drop edits to SSL Conf file
 	remove_secure_session
-	locate_support_files
 	secure_session
+	locate_support_files
 	write_global_safe_ssl_cnf_tmp
 
 	# Require --copy-ext
@@ -4661,6 +4661,11 @@ verify_working_env() {
 			write_global_safe_ssl_cnf_tmp
 		fi
 	fi
+
+	# Find x509-types, openssl-easyrsa.cnf
+	# and easyrsa-tools.lib
+	locate_support_files
+
 	verbose "verify_working_env: COMPLETED Handover-to: $cmd"
 } # => verify_working_env()
 
@@ -4716,6 +4721,10 @@ verify_working_env - easyrsa_mktemp global_safe_ssl_cnf_tmp"
 # If the existing file has a known hash then use temp-file.
 # Otherwise, use the file in place.
 write_easyrsa_ssl_cnf_tmp() {
+	# If EASYRSA_SSL_CONF is undefined then use default
+	[ "$EASYRSA_SSL_CONF" ] || set_var \
+		EASYRSA_SSL_CONF "$EASYRSA_PKI"/openssl-easyrsa.cnf
+
 	if [ -f "$EASYRSA_SSL_CONF" ]; then
 		verbose "write_easyrsa_ssl_cnf_tmp: SSL config EXISTS"
 
@@ -5831,9 +5840,6 @@ validate_default_vars
 
 # Check for conflicting input options
 mutual_exclusions
-
-# Find x509-types, openssl-easyrsa.cnf and easyrsa-tools.lib
-locate_support_files
 
 # Verify SSL Lib - One time ONLY
 verify_ssl_lib

--- a/easyrsa3/easyrsa-tools.lib
+++ b/easyrsa3/easyrsa-tools.lib
@@ -417,11 +417,11 @@ read_db() {
 		# Recreate temp session
 		remove_secure_session || \
 			die "read_db - remove_secure_session"
-		locate_support_files
 		secure_session || \
 			die "read_db - secure_session"
 		# Recreate openssl-easyrsa.cnf (Temp)
 		write_global_safe_ssl_cnf_tmp
+		locate_support_files
 
 		# Interpret the db/certificate record
 		unset -v db_serial db_cn db_revoke_date db_reason

--- a/easyrsa3/easyrsa-tools.lib
+++ b/easyrsa3/easyrsa-tools.lib
@@ -414,14 +414,12 @@ read_db() {
 
 		verbose "***** Read next record *****"
 
-		# Recreate temp session
-		remove_secure_session || \
-			die "read_db - remove_secure_session"
-		secure_session || \
-			die "read_db - secure_session"
-		# Recreate openssl-easyrsa.cnf (Temp)
-		write_global_safe_ssl_cnf_tmp
+		# Recreate temp-session and
+		# drop edits to SSL Conf file
+		remove_secure_session
+		secure_session
 		locate_support_files
+		write_global_safe_ssl_cnf_tmp
 
 		# Interpret the db/certificate record
 		unset -v db_serial db_cn db_revoke_date db_reason


### PR DESCRIPTION
easyrsa:
Move locate_support_files() to the last command in verify_working_env(). This means that for single commands, locate_support_files() will find an existing 'openssl-easyrsa.cnf' file, after secure_session() has cleared '$EASYRSA_SSL_CONF' variable.

For build_full(), use locate_support_files() after secure_session(), during the phase between gen_req() and sign_req(), when the secure session is recreated.

easyrsa-tools.lib:
In read_db(), set the same order as above, between each record.

_edit_ included in force push.