### PR TITLE
Revert da3c249: Do not remove index.txt.attr

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.2 (TBD)
 
+   * Revert da3c249: Do not remove index.txt.attr (a236b97) (#1287)
    * Windows: Remove mktemp binary and text files (135f642) (#1285)
    * op-test.sh: Disable download ossl3 and shellcheck binaries (473c43b) (#1284)
    * Forbid self-signed certificate from being expired/renewed/revoked (ab45ae7) (#1274)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -986,12 +986,6 @@ cleanup() {
 		print; cat "$easyrsa_err_log"; print
 	fi
 
-	# Remove redundant file: index.txt.attr
-	if [ -f "$EASYRSA_PKI"/index.txt.attr ]; then
-		rm -f "$EASYRSA_PKI"/index.txt.attr
-		verbose "cleanup: DELETED $EASYRSA_PKI/index.txt.attr"
-	fi
-
 	# undo changes BEFORE delete temp-dir
 	# Remove files when build_full()->sign_req() is interrupted
 	[ "$error_build_full_cleanup" ] && \


### PR DESCRIPTION
Also, do not expect index.txt.attr for verify_ca_init()