### PR TITLE
check_serial_unique(): Check for duplicate Subject error

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.3.0 (TBD)
 
+   * check_serial_unique(): Check for duplicate Subject error (be8467f) (#1294)
    * renew: Print 'unique_subject = no' to index.txt.attr (857a4e7) (#1293)
    * Update OpenSSL to 3.4.0 (d020b66)
 

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2900,6 +2900,11 @@ check_serial_unique() {
 			unique_serial_true=1
 			verbose "check_serial_unique: unique_serial=true"
 			;;
+		# This is caused by file:index.txt.attr being set to
+		# 'unique_subject = yes' AND a duplicate cert subject
+		(*"Error creating name index"*)
+			die "check_serial_unique(): Duplicate Subject conflict"
+			;;
 		*)
 			unique_serial_true=
 			verbose "check_serial_unique: unique_serial=false"


### PR DESCRIPTION
If a certificate has been renewed by an earlier version of Easy-RSA then it is possible that the file:index.txt.attr is still set with 'unique_subject = yes', which will cause an unexpected error for sign-req:check_serial_unique(). This error is now handled specifically.