### PR TITLE
Correctly define options names - Remove wild-card pattern

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.3.0 (TBD)
 
+   * Correctly define options names - Remove wild-card pattern (d145504) (#1297)
    * check_serial_unique(): Check for duplicate Subject error (be8467f) (#1294)
    * renew: Print 'unique_subject = no' to index.txt.attr (857a4e7) (#1293)
    * Update OpenSSL to 3.4.0 (d020b66)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -6829,23 +6829,23 @@ while :; do
 			empty_ok=1
 			export EASYRSA_AUTO_SAN=1
 			;;
-		--san-crit*)
+		--san-crit|--san-critical)
 			empty_ok=1
 			export EASYRSA_SAN_CRIT='critical,'
 			;;
-		--bc-crit*)
+		--bc-crit|--bc-critical)
 			empty_ok=1
 			export EASYRSA_BC_CRIT=1
 			;;
-		--ku-crit*)
+		--ku-crit|--ku-critical)
 			empty_ok=1
 			export EASYRSA_KU_CRIT=1
 			;;
-		--eku-crit*)
+		--eku-crit|--eku-critical)
 			empty_ok=1
 			export EASYRSA_EKU_CRIT=1
 			;;
-		--new-subj*)
+		--new-subj|--new-subject)
 			export EASYRSA_NEW_SUBJECT="$val"
 			;;
 		--usefn)


### PR DESCRIPTION
eg: replace --bc-crit* with --bc-crit|--bc-critical.

Otherwise, wild-cards allow command line to accept user errors, such as '--bc-crit-ku-crit', when '--bc-crit --ku-crit' is intended.