### PR TITLE
add_critical_attrib(): do not add critical if critical exists

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2868,7 +2868,7 @@ add_critical_attrib() {
 	[ -f "$2" ] || die "add_critical_attrib - file-2: '$2'"
 	[ -f "$3" ] || die "add_critical_attrib - file-3: '$3'"
 
-	sed s/"$1 = "/"$1 = critical,"/g "$2" > "$3"
+	sed "/$1[[:blank:]]*=[[:blank:]]*critical/!s/$1[[:blank:]]*=[[:blank:]]*/$1 = critical,/g" "$2" > "$3"
 } # => add_critical_attrib()
 
 # Check serial in db


### PR DESCRIPTION
The add_critical_attrib() function adds a critical tag to extensions unconditionally.
This can lead to problems if a user set critical tag manually in x509-types.
For example:
`keyUsage = critical,digitalSignature,keyEncipherment`
During the renew, this will result in a duplicate tag:
`keyUsage = critical,critical,digitalSignature,keyEncipherment`
OpenSSL fails to process such a config.
I added a condition to sed to check for existence of a critical tag and replaced spaces with [[:blank:]] class.