### PR TITLE
add_critical_attrib(): Do not add 'critical' if 'critical' exists

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ Easy-RSA 3 ChangeLog
 
 3.2.3 (TBD)
 
+   * add_critical_attrib(): Do not add 'critical' if it exists (cdfaf61) (#1308)
+     Original bug report: Dmitry Kononov (#1306)
    * select_vars(): Minor improvements (12ecc1a) (#1300)
    * expire_status_v2(): Refactor 'if' to capture -date error (52dafed) (#1304)
    * Reinstate old function as 'db_date_to_iso_8601()' (0444ad3) (#1303)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2868,7 +2868,12 @@ add_critical_attrib() {
 	[ -f "$2" ] || die "add_critical_attrib - file-2: '$2'"
 	[ -f "$3" ] || die "add_critical_attrib - file-3: '$3'"
 
-	sed s/"$1 = "/"$1 = critical,"/g "$2" > "$3"
+	# Insert 'critical,' attrib, ONLY if NOT present
+	srch="${1}[[:blank:]]*=[[:blank:]]*critical"
+	repl="${1}[[:blank:]]*=[[:blank:]]*"
+	with="${1} = critical,"
+	sed /"$srch"/!s/"$repl"/"$with"/g "$2" > "$3" || return 1
+	unset -v srch repl with
 } # => add_critical_attrib()
 
 # Check serial in db


### PR DESCRIPTION
The add_critical_attrib() function adds a critical tag to extensions unconditionally. This can lead to problems if a user sets 'critical' tag manually in x509-types.

For example:
'keyUsage = critical,digitalSignature,keyEncipherment'

During command 'renew', this will result in a duplicate tag: 'keyUsage = critical,critical,digitalSignature,keyEncipherment'

OpenSSL fails to process such a config.

Add 'sed' condition to check for the existence of a 'critical' tag. Also, replace search regex 'spaces' with '[[:blank:]]' class.