### PR TITLE
will_cert_be_valid(): Remove SSL option -noout

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.3 (TBD)
 
+   * will_cert_be_valid(): Remove SSL option -noout (9c8465e) (#1321)
    * New option --text: Create CSR files with human readable text (c152118) (#1319)
    * Command 'write': Remove options 'overwrite' and 'filename' (153ec6f) (#1318)
    * easyrsa_mktemp(): Change usage to not check for errors (64c201a) (#1315)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4326,15 +4326,14 @@ will_cert_be_valid() {
 
 	# is the cert still valid at this future date
 	ssl_out="$(
-		"$EASYRSA_OPENSSL" x509 -in "$1" -noout \
-			-checkend "$2"
+		"$EASYRSA_OPENSSL" x509 -in "$1" -checkend "$2"
 	)"
 
 	# analyse SSL output
 	case "$ssl_out" in
 		'Certificate will not expire') return 0 ;;
 		'Certificate will expire') return 1 ;;
-		*) die "will_cert_be_valid - Failure"
+		*) die "will_cert_be_valid - Failure: '$ssl_out'"
 	esac
 } # => will_cert_be_valid()
 


### PR DESCRIPTION
Using SSL command x509 with option -checkend:
* LibreSSL, -noout causes no ouput, only error status.
* OpenSSL, -noout has no effect.