### PR TITLE
inine_file(): Correct logic and add 'dh none' for DH params file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.3 (TBD)
 
+   * inine_file(): Correct logic and add 'dh none' for DH params file (7d5c52e) (#1330)
    * Update Copyright 2025 (8586bcf) (#1327)
    * secure_session(): Use new easyrsa_mkdir() to create session dir (41c154c) (#1324)
    * easyrsa_mkdir(): Separate Windows from *nix (7c76540) (#1324)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3110,10 +3110,11 @@ $(cat "$ca_source")
 	fi
 
 	# dh params file, for RSA servers only
-	if [ "$EASYRSA_ALGO" = rsa ]; then
-		case "$crt_type" in
-		server|serverClient)
-			# Collect DH data
+	dh_params_data=
+	case "$crt_type" in
+	server|serverClient)
+		# Collect DH data
+		if [ "$EASYRSA_ALGO" = rsa ]; then
 			if [ -f "$dh_params_source" ]; then
 				dh_params_data="${NL}
 <dh>
@@ -3126,15 +3127,17 @@ $(cat "$dh_params_source")
 # * Paste your Diffie-Hellman parameters file here *
 # </dh>"
 			fi
-
-			# Append DH data to CA data
-			ca_data="${ca_data}${dh_params_data}"
+		else
+			# ok, not RSA
+			dh_params_data="${NL}
+# Diffie-Hellman parameters file not required
+dh none"
+		fi
 		;;
 		*) : # ok, not server
-		esac
-	else
-		: # ok, not RSA
-	fi
+	esac
+	# Append DH data to CA data
+	ca_data="${ca_data}${dh_params_data}"
 
 	# TLS KEY - Set TLS auth|crypt key inline label
 	if [ -f "$tls_source" ]; then


### PR DESCRIPTION
Correct the logic by placing the certificate type above the algorithm.

Add 'dh none' for non RSA servers.