### PR TITLE
show-expire: Move setting $pre_expire_window_s to status()

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,8 @@ Easy-RSA 3 ChangeLog
 
 3.2.3 (TBD)
 
+   * show-expire: Move setting $pre_expire_window_s to status() (4b05181) (#1332)
+     Original bug report: Antonio Gurgel (#1331)
    * inine_file(): Correct logic and add 'dh none' for DH params file (7d5c52e) (#1330)
    * Update Copyright 2025 (8586bcf) (#1327)
    * secure_session(): Use new easyrsa_mkdir() to create session dir (41c154c) (#1324)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -4448,11 +4448,6 @@ read_db() {
 
 # Expire status
 expire_status_v2() {
-	# expiry seconds
-	pre_expire_window_s="$((
-		EASYRSA_PRE_EXPIRY_WINDOW * 60*60*24
-		))"
-
 	# The certificate for CN should exist but may not
 	if [ -f "$1" ]; then
 		verbose "expire_status: cert exists"
@@ -4567,6 +4562,11 @@ status() {
 
 	# test fix: https://github.com/OpenVPN/easy-rsa/issues/819
 	export LC_TIME=C.UTF-8
+
+	# expiry seconds
+	pre_expire_window_s="$((
+		EASYRSA_PRE_EXPIRY_WINDOW * 60*60*24
+		))"
 
 	# If no target file then add Notice
 	if [ -z "$target" ]; then


### PR DESCRIPTION
This ensures that $pre_expire_window_s is always set.