### PR TITLE
add_critical_attrib(): export temp-file name as input file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Easy-RSA 3 ChangeLog
 
 3.2.3 (TBD)
 
+   * add_critical_attrib(): export temp-file name as input file (e5b8d97) (#1333)
    * Unit-test: Drop old *nix test (63f3869) (#1335)
    * Always export EASYRSA_SSL_CONF, when assigned (code standard) (e77240d) (#1334)
    * show-expire: Move setting $pre_expire_window_s to status() (4b05181) (#1332)

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -1849,15 +1849,17 @@ Raw CA mode
 
 	# keyUsage critical
 	if [ "$EASYRSA_KU_CRIT" ]; then
-		add_critical_attrib_v2 keyUsage "$x509_type_file" || \
-			die "build-ca - add_critical_attrib_v2 keyUsage"
+		add_critical_attrib keyUsage \
+			"$x509_type_file" x509_type_file || \
+				die "build-ca - add_critical_attrib kU"
 		verbose "build_ca: keyUsage critical OK"
 	fi
 
 	# basicConstraints critical
 	if [ "$EASYRSA_BC_CRIT" ]; then
-		add_critical_attrib_v2 basicConstraints "$x509_type_file" || \
-			die "build-ca - add_critical_attrib_v2 basicConstraints"
+		add_critical_attrib basicConstraints \
+			"$x509_type_file" x509_type_file || \
+				die "build-ca - add_critical_attrib bC"
 		verbose "build_ca: basicConstraints critical OK"
 	fi
 
@@ -2556,8 +2558,9 @@ Writing 'copy_exts' to SSL config temp-file failed"
 	# keyUsage critical
 	confirm_ku_crit=
 	if [ "$EASYRSA_KU_CRIT" ]; then
-		add_critical_attrib_v2 keyUsage "$x509_type_file" || \
-			die "sign-req - add_critical_attrib_v2 keyUsage"
+		add_critical_attrib keyUsage \
+			"$x509_type_file" x509_type_file || \
+				die "sign-req - add_critical_attrib kU"
 		confirm_ku_crit="  keyUsage:         'critical'${NL}"
 		verbose "sign_req: keyUsage critical OK"
 	fi
@@ -2565,8 +2568,9 @@ Writing 'copy_exts' to SSL config temp-file failed"
 	# basicConstraints critical
 	confirm_bc_crit=
 	if [ "$EASYRSA_BC_CRIT" ]; then
-		add_critical_attrib_v2 basicConstraints "$x509_type_file" || \
-			die "sign-req - add_critical_attrib_v2 basicConstraints"
+		add_critical_attrib basicConstraints \
+			"$x509_type_file" x509_type_file || \
+				die "sign-req - add_critical_attrib bC"
 		confirm_bc_crit="  basicConstraints: 'critical'${NL}"
 		verbose "sign_req: basicConstraints critical OK"
 	fi
@@ -2574,8 +2578,9 @@ Writing 'copy_exts' to SSL config temp-file failed"
 	# extendedKeyUsage critical
 	confirm_eku_crit=
 	if [ "$EASYRSA_EKU_CRIT" ]; then
-		add_critical_attrib_v2 extendedKeyUsage "$x509_type_file" || \
-			die "sign-req - add_critical_attrib_v2 extendedKeyUsage"
+		add_critical_attrib extendedKeyUsage \
+			"$x509_type_file" x509_type_file || \
+				die "sign-req - add_critical_attrib eKU"
 		confirm_eku_crit="  extendedKeyUsage: 'critical'${NL}"
 		verbose "sign_req: extendedKeyUsage critical OK"
 	fi
@@ -2829,14 +2834,15 @@ Certificate created at:
 } # => sign_req()
 
 # Add 'critical' attribute to X509-type file
-add_critical_attrib_v2() {
-	fn_name="$fn_name; add_critical_attrib_v2"
+add_critical_attrib() {
+	fn_name="$fn_name; add_critical_attrib"
 	case "$1" in
 		basicConstraints|keyUsage|extendedKeyUsage) : ;; # ok
 		*) die "$fn_name - usage: '$1'"
 	esac
 
-	[ -f "$2" ] || die "$fn_name - missing output file"
+	[ -f "$2" ] || die "$fn_name - missing input file"
+	[ "$3" ] || die "$fn_name - missing variable"
 
 	crit_tmp=
 	easyrsa_mktemp crit_tmp
@@ -2849,11 +2855,12 @@ add_critical_attrib_v2() {
 		"$2" > "$crit_tmp" || return 1
 
 	# Use the new tmp-file:$crit_tmp with critical attribute
-	mv -f "$crit_tmp" "$2" || return 1
+	force_set_var "$3" "$crit_tmp" || return 1
 
-	fn_name="${fn_name%; add_critical_attrib_v2}"
+	verbose "$fn_name: ${1}: force_set_var: ${3} = ${crit_tmp}"
+	fn_name="${fn_name%; add_critical_attrib}"
 	unset -v srch repl with crit_tmp
-} # => add_critical_attrib_v2()
+} # => add_critical_attrib()
 
 # Check serial in db
 check_serial_unique() {
@@ -4992,16 +4999,18 @@ $cmd does not support setting an external commonName."
 	# basicConstraints critical
 	if grep -q 'Basic Constraints: critical' "$old_cert_tmp"
 	then
-		add_critical_attrib_v2 basicConstraints "$x509_type_file" || \
-			die "$f_name BC add_critical_attrib_v2"
+		add_critical_attrib basicConstraints \
+			"$x509_type_file" x509_type_file || \
+				die "$f_name: add_critical_attrib bC"
 		verbose "renew_ca_cert: basicConstraints critical OK"
 	fi
 
 	# keyUsage critical
 	if grep -q 'Key Usage: critical' "$old_cert_tmp"
 	then
-		add_critical_attrib_v2 keyUsage "$x509_type_file" || \
-			die "$f_name KU add_critical_attrib_v2"
+		add_critical_attrib keyUsage \
+			"$x509_type_file" x509_type_file || \
+				die "$f_name: add_critical_attrib kU"
 		verbose "renew_ca_cert: keyUsage critical OK"
 	fi
 


### PR DESCRIPTION
Replace a file move action with a variable assignment.

This change is necessary, otherwise, the 'x509-type/file' is permanently
overwritten with the "critical" attribute temp-file.
