### PR TITLE
Use tmp dir for lock file

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -5702,7 +5702,7 @@ request_lock_file() {
 	create_lock_file_error=
 	if [ -d "${EASYRSA_PKI}" ]; then
 
-		lock_file="${EASYRSA_PKI}"/lock.file
+		lock_file="${EASYRSA_TEMP_DIR}"/lock.file
 		if create_lock_file "$lock_file"; then
 			verbose "verify_working_env: lock-file CREATED OK"
 		else


### PR DESCRIPTION
Commit #ff22f82 introduced a lock file ability to preserve actions from simultaneous accesses.
In some use cases it is necessary to use a temporary directory (specified through env var EASYRSA_TEMP_DIR or --tmp-dir parameter) to avoid modifications on pki directory.
If that is the case, the lock file complains if pki directory is read-only, for example, and easyrsa fails to execute any command.

This PR adapta the lock file to use also the tmp directory, in case it is defined, or pki if it is not; this, in some way, keeps 'compatibility' with the general behavior of easyrsa.

On the other hand, and for this reason I am not sure this change is convinient or just the opposite, using a temporary location for the lock file that can be specified for each execution, makes the locking mechanism less safe, as the lock file can be different for two executions.

So, just in case you think it is worth, or the risk is worse than the benefit of keeping using easyrsa with temporary directory, Or maybe this helps to another solution, that I have not found (forcing lock file to a hard coded path as /tmp is not one, I guess).
