### PR TITLE
Remove: write_global_safe_ssl_cnf_tmp()

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -2813,7 +2813,7 @@ Conflicting file found at:
 	remove_secure_session
 	secure_session
 	locate_support_files
-	write_global_safe_ssl_cnf_tmp
+	write_easyrsa_ssl_cnf_tmp
 
 	# Require --copy-ext
 	export EASYRSA_CP_EXT=1
@@ -4237,7 +4237,7 @@ read_db() {
 		remove_secure_session
 		secure_session
 		locate_support_files
-		write_global_safe_ssl_cnf_tmp
+		write_easyrsa_ssl_cnf_tmp
 
 		# Interpret the db/certificate record
 		unset -v db_serial db_cn db_revoke_date db_reason
@@ -5787,7 +5787,7 @@ Using Easy-RSA 'vars' configuration:
 		easyrsa_mktemp test_temp_file
 
 		# global safe ssl cnf temp
-		write_global_safe_ssl_cnf_tmp
+		write_easyrsa_ssl_cnf_tmp
 
 		# Verify selected algorithm and parameters
 		verify_algo_params
@@ -5807,7 +5807,7 @@ Using Easy-RSA 'vars' configuration:
 			easyrsa_mktemp test_temp_file
 
 			# global safe ssl cnf temp
-			write_global_safe_ssl_cnf_tmp
+			write_easyrsa_ssl_cnf_tmp
 		fi
 	fi
 
@@ -5854,19 +5854,6 @@ force_set_var() {
 	set_var "$1" "$2" && return
 	die "force_set_var - set_var '$*'"
 } # => force_set_var()
-
-# global Safe SSL conf file, for use by any SSL lib
-write_global_safe_ssl_cnf_tmp() {
-	global_safe_ssl_cnf_tmp=
-	easyrsa_mktemp global_safe_ssl_cnf_tmp
-
-	write_legacy_file_v2 safe-cnf "$global_safe_ssl_cnf_tmp" \
-		overwrite || die "verify_working_env - write safe-cnf"
-
-	export OPENSSL_CONF="$global_safe_ssl_cnf_tmp"
-	verbose "\
-write_global_safe_ssl_cnf_tmp; GLOBAL OPENSSL_CONF = $OPENSSL_CONF"
-} # => write_global_safe_ssl_cnf_tmp()
 
 # Create as needed: $EASYRSA_SSL_CONF pki/openssl-easyrsa.cnf
 # If the existing file has a known hash then use temp-file.

--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -6069,11 +6069,17 @@ write_legacy_file_v2() {
 
 	# Select by type
 	case "$write_type" in
-	ssl-cnf)
-		set_openssl_easyrsa_cnf_vars unexpanded
-		;;
-	safe-cnf)
-		set_openssl_easyrsa_cnf_vars expanded
+	ssl-cnf|safe-cnf)
+		# Select or enforce expansion
+		if [ "$write_type" = safe-cnf ] || [ "$EASYRSA_FORCE_SAFE_SSL" ]
+		then
+			expansion=expanded
+		else
+			expansion=unexpanded
+		fi
+
+		# Set SSL config vars as per required expansion
+		set_openssl_easyrsa_cnf_vars "$expansion"
 		;;
 	vars)
 		;;


### PR DESCRIPTION
write_global_safe_ssl_cnf_tmp() conditionally expanded the existing SSL config file, without updating $EASYRSA_SSL_CONF.

The 'global' file is no nonger required.

Replace superfluous function 'write_global_safe_ssl_cnf_tmp()'; With the intended function 'write_easyrsa_ssl_cnf_tmp()'

This conditonally 'expands' any SSL config file, currently in use, OR creates a correctly formatted SSL config file.

Required 'expansion' is conditionally set by use of LibreSSL.

Option --force-safe-ssl will expand an existing SSL config file OR force an expanded-default SSL config file.

UT Passed on OpenBSD.