### PR TITLE
init-pki: Introduce configurable cryptography

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -64,6 +64,7 @@ Certificate & Request options: (these impact cert/req field values)
 --use-algo=ALG  : Crypto alg to use: choose rsa (default), ec or ed
 --curve=NAME    : For elliptic curve, sets the named curve
                   (Default: algo ec: secp384r1, algo ed: ed25519)
+                  (--use-algo and --curve can be used to configure 'init-pki')
 
 --subca-len=#   : Path length of signed intermediate CA certificates
 --copy-ext      : Copy included request X509 extensions (namely subjAltName)
@@ -110,7 +111,7 @@ Deprecated features:
 
 Command list:
 
-  init-pki
+  init-pki [ cmd-opts ]
   self-sign-server <file_name_base> [ cmd-opts ]
   self-sign-client <file_name_base> [ cmd-opts ]
   build-ca [ cmd-opts ]
@@ -169,7 +170,19 @@ Usage: easyrsa [ OPTIONS.. ] <COMMAND> <TARGET> [ cmd-opts.. ]"
 		text="
 * init-pki [ cmd-opts ]
 
-      Removes & re-initializes the PKI directory for a new PKI"
+      Removes & re-initializes the PKI directory for a new PKI
+
+      The new PKI can be auto-configured to use alternative cryptography.
+
+      The following command line examples are equivalent:
+        $ easyrsa init-pki ed448
+        $ easyrsa init-pki ed ed448
+        $ easyrsa --use-algo=ed --curve=ed448 init-pki
+
+      Note: cmd-opts take priority over '--' global options"
+		opts="
+      * Optional algorithm 'ec' or 'ed'  (Default: rsa)
+      * Optional curve name (Default: None, secp384r1 or ed25519)"
 	;;
 	self-sign*)
 		text="
@@ -1380,6 +1393,52 @@ $verify_ca_help_note"
 
 # init-pki backend:
 init_pki() {
+	verbose "BEGIN: algo: '$EASYRSA_ALGO' | curve: '$EASYRSA_CURVE'"
+
+	# Parse options for algo/curve - overwrite defaults
+	while [ "$1" ]; do
+		case "$1" in
+			rsa)
+				export EASYRSA_ALGO="$1"
+				unset -v EASYRSA_CURVE
+			;;
+			ec)
+				export EASYRSA_ALGO="$1"
+				export EASYRSA_CURVE=secp384r1
+			;;
+			ed)
+				export EASYRSA_ALGO="$1"
+				export EASYRSA_CURVE=ed25519
+			;;
+			*)
+				export EASYRSA_CURVE="$1"
+				case "$EASYRSA_CURVE" in
+					ed*) export EASYRSA_ALGO=ed ;;
+					*) export EASYRSA_ALGO=ec
+				esac
+		esac
+		shift
+	done
+
+	# Set default curve based on algo
+	case "$EASYRSA_ALGO" in
+		rsa) : ;; # ok
+		ec) set_var EASYRSA_CURVE secp384r1 ;;
+		ed) set_var EASYRSA_CURVE ed25519 ;;
+		*) die "Unknown EASYRSA_ALGO: '$EASYRSA_ALGO'"
+	esac
+
+	# Set default algo based on curve
+	case "$EASYRSA_CURVE" in
+		'') : ;; # ok
+		ed*) set_var EASYRSA_ALGO ed ;;
+		*) set_var EASYRSA_ALGO ec
+	esac
+
+	# Verify user settings
+	verbose "TRY: algo: '$EASYRSA_ALGO' | curve: '$EASYRSA_CURVE'"
+	verify_algo_params
+
 	# EasyRSA will NOT do 'rm -rf /'
 	case "$EASYRSA_PKI" in
 		.|..|./|../|.//*|..//*|/|//*|\\|?:|'')
@@ -1394,12 +1453,12 @@ WARNING!!!
 You are about to remove the EASYRSA_PKI at:
 * $EASYRSA_PKI
 
-and initialize a fresh PKI here."
-	fi
+and initialize a fresh PKI here. $auto_algo"
 
-	# # # shellcheck disable=SC2115 # Use "${var:?}"
-	rm -rf "$EASYRSA_PKI" || \
-		die "init-pki hard reset failed."
+		# Remove existing PKI
+		rm -rf "$EASYRSA_PKI" || \
+			die "Failed to remove existing PKI: '$EASYRSA_PKI'"
+	fi
 
 	# new dirs:
 	for i in issued private reqs; do
@@ -1409,7 +1468,32 @@ and initialize a fresh PKI here."
 
 	# write pki/vars.example - no temp-file because no session
 	write_legacy_file_v2 vars "$EASYRSA_PKI"/vars.example || \
-		warn "init_pki() - Failed to create vars.example"
+		die "init_pki() - Failed to create vars.example"
+
+	#  Auto-configuration $pki/vars for ec/ed
+	case "$EASYRSA_ALGO" in
+	rsa) : ;; # ok
+	ec|ed)
+		# Set comment for vars file
+		case "$EASYRSA_ALGO" in
+		ec) auto_algo="Auto-configured for Elliptic curve '$EASYRSA_CURVE'" ;;
+		ed) auto_algo="Auto-configured for Edwards curve '$EASYRSA_CURVE'"
+		esac
+
+		# sed search and replace regex
+		s_alg='#set_var[[:blank:]]*EASYRSA_ALGO[[:blank:]]*rsa'
+		r_alg="set_var EASYRSA_ALGO $EASYRSA_ALGO   # -->  $auto_algo"
+		s_crv='#set_var[[:blank:]]*EASYRSA_CURVE[[:blank:]]*secp384r1'
+		r_crv="set_var EASYRSA_CURVE $EASYRSA_CURVE   # -->  $auto_algo"
+
+		# Create Auto-configured vars file
+		# Note: pki/vars.example is Always created by Easy-RSA above
+		sed -e s/"$s_alg"/"$r_alg"/ -e s/"$s_crv"/"$r_crv"/ \
+			"$EASYRSA_PKI"/vars.example > "$EASYRSA_PKI"/vars || \
+				die "sed auto-vars"
+		;;
+	*) die "Auto-configuration, Unknown EASYRSA_ALGO: '$EASYRSA_ALGO'"
+	esac
 
 	# User notice
 	notice "\
@@ -1418,12 +1502,15 @@ and initialize a fresh PKI here."
 Your newly created PKI dir is:
 * $EASYRSA_PKI"
 
-	# Select and show vars file
-	unset -v EASYRSA_VARS_FILE
+	# Select and show Auto-configured vars file
+	unset -v ignore_vars EASYRSA_VARS_FILE
 	select_vars
-	information "\
-Using Easy-RSA configuration:
-* ${EASYRSA_VARS_FILE:-undefined}"
+	if [ "$EASYRSA_VARS_FILE" ]; then
+		information "\
+IMPORTANT: PKI algorithm is $auto_algo${NL}
+Using Easy-RSA Auto-configured 'vars' file:
+* ${EASYRSA_VARS_FILE}${NL}"
+	fi
 } # => init_pki()
 
 # Find support files from various sources
@@ -5322,35 +5409,53 @@ show_host() {
 verify_algo_params() {
 	case "$EASYRSA_ALGO" in
 	rsa)
+		[ "$EASYRSA_CURVE" ] && user_error "\
+Elliptic curve cryptography cannot be use with algo '$EASYRSA_ALGO'"
 		# Set RSA key size
 		EASYRSA_ALGO_PARAMS="$EASYRSA_KEY_SIZE"
 		;;
 	ec)
-		# Verify Elliptic curve
-		EASYRSA_ALGO_PARAMS=""
-		easyrsa_mktemp EASYRSA_ALGO_PARAMS
-
-		# Create the required ecparams file, temp-file
-		# call openssl directly because error is expected
+		case "$cmd" in
+		build-ca|gen-req|build-*-full)
+			# build ec-params file as $EASYRSA_ALGO_PARAMS
+			build_ecparam_file
+			;;
+		*)
+			# Verify Elliptic curve
 			"$EASYRSA_OPENSSL" ecparam \
 				-name "$EASYRSA_CURVE" \
-				-out "$EASYRSA_ALGO_PARAMS" \
 				>/dev/null 2>&1 || user_error "\
 Failed to generate ecparam file for curve '$EASYRSA_CURVE'"
+		esac
 		;;
 	ed)
 		# Verify Edwards curve
-		# call openssl directly because error is expected
-			"$EASYRSA_OPENSSL" genpkey \
-				-algorithm "$EASYRSA_CURVE" \
-				>/dev/null 2>&1 || user_error "\
+		"$EASYRSA_OPENSSL" genpkey \
+			-algorithm "$EASYRSA_CURVE" \
+			>/dev/null 2>&1 || user_error "\
 Edwards Curve '$EASYRSA_CURVE' not found."
 		;;
 	*) user_error "\
 Unknown algorithm '$EASYRSA_ALGO': Must be 'rsa', 'ec' or 'ed'"
 	esac
-	verbose "verify_algo_params; OK: algo '$EASYRSA_ALGO'"
+	verbose "\
+verify_algo_params; OK: algo '$EASYRSA_ALGO' | curve '$EASYRSA_CURVE'"
 } # => verify_algo_params()
+
+# build ecparam file
+build_ecparam_file() {
+	# Only valid for algo ec
+	[ "$EASYRSA_ALGO" = ec ] || return 0
+
+	# User specified algo params file exists
+	[ "$EASYRSA_ALGO_PARAMS" ] && [ -f "$EASYRSA_ALGO_PARAMS" ] && return
+	easyrsa_mktemp EASYRSA_ALGO_PARAMS
+
+	# Create the required ecparams file, temp-file
+	"$EASYRSA_OPENSSL" ecparam -name "$EASYRSA_CURVE" \
+		-out "$EASYRSA_ALGO_PARAMS" >/dev/null 2>&1 || user_error \
+			"Failed to generate ecparam file for curve '$EASYRSA_CURVE'"
+} # => build_ec_param_file()
 
 # Check for conflicting input options
 mutual_exclusions() {
@@ -5439,6 +5544,9 @@ To correct this problem, it is recommended that you either:
 # If not present, defaults are used to support
 # running without a sourced config format.
 select_vars() {
+	# Deliberately ignore vars
+	[ "$ignore_vars" ] && return 1
+
 	# User specified vars file will be used ONLY
 	if [ "$EASYRSA_VARS_FILE" ]; then
 		: # Takes priority, nothing to do
@@ -6543,6 +6651,7 @@ unset -v \
 	secured_session \
 	alias_days text \
 	prohibit_no_pass \
+	ignore_vars \
 	invalid_vars \
 	local_request error_build_full_cleanup \
 	selfsign_eku \
@@ -6618,6 +6727,10 @@ while :; do
 			;;
 		--curve)
 			export EASYRSA_CURVE="$val"
+			case "$EASYRSA_CURVE" in
+				ed*) set_var EASYRSA_ALGO ed ;;
+				*) set_var EASYRSA_ALGO ec
+			esac
 			;;
 		--dn-mode)
 			export EASYRSA_DN="$val"
@@ -6818,6 +6931,7 @@ cmd="$1"
 # ONLY verify_working_env() for valid commands
 case "$cmd" in
 	init-pki|clean-all)
+		ignore_vars=1 # Deliberately ignore vars
 		require_pki=""; require_ca=""; verify_working_env
 		init_pki "$@"
 		;;


### PR DESCRIPTION
init-pki can now create a preconfigured 'vars' file, to use Elliptic curve or Edwards curve cryptography.

These options can be used to configure init-pki, in the following order:

* init-pki curve-name: Acepted values any Elliptic or Edwards curve
  'curve-name' will preset algorithm.

* init-pki algorithm: Acepted values ec or ed
  'algorithm' will opportunistically preset 'curve-name'

Command options take priority over Global options
* Global option --curve
* Global option --use-algo