### PR TITLE
Allow non-server TLS certificates to be created

### DIFF
--- a/easyrsa3/easyrsa
+++ b/easyrsa3/easyrsa
@@ -3022,7 +3022,7 @@ $(cat "$crt_source")
 		crt_fingerprint="${crt_fingerprint#*=}"
 
 		# Certificate type
-		inline_crt_type=
+		inline_crt_type="$crt_type"
 		ssl_cert_x509v3_eku "$crt_source" inline_crt_type || \
 			warn "inline_file: Unknown cert-type: '$inline_crt_type'"
 


### PR DESCRIPTION
Pass in the desired certificate type so that the proper extension "TLS Web Server Authentication", "TLS Web Client Authentication", or both can be included for server, client and serverClient respectively.